### PR TITLE
fix(serialization): restrict polymorphic deserialization to trusted types

### DIFF
--- a/common/src/main/java/io/fluxzero/common/serialization/AllowlistTypeValidator.java
+++ b/common/src/main/java/io/fluxzero/common/serialization/AllowlistTypeValidator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.common.serialization;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * A {@link PolymorphicTypeValidator} that restricts deserialization to types from trusted packages
+ * or types registered in the {@link TypeRegistry}.
+ * <p>
+ * This prevents arbitrary class instantiation via the {@code @class} field in JSON, which could
+ * otherwise be exploited to achieve remote code execution through Jackson deserialization gadgets.
+ */
+public class AllowlistTypeValidator extends PolymorphicTypeValidator.Base {
+
+    static final AllowlistTypeValidator instance = new AllowlistTypeValidator();
+
+    private static final Set<String> ALLOWED_PACKAGE_PREFIXES = Set.of(
+            "io.fluxzero.",
+            "com.fasterxml.jackson.",
+            "java.util.",
+            "java.math.",
+            "java.time.",
+            "[" // array types
+    );
+
+    private static final Set<String> ALLOWED_CLASSES = Set.of(
+            "java.lang.Boolean",
+            "java.lang.Byte",
+            "java.lang.Character",
+            "java.lang.Double",
+            "java.lang.Float",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Number",
+            "java.lang.Short",
+            "java.lang.String"
+    );
+
+    private final Supplier<TypeRegistry> typeRegistry;
+
+    AllowlistTypeValidator() {
+        this(DefaultTypeRegistry::new);
+    }
+
+    AllowlistTypeValidator(Supplier<TypeRegistry> typeRegistry) {
+        this.typeRegistry = typeRegistry;
+    }
+
+    @Override
+    public Validity validateBaseType(MapperConfig<?> config, JavaType baseType) {
+        return Validity.INDETERMINATE;
+    }
+
+    boolean isAllowed(String className) {
+        if (ALLOWED_CLASSES.contains(className)) {
+            return true;
+        }
+        for (String prefix : ALLOWED_PACKAGE_PREFIXES) {
+            if (className.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return typeRegistry.get().isRegistered(className);
+    }
+
+    @Override
+    public Validity validateSubClassName(MapperConfig<?> config, JavaType baseType, String subClassName) {
+        return isAllowed(subClassName) ? Validity.ALLOWED : Validity.DENIED;
+    }
+
+    @Override
+    public Validity validateSubType(MapperConfig<?> config, JavaType baseType, JavaType subType) {
+        return isAllowed(subType.getRawClass().getName()) ? Validity.ALLOWED : Validity.DENIED;
+    }
+}

--- a/common/src/main/java/io/fluxzero/common/serialization/DefaultTypeRegistry.java
+++ b/common/src/main/java/io/fluxzero/common/serialization/DefaultTypeRegistry.java
@@ -74,4 +74,8 @@ public class DefaultTypeRegistry implements TypeRegistry {
         });
     }
 
+    @Override
+    public boolean isRegistered(String fullyQualifiedName) {
+        return fullTypeNames.contains(fullyQualifiedName);
+    }
 }

--- a/common/src/main/java/io/fluxzero/common/serialization/GlobalTypeIdResolver.java
+++ b/common/src/main/java/io/fluxzero/common/serialization/GlobalTypeIdResolver.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import io.fluxzero.common.reflection.ReflectionUtils;
 
+import java.io.IOException;
+
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 public class GlobalTypeIdResolver extends TypeIdResolverBase {
@@ -34,8 +36,14 @@ public class GlobalTypeIdResolver extends TypeIdResolverBase {
     }
 
     @Override
-    public JavaType typeFromId(DatabindContext context, String id) {
-        return context.constructType(ReflectionUtils.classForName(id));
+    public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+        Class<?> clazz = ReflectionUtils.classForName(id);
+        if (!AllowlistTypeValidator.instance.isAllowed(clazz.getName())) {
+            throw new IllegalArgumentException(
+                    "Deserialization of type " + id + " is not allowed. "
+                    + "Only types from trusted packages or registered via @RegisterType may be used in @class.");
+        }
+        return context.constructType(clazz);
     }
 
     @Override

--- a/common/src/main/java/io/fluxzero/common/serialization/JsonUtils.java
+++ b/common/src/main/java/io/fluxzero/common/serialization/JsonUtils.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTypeResolverBuilder;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -191,7 +190,7 @@ public class JsonUtils {
      * configuration and ensures compatibility.
      */
     public static JsonMapper reader = writer.rebuild()
-            .setDefaultTyping(new DefaultTypeResolverBuilder(JAVA_LANG_OBJECT, LaissezFaireSubTypeValidator.instance)
+            .setDefaultTyping(new DefaultTypeResolverBuilder(JAVA_LANG_OBJECT, AllowlistTypeValidator.instance)
                                       .init(Id.CLASS, new GlobalTypeIdResolver()).inclusion(JsonTypeInfo.As.PROPERTY))
             .build();
 

--- a/common/src/main/java/io/fluxzero/common/serialization/TypeRegistry.java
+++ b/common/src/main/java/io/fluxzero/common/serialization/TypeRegistry.java
@@ -47,4 +47,14 @@ public interface TypeRegistry {
      * @return an {@code Optional} containing the resolved fully qualified class name, or empty if not found
      */
     Optional<String> getTypeName(String alias);
+
+    /**
+     * Returns whether the given fully qualified class name is registered in this registry.
+     *
+     * @param fullyQualifiedName the fully qualified class name to check
+     * @return {@code true} if the type is registered, {@code false} otherwise
+     */
+    default boolean isRegistered(String fullyQualifiedName) {
+        return false;
+    }
 }

--- a/common/src/test/java/io/fluxzero/common/serialization/GlobalTypeIdResolverTest.java
+++ b/common/src/test/java/io/fluxzero/common/serialization/GlobalTypeIdResolverTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.common.serialization;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalTypeIdResolverTest {
+
+    @Test
+    void rejectsArbitraryClassDeserialization() {
+        String maliciousJson = """
+                {"@class": "javax.script.ScriptEngineManager"}
+                """;
+        Exception e = assertThrows(Exception.class, () -> JsonUtils.fromJson(maliciousJson));
+        assertTrue(e.getMessage().contains("not allowed"), e.getMessage());
+    }
+
+    @Test
+    void rejectsJavaLangProcessBuilder() {
+        String maliciousJson = """
+                {"@class": "java.lang.ProcessBuilder", "command": ["echo", "pwned"]}
+                """;
+        Exception e = assertThrows(Exception.class, () -> JsonUtils.fromJson(maliciousJson));
+        assertTrue(e.getMessage().contains("not allowed"), e.getMessage());
+    }
+
+    @Test
+    void rejectsJavaNetURL() {
+        String maliciousJson = """
+                {"@class": "java.net.URL", "protocol": "http", "host": "evil.com", "file": "/"}
+                """;
+        Exception e = assertThrows(Exception.class, () -> JsonUtils.fromJson(maliciousJson));
+        assertTrue(e.getMessage().contains("not allowed"), e.getMessage());
+    }
+
+    @Test
+    void allowsFluxzeroTypes() {
+        String json = """
+                {"@class": "io.fluxzero.common.api.Metadata", "entries": {}}
+                """;
+        assertDoesNotThrow(() -> JsonUtils.fromJson(json));
+    }
+
+    @Test
+    void allowsStandardCollectionTypes() {
+        String json = """
+                {"@class": "java.util.LinkedHashMap"}
+                """;
+        assertDoesNotThrow(() -> JsonUtils.fromJson(json));
+    }
+
+    @Test
+    void allowlistPermitsRegisteredTypes() {
+        var registry = new DefaultTypeRegistry(List.of("com.example.MyEvent"));
+        var validator = new AllowlistTypeValidator(() -> registry);
+        assertTrue(validator.isAllowed("com.example.MyEvent"));
+    }
+
+    @Test
+    void allowlistRejectsUnregisteredExternalTypes() {
+        var registry = new DefaultTypeRegistry(emptyList());
+        var validator = new AllowlistTypeValidator(() -> registry);
+        assertFalse(validator.isAllowed("com.evil.Exploit"));
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `LaissezFaireSubTypeValidator` with `AllowlistTypeValidator` to prevent arbitrary class instantiation via the `@class` field in JSON input
- Allowlist permits only trusted package prefixes (`io.fluxzero.*`, `com.fasterxml.jackson.*`, `java.util.*`, `java.time.*`, `java.math.*`, boxed `java.lang` types) and types registered via `@RegisterType`
- Enforce validation in both `GlobalTypeIdResolver.typeFromId` (primary gate) and as `PolymorphicTypeValidator` on the reader `ObjectMapper` (defence in depth)

## Motivation

`GlobalTypeIdResolver` combined with `LaissezFaireSubTypeValidator` allowed arbitrary class instantiation via the `@class` field in JSON input. An attacker controlling JSON payloads could exploit Jackson deserialization gadgets (e.g. `ScriptEngineManager`, JNDI lookups) to achieve remote code execution.

## Test plan

- [x] Tests verify rejection of malicious types (`ScriptEngineManager`, `ProcessBuilder`, `java.net.URL`)
- [x] Tests verify acceptance of trusted types (`io.fluxzero.*`, `java.util.*`)
- [x] Tests verify acceptance of `@RegisterType`-registered types and rejection of unregistered external types