### PR TITLE
feat(web): support chunked proxy uploads and streamed form handling

### DIFF
--- a/.run/ProxyServer.run.xml
+++ b/.run/ProxyServer.run.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ProxyServer" type="Application" factoryName="Application" nameIsGenerated="true">
+    <envs>
+      <env name="FLUXZERO_BASE_URL" value="ws://localhost:8888" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="io.fluxzero.proxy.ProxyServer" />
+    <module name="proxy" />
+    <extension name="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="io.fluxzero.proxy.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/UploadTestApp.run.xml
+++ b/.run/UploadTestApp.run.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="UploadTestApp" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="io.fluxzero.proxy.UploadTestApp" />
+    <module name="proxy" />
+    <option name="VM_PARAMETERS" value="-Xms16g -Xmx16g" />
+    <extension name="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="io.fluxzero.proxy.testclient.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/annotation-processor-tests/src/test/java/io/fluxzero/sdk/web/RestTests.java
+++ b/annotation-processor-tests/src/test/java/io/fluxzero/sdk/web/RestTests.java
@@ -1,8 +1,14 @@
 package io.fluxzero.sdk.web;
 
+import io.fluxzero.common.ConsistentHashing;
+import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.HasMetadata;
+import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.publishing.DefaultRequestHandler;
 import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.tracking.handling.validation.ValidationException;
 import jakarta.validation.constraints.NotNull;
@@ -11,7 +17,21 @@ import lombok.Value;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RestTests {
 
@@ -106,7 +126,7 @@ class RestTests {
     @Nested
     class BodyParamTests {
 
-        final TestFixture testFixture = TestFixture.create(new Handler());
+        final TestFixture testFixture = TestFixture.createAsync(new Handler());
 
         @Test
         void testBodyParam_defaultNames() {
@@ -145,6 +165,61 @@ class RestTests {
                     .as(HotelId.class)).expectResult(new HotelId("hotel-from-body"));
         }
 
+        @Test
+        void testChunkedBodyParamWaitsForFinalChunkWithoutBlockingTracker() {
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/bodyParam/chunked")
+                String post(@BodyParam("message") String message) {
+                    handled.set(message);
+                    handledLatch.countDown();
+                    return message;
+                }
+
+                @HandlePost("/ping")
+                String ping() {
+                    return "pong";
+                }
+            }).whenApplying(fc -> {
+                WebRequest request = WebRequest.builder().method("POST").url("/bodyParam/chunked").payload(new byte[0])
+                        .header("Content-Type", "application/json").build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>("{\"message\":\"hello ".getBytes(), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>("world\"}".getBytes(), byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-bodyparam-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertFalse(handledLatch.await(50, TimeUnit.MILLISECONDS));
+                    assertNull(handled.get());
+                    assertEquals("pong", fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/ping").build()).getPayloadAs(String.class));
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals("hello world", handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
         static class Handler {
             @HandlePost("/bookings")
             String create(@BodyParam SomeId hotelId, @BodyParam SomeId roomId, @BodyParam BookingDetails details) {
@@ -168,7 +243,7 @@ class RestTests {
     @Nested
     class FormParamTests {
 
-        final TestFixture testFixture = TestFixture.create(new Handler());
+        final TestFixture testFixture = TestFixture.createAsync(new Handler());
 
         @Test
         void testFormParam_rawStringBody_absoluteUrl() {
@@ -203,6 +278,429 @@ class RestTests {
                                   + "/callback/google|google-code");
         }
 
+        @Test
+        void testFormParam_objectBody_viaWebRequestGatewaySendAndWait() {
+            testFixture.whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                                    WebRequest.post("https://mock-google.test/token-object")
+                                            .contentType("application/x-www-form-urlencoded")
+                                            .body("grant_type=authorization_code&code=google-code"
+                                                  + "&client_id=google-managed-client"
+                                                  + "&client_secret=google-managed-secret"
+                                                  + "&redirect_uri=https%3A%2F%2Fauth.fluxzero.test"
+                                                  + "%2Flogin%2Fcallback%2Fgoogle")
+                                            .build())
+                            .getPayloadAs(String.class))
+                    .expectResult("google-managed-client|google-managed-secret|https://auth.fluxzero.test/login"
+                                  + "/callback/google|google-code");
+        }
+
+        @Test
+        void testFormParam_stillPrefersMatchingFieldOverWholeFormFallback() {
+            testFixture.whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                                    WebRequest.post("https://mock-google.test/token-id")
+                                            .contentType("application/x-www-form-urlencoded")
+                                            .body("clientId=google-managed-client")
+                                            .build())
+                            .getPayloadAs(String.class))
+                    .expectResult("google-managed-client");
+        }
+
+        @Test
+        void testFormParam_multipartBody_viaWebRequestGatewaySendAndWait() {
+            String boundary = "fluxzeroBoundary";
+            String body = "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"client_id\"\r\n\r\n"
+                          + "google-managed-client\r\n"
+                          + "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"client_secret\"\r\n\r\n"
+                          + "google-managed-secret\r\n"
+                          + "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"redirect_uri\"\r\n\r\n"
+                          + "https://auth.fluxzero.test/login/callback/google\r\n"
+                          + "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"code\"\r\n\r\n"
+                          + "google-code\r\n"
+                          + "--" + boundary + "--\r\n";
+            testFixture.whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                                    WebRequest.post("https://mock-google.test/token")
+                                            .contentType("multipart/form-data; boundary=" + boundary)
+                                            .body(body)
+                                            .build())
+                            .getPayloadAs(String.class))
+                    .expectResult("google-managed-client|google-managed-secret|https://auth.fluxzero.test/login"
+                                  + "/callback/google|google-code");
+        }
+
+        @Test
+        void testChunkedFormParamWaitsForFinalChunkWithoutBlockingTracker() {
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/formParam/chunked")
+                String post(@FormParam("message") String message) {
+                    handled.set(message);
+                    handledLatch.countDown();
+                    return message;
+                }
+
+                @HandlePost("/ping")
+                String ping() {
+                    return "pong";
+                }
+            }).whenApplying(fc -> {
+                WebRequest request = WebRequest.builder().method("POST").url("/formParam/chunked").payload(new byte[0])
+                        .header("Content-Type", "application/x-www-form-urlencoded").build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>("message=hello+".getBytes(), byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>("world".getBytes(), byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-formparam-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertFalse(handledLatch.await(50, TimeUnit.MILLISECONDS));
+                    assertNull(handled.get());
+                    assertEquals("pong", fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/ping").build()).getPayloadAs(String.class));
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals("hello world", handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
+        @Test
+        void testChunkedFormObjectParamWaitsForFinalChunkWithoutBlockingTracker() {
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/formParam/object-chunked")
+                String post(TokenForm form) {
+                    handled.set(form.clientId + "|" + form.clientSecret + "|" + form.redirectUri + "|" + form.code);
+                    handledLatch.countDown();
+                    return handled.get();
+                }
+
+                @HandlePost("/ping")
+                String ping() {
+                    return "pong";
+                }
+            }).whenApplying(fc -> {
+                WebRequest request = WebRequest.builder().method("POST").url("/formParam/object-chunked")
+                        .payload(new byte[0]).header("Content-Type", "application/x-www-form-urlencoded").build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>("client_id=google-managed-client&client_secret=google-managed-secret"
+                                   .getBytes(), byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>(("&redirect_uri=https%3A%2F%2Fauth.fluxzero.test%2Flogin%2Fcallback%2Fgoogle"
+                                    + "&code=google-code").getBytes(), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-form-object-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertFalse(handledLatch.await(50, TimeUnit.MILLISECONDS));
+                    assertNull(handled.get());
+                    assertEquals("pong", fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/ping").build()).getPayloadAs(String.class));
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals("google-managed-client|google-managed-secret|https://auth.fluxzero.test/login"
+                                 + "/callback/google|google-code", handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
+        @Test
+        void testChunkedMultipartFormParamWaitsForFinalChunkWithoutBlockingTracker() {
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/formParam/multipart")
+                String post(@FormParam("message") String message) {
+                    handled.set(message);
+                    handledLatch.countDown();
+                    return message;
+                }
+
+                @HandlePost("/ping")
+                String ping() {
+                    return "pong";
+                }
+            }).whenApplying(fc -> {
+                String boundary = "chunkedBoundary";
+                WebRequest request = WebRequest.builder().method("POST").url("/formParam/multipart").payload(new byte[0])
+                        .header("Content-Type", "multipart/form-data; boundary=" + boundary).build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>(("--" + boundary + "\r\n"
+                                    + "Content-Disposition: form-data; name=\"message\"\r\n\r\n"
+                                    + "hello ").getBytes(), byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>(("world\r\n--" + boundary + "--\r\n").getBytes(), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-multipart-formparam-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertFalse(handledLatch.await(50, TimeUnit.MILLISECONDS));
+                    assertNull(handled.get());
+                    assertEquals("pong", fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/ping").build()).getPayloadAs(String.class));
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals("hello world", handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
+        @Test
+        void testFormParam_multipartFilePart_viaWebRequestGatewaySendAndWait() {
+            String boundary = "fileBoundary";
+            String fileContents = "%PDF-1.7\nfluxzero test file\n";
+            String body = "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"document\"; filename=\"document.pdf\"\r\n"
+                          + "Content-Type: application/pdf\r\n\r\n"
+                          + fileContents + "\r\n"
+                          + "--" + boundary + "--\r\n";
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/multipart/file")
+                String post(@FormParam("document") MultipartFormPart document,
+                            @FormParam("document") InputStream stream) throws Exception {
+                    return document.getFilename() + "|" + document.getContentType() + "|"
+                           + Base64.getEncoder().encodeToString(stream.readAllBytes());
+                }
+            }).whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/multipart/file")
+                                    .contentType("multipart/form-data; boundary=" + boundary)
+                                    .body(body.getBytes(StandardCharsets.ISO_8859_1))
+                                    .build())
+                    .getPayloadAs(String.class))
+                    .expectResult("document.pdf|application/pdf|"
+                                  + Base64.getEncoder().encodeToString(
+                                          fileContents.getBytes(StandardCharsets.ISO_8859_1)));
+        }
+
+        @Test
+        void testFormParam_multipartFilePartPreservesBoundaryTextInsideFile() {
+            String boundary = "fileBoundary";
+            String fileContents = "prefix--" + boundary + "--suffix";
+            String body = "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"document\"; filename=\"document.pdf\"\r\n"
+                          + "Content-Type: application/pdf\r\n\r\n"
+                          + fileContents + "\r\n"
+                          + "--" + boundary + "--\r\n";
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/multipart/file-with-boundary-text")
+                String post(@FormParam("document") byte[] document) {
+                    return new String(document, StandardCharsets.ISO_8859_1);
+                }
+            }).whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/multipart/file-with-boundary-text")
+                                    .contentType("multipart/form-data; boundary=" + boundary)
+                                    .body(body.getBytes(StandardCharsets.ISO_8859_1))
+                                    .build())
+                    .getPayloadAs(String.class))
+                    .expectResult(fileContents);
+        }
+
+        @Test
+        void testChunkedMultipartFilePartWaitsForFinalChunkWithoutBlockingTracker() {
+            byte[] fileBytes = "%PDF-1.7\nchunked file\n".getBytes(StandardCharsets.ISO_8859_1);
+            String expected = Base64.getEncoder().encodeToString(fileBytes);
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/formParam/multipart-file")
+                String post(@FormParam("document") byte[] document) {
+                    handled.set(Base64.getEncoder().encodeToString(document));
+                    handledLatch.countDown();
+                    return handled.get();
+                }
+
+                @HandlePost("/ping")
+                String ping() {
+                    return "pong";
+                }
+            }).whenApplying(fc -> {
+                String boundary = "chunkedFileBoundary";
+                WebRequest request = WebRequest.builder().method("POST").url("/formParam/multipart-file")
+                        .payload(new byte[0]).header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                        .build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>(("--" + boundary + "\r\n"
+                                    + "Content-Disposition: form-data; name=\"document\"; filename=\"document.pdf\"\r\n"
+                                    + "Content-Type: application/pdf\r\n\r\n").getBytes(StandardCharsets.ISO_8859_1),
+                                   byte[].class.getName(), 0, "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>((new String(fileBytes, StandardCharsets.ISO_8859_1) + "\r\n--" + boundary
+                                    + "--\r\n").getBytes(StandardCharsets.ISO_8859_1), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-multipart-file-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertFalse(handledLatch.await(50, TimeUnit.MILLISECONDS));
+                    assertNull(handled.get());
+                    assertEquals("pong", fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/ping").build()).getPayloadAs(String.class));
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals(expected, handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
+        @Test
+        void testFormParam_multipleMultipartFilePartsBySameKey() {
+            String boundary = "multiFileBoundary";
+            String body = "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"document\"; filename=\"one.pdf\"\r\n"
+                          + "Content-Type: application/pdf\r\n\r\n"
+                          + "first-file\r\n"
+                          + "--" + boundary + "\r\n"
+                          + "Content-Disposition: form-data; name=\"document\"; filename=\"two.pdf\"\r\n"
+                          + "Content-Type: application/pdf\r\n\r\n"
+                          + "second-file\r\n"
+                          + "--" + boundary + "--\r\n";
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/multipart/files")
+                String post(@FormParam("document") List<MultipartFormPart> documents) {
+                    return documents.stream()
+                            .map(document -> document.getFilename() + ":" + document.asString(StandardCharsets.ISO_8859_1))
+                            .reduce((a, b) -> a + "|" + b).orElse("");
+                }
+            }).whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                            WebRequest.post("/multipart/files")
+                                    .contentType("multipart/form-data; boundary=" + boundary)
+                                    .body(body.getBytes(StandardCharsets.ISO_8859_1))
+                                    .build())
+                    .getPayloadAs(String.class))
+                    .expectResult("one.pdf:first-file|two.pdf:second-file");
+        }
+
+        @Test
+        void testChunkedMultipartMultipleFilePartsBySameKey() {
+            AtomicReference<String> handled = new AtomicReference<>();
+            CountDownLatch handledLatch = new CountDownLatch(1);
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/multipart/multi-file-chunked")
+                String post(@FormParam("document") List<byte[]> documents) {
+                    handled.set(documents.stream().map(bytes -> new String(bytes, StandardCharsets.ISO_8859_1))
+                                        .reduce((a, b) -> a + "|" + b).orElse(""));
+                    handledLatch.countDown();
+                    return handled.get();
+                }
+            }).whenApplying(fc -> {
+                String boundary = "chunkedMultiBoundary";
+                WebRequest request = WebRequest.builder().method("POST").url("/multipart/multi-file-chunked")
+                        .payload(new byte[0]).header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                        .build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>(("--" + boundary + "\r\n"
+                                    + "Content-Disposition: form-data; name=\"document\"; filename=\"one.pdf\"\r\n"
+                                    + "Content-Type: application/pdf\r\n\r\n"
+                                    + "first-file\r\n"
+                                    + "--" + boundary + "\r\n"
+                                    + "Content-Disposition: form-data; name=\"document\"; filename=\"two.pdf\"\r\n"
+                                    + "Content-Type: application/pdf\r\n\r\n")
+                                           .getBytes(StandardCharsets.ISO_8859_1), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>(("second-file\r\n--" + boundary + "--\r\n")
+                                           .getBytes(StandardCharsets.ISO_8859_1), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-multipart-multi-file-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertNull(handled.get());
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    responseFuture.get();
+                    assertTrue(handledLatch.await(1, TimeUnit.SECONDS));
+                    assertEquals("first-file|second-file", handled.get());
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
         @Path("https://mock-google.test")
         static class Handler {
             @HandlePost("/token")
@@ -212,6 +710,24 @@ class RestTests {
                          @FormParam("code") String code) {
                 return clientId + "|" + clientSecret + "|" + redirectUri + "|" + code;
             }
+
+            @HandlePost("/token-object")
+            String tokenObject(TokenForm form) {
+                return form.clientId + "|" + form.clientSecret + "|" + form.redirectUri + "|" + form.code;
+            }
+
+            @HandlePost("/token-id")
+            String tokenId(@FormParam SomeId clientId) {
+                return clientId.getFunctionalId();
+            }
+        }
+
+        @Value
+        static class TokenForm {
+            String clientId;
+            String clientSecret;
+            String redirectUri;
+            String code;
         }
     }
 

--- a/common/src/main/java/io/fluxzero/common/api/HasMetadata.java
+++ b/common/src/main/java/io/fluxzero/common/api/HasMetadata.java
@@ -30,7 +30,20 @@ package io.fluxzero.common.api;
  */
 public interface HasMetadata {
 
+    /**
+     * Metadata key that marks the final part of a chunked message.
+     */
     String FINAL_CHUNK = "$finalChunk";
+
+    /**
+     * Metadata key that marks the first part of a chunked message.
+     */
+    String FIRST_CHUNK = "$firstChunk";
+
+    /**
+     * Metadata key that stores the zero-based position of a chunk within a chunked message.
+     */
+    String CHUNK_INDEX = "$chunkIndex";
 
     /**
      * Returns the {@link Metadata} associated with this object.
@@ -58,5 +71,15 @@ public interface HasMetadata {
      */
     default boolean lastChunk() {
         return "true".equalsIgnoreCase(getMetadata().getOrDefault(FINAL_CHUNK, "true"));
+    }
+
+    /**
+     * Determines if the data associated with this metadata is the first part of the data. If the
+     * {@code FIRST_CHUNK} key is missing or set to {@code true}, this method returns {@code true}.
+     *
+     * @return true if the metadata value for the {@code FIRST_CHUNK} key is {@code true}, false otherwise.
+     */
+    default boolean firstChunk() {
+        return "true".equalsIgnoreCase(getMetadata().getOrDefault(FIRST_CHUNK, "true"));
     }
 }

--- a/common/src/main/java/io/fluxzero/common/api/publishing/Append.java
+++ b/common/src/main/java/io/fluxzero/common/api/publishing/Append.java
@@ -28,13 +28,11 @@ import static java.util.Optional.ofNullable;
 /**
  * Command to publish messages to a specific log in Fluxzero (e.g., commands, events, metrics, etc.).
  * <p>
- * The messages are written to the log associated with the given {@link #messageType}.
- * Each message is represented as a {@link SerializedMessage} and is appended to the log
- * in the order provided.
+ * The messages are written to the log associated with the given {@link #messageType}. Each message is represented as a
+ * {@link SerializedMessage} and is appended to the log in the order provided.
  * <p>
- * This operation is typically used by low-level clients (such as {@code GatewayClient})
- * that need full control over message serialization and targeting. High-level APIs usually
- * delegate to this command internally.
+ * This operation is typically used by low-level clients (such as {@code GatewayClient}) that need full control over
+ * message serialization and targeting. High-level APIs usually delegate to this command internally.
  *
  * @see MessageType
  * @see SerializedMessage
@@ -73,7 +71,7 @@ public class Append extends Command {
 
     @Override
     public String routingKey() {
-        return messageType.name();
+        return messages.isEmpty() ? null : routingKeyFor(messages.getFirst());
     }
 
     @Override
@@ -84,6 +82,14 @@ public class Append extends Command {
     @Override
     public Metric toMetric() {
         return new Metric(getMessageType(), getSize(), getBytes(), getGuarantee());
+    }
+
+    /**
+     * Generates a routing key for the specified serialized message. The routing key is based on the segment of the
+     * message if it is available; otherwise, it defaults to the unique message identifier.
+     */
+    public static String routingKeyFor(SerializedMessage message) {
+        return ofNullable(message.getSegment()).map(s -> Integer.toString(s)).orElseGet(message::getMessageId);
     }
 
     /**

--- a/common/src/test/java/io/fluxzero/common/api/publishing/AppendTest.java
+++ b/common/src/test/java/io/fluxzero/common/api/publishing/AppendTest.java
@@ -1,0 +1,44 @@
+package io.fluxzero.common.api.publishing;
+
+import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AppendTest {
+
+    @Test
+    void routingKeyUsesSegmentWhenAvailable() {
+        SerializedMessage first = message("a", 4);
+        SerializedMessage second = message("b", 4);
+
+        assertEquals("4", new Append(MessageType.WEBREQUEST, List.of(first, second), Guarantee.SENT).routingKey());
+    }
+
+    @Test
+    void routingKeyFallsBackToMessageIdWhenSegmentIsMissing() {
+        assertEquals("a",
+                     new Append(MessageType.WEBREQUEST, List.of(message("a", null)), Guarantee.SENT).routingKey());
+    }
+
+    @Test
+    void routingKeyUsesFirstMessageAffinityForMixedBatch() {
+        Append append = new Append(MessageType.WEBREQUEST, List.of(message("a", 4), message("b", 5)),
+                                   Guarantee.SENT);
+
+        assertEquals("4", append.routingKey());
+    }
+
+    private static SerializedMessage message(String messageId, Integer segment) {
+        SerializedMessage message = new SerializedMessage(new Data<>(new byte[]{1}, byte[].class.getName(), 0,
+                                                                    Data.JSON_FORMAT), Metadata.empty(), messageId, 1L);
+        message.setSegment(segment);
+        return message;
+    }
+}

--- a/proxy/src/main/java/io/fluxzero/proxy/ProxyRequestHandler.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ProxyRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,11 @@
 
 package io.fluxzero.proxy;
 
+import io.fluxzero.common.ConsistentHashing;
 import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.HasMetadata;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.sdk.common.AbstractNamespaced;
 import io.fluxzero.sdk.configuration.client.Client;
@@ -47,7 +50,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
+import org.xnio.channels.Channels;
+import org.xnio.channels.StreamSourceChannel;
 
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -58,11 +65,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static io.fluxzero.common.ObjectUtils.newWorkerPool;
 import static io.fluxzero.common.ObjectUtils.unwrapException;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getBooleanProperty;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.mapProperty;
 import static io.undertow.servlet.Servlets.deployment;
 import static java.lang.String.format;
@@ -72,16 +85,23 @@ import static java.util.Optional.ofNullable;
 public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler> implements HttpHandler {
 
     public static final String CORS_DOMAINS_PROPERTY = "FLUXZERO_CORS_DOMAINS";
+    public static final String REQUEST_CHUNK_SIZE_PROPERTY = "FLUXZERO_PROXY_REQUEST_CHUNK_SIZE";
+    public static final String LOG_CHUNK_DISPATCHES_PROPERTY = "FLUXZERO_PROXY_LOG_CHUNK_DISPATCHES";
+    public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(200);
 
     @Getter
     private final Client client;
 
+    private final int maxRequestSize;
+    private final Duration requestTimeout;
     private final ProxySerializer serializer = new ProxySerializer();
     private final GatewayClient requestGateway;
     private final RequestHandler requestHandler;
     private final WebsocketEndpoint websocketEndpoint;
     private final HttpHandler websocketHandler;
     private final NamespaceSelector namespaceSelector;
+    private final ExecutorService chunkedResponseExecutor;
+    private final boolean logChunkDispatches;
 
     private final AtomicBoolean closed = new AtomicBoolean();
     @Getter(lazy = true)
@@ -89,23 +109,42 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
             .filter(d -> !d.isEmpty()).collect(Collectors.toSet()), Set::of);
 
     public ProxyRequestHandler(Client client) {
-        this(client, new NamespaceSelector());
+        this(client, new NamespaceSelector(),
+             validateRequestChunkSize(getIntegerProperty(REQUEST_CHUNK_SIZE_PROPERTY, WebUtils.DEFAULT_CHUNK_SIZE)),
+             DEFAULT_REQUEST_TIMEOUT);
     }
 
-    private ProxyRequestHandler(Client client, NamespaceSelector namespaceSelector) {
+    protected ProxyRequestHandler(Client client, int maxRequestSize, Duration requestTimeout) {
+        this(client, new NamespaceSelector(), validateRequestChunkSize(maxRequestSize), requestTimeout);
+    }
+
+    private ProxyRequestHandler(Client client, NamespaceSelector namespaceSelector, int maxRequestSize,
+                                Duration requestTimeout) {
         this.client = client;
+        this.maxRequestSize = maxRequestSize;
+        this.requestTimeout = requestTimeout;
         requestGateway = client.getGatewayClient(MessageType.WEBREQUEST);
-        requestHandler = new DefaultRequestHandler(client, MessageType.WEBRESPONSE, Duration.ofSeconds(200),
+        requestHandler = new DefaultRequestHandler(client, MessageType.WEBRESPONSE, requestTimeout,
                                                    format("%s_%s", client.name(), "$proxy-request-handler"));
+        chunkedResponseExecutor = newWorkerPool(format("%s_%s", client.name(), "$proxy-chunked-response"), 8);
         websocketEndpoint = new WebsocketEndpoint(client);
         websocketHandler = createWebsocketHandler();
         this.namespaceSelector = namespaceSelector;
+        logChunkDispatches = getBooleanProperty(LOG_CHUNK_DISPATCHES_PROPERTY);
+    }
+
+    protected static int validateRequestChunkSize(int chunkSize) {
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException(REQUEST_CHUNK_SIZE_PROPERTY + " must be greater than 0");
+        }
+        return chunkSize;
     }
 
     @Override
     protected ProxyRequestHandler createForNamespace(String namespace) {
         return Objects.equals(client.namespace(), namespace)
-                ? this : new ProxyRequestHandler(client.forNamespace(namespace), namespaceSelector);
+                ? this : new ProxyRequestHandler(client.forNamespace(namespace), namespaceSelector, maxRequestSize,
+                                                 requestTimeout);
     }
 
     @Override
@@ -121,10 +160,19 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
         if (handleCorsPreflight(exchange)) {
             return;
         }
+        if (shouldChunkRequest(exchange)) {
+            try {
+                sendWebRequest(exchange, createWebRequest(exchange, new byte[0]), true);
+            } catch (Throwable e) {
+                log.error("Failed to stream incoming message", e);
+                sendServerError(exchange);
+            }
+            return;
+        }
         exchange.getRequestReceiver().receiveFullBytes(
                 (se, payload) -> se.dispatch(() -> {
                     try {
-                        sendWebRequest(se, createWebRequest(se, payload));
+                        sendWebRequest(se, createWebRequest(se, payload), false);
                     } catch (Throwable e) {
                         log.error("Failed to create request", e);
                         sendServerError(se);
@@ -144,6 +192,11 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
         se.getRequestHeaders().forEach(
                 header -> header.forEach(value -> builder.header(header.getHeaderName().toString(), value)));
         return tryUpgrade(builder.build(), se);
+    }
+
+    protected boolean shouldChunkRequest(HttpServerExchange exchange) {
+        long contentLength = exchange.getRequestContentLength();
+        return contentLength < 0 || contentLength > maxRequestSize;
     }
 
     protected WebRequest tryUpgrade(WebRequest webRequest, HttpServerExchange se) {
@@ -240,7 +293,7 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
         return false;
     }
 
-    protected void sendWebRequest(HttpServerExchange se, WebRequest webRequest) {
+    protected void sendWebRequest(HttpServerExchange se, WebRequest webRequest, boolean chunked) {
         String namespace;
         try {
             namespace = namespaceSelector.select(webRequest);
@@ -250,10 +303,18 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
             return;
         }
         if (namespace != null) {
-            forNamespace(namespace).doSendWebRequest(se, webRequest);
+            forNamespace(namespace).sendResolvedWebRequest(se, webRequest, chunked);
             return;
         }
-        doSendWebRequest(se, webRequest);
+        sendResolvedWebRequest(se, webRequest, chunked);
+    }
+
+    protected void sendResolvedWebRequest(HttpServerExchange se, WebRequest webRequest, boolean chunked) {
+        if (chunked) {
+            doSendChunkedWebRequest(se, webRequest);
+        } else {
+            doSendWebRequest(se, webRequest);
+        }
     }
 
     protected void doSendWebRequest(HttpServerExchange se, WebRequest webRequest) {
@@ -261,25 +322,276 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
         requestHandler.sendRequest(
                         requestMessage, m -> requestGateway.append(Guarantee.SENT, m),
                         intermediateResponse -> handleResponse(intermediateResponse, webRequest, se))
-                .whenComplete((r, e) -> {
-                    try {
-                        e = unwrapException(e);
-                        if (e == null) {
-                            handleResponse(r, webRequest, se);
-                        } else if (e instanceof TimeoutException) {
-                            log.warn("Request {} timed out (messageId: {}). This is possibly due to a missing handler.",
-                                     webRequest, webRequest.getMessageId(), e);
-                            sendGatewayTimeout(se);
-                        } else {
-                            log.error("Failed to complete {} (messageId: {})",
-                                      webRequest, webRequest.getMessageId(), e);
-                            sendServerError(se);
-                        }
-                    } catch (Throwable t) {
-                        log.error("Failed to process response {} to request {}", e == null ? r : e, webRequest, t);
-                        sendServerError(se);
+                .whenComplete((r, e) -> completeResponse(r, e, webRequest, se));
+    }
+
+    protected void doSendChunkedWebRequest(HttpServerExchange se, WebRequest webRequest) {
+        se.dispatch(chunkedResponseExecutor, () -> readChunkedWebRequest(se, webRequest));
+    }
+
+    protected void readChunkedWebRequest(HttpServerExchange se, WebRequest webRequest) {
+        AtomicReference<ChunkedProxyRequest> chunkedRequest = new AtomicReference<>();
+        AtomicReference<ByteArrayOutputStream> pendingBuffer =
+                new AtomicReference<>(new ByteArrayOutputStream(maxRequestSize));
+        AtomicBoolean failed = new AtomicBoolean();
+        long expectedContentLength = se.getRequestContentLength();
+        long totalRead = 0;
+        try {
+            StreamSourceChannel requestChannel = se.getRequestChannel();
+            ByteBuffer readBuffer = ByteBuffer.allocate(Math.min(maxRequestSize, 64 * 1024));
+            long readTimeoutMillis = Math.max(1L, Math.min(requestTimeout.toMillis(), 100L));
+            while (!failed.get()) {
+                readBuffer.clear();
+                int read = Channels.readBlocking(requestChannel, readBuffer, readTimeoutMillis,
+                                                 java.util.concurrent.TimeUnit.MILLISECONDS);
+                if (read < 0) {
+                    if (expectedContentLength >= 0 && totalRead < expectedContentLength) {
+                        throw new EOFException(format("Request ended early after %s of %s bytes",
+                                                      totalRead, expectedContentLength));
+                    }
+                    break;
+                }
+                if (read == 0) {
+                    continue;
+                }
+                totalRead += read;
+                processChunkedRequestBytes(se, webRequest, readBuffer.array(), read, false, chunkedRequest,
+                                           pendingBuffer, failed);
+                awaitChunkDispatch(se, webRequest, chunkedRequest.get(), false, failed);
+            }
+            if (failed.get()) {
+                return;
+            }
+            processChunkedRequestBytes(se, webRequest, new byte[0], 0, true, chunkedRequest, pendingBuffer, failed);
+            awaitChunkDispatch(se, webRequest, chunkedRequest.get(), true, failed);
+        } catch (Throwable error) {
+            if (failed.compareAndSet(false, true)) {
+                log.error("Failed to read incoming message", error);
+                completeResponse(null, error, webRequest, se);
+            }
+        }
+    }
+
+    protected void processChunkedRequestBytes(HttpServerExchange se, WebRequest webRequest, byte[] bytes,
+                                              int length, boolean last,
+                                              AtomicReference<ChunkedProxyRequest> chunkedRequest,
+                                              AtomicReference<ByteArrayOutputStream> pendingBuffer,
+                                              AtomicBoolean failed) {
+        if (failed.get()) {
+            return;
+        }
+        try {
+            ByteArrayOutputStream buffer = pendingBuffer.get();
+            if (length > 0) {
+                buffer.write(bytes, 0, length);
+            }
+            ChunkedProxyRequest currentRequest = chunkedRequest.get();
+            boolean dispatchedFinalChunk = false;
+            if (currentRequest == null && last && buffer.size() <= maxRequestSize) {
+                doSendWebRequest(se, webRequest.withPayload(buffer.toByteArray()));
+                buffer.reset();
+                return;
+            }
+            while (buffer.size() >= maxRequestSize || (last && buffer.size() > 0)) {
+                if (currentRequest == null) {
+                    currentRequest = new ChunkedProxyRequest(webRequest, se);
+                    currentRequest.watchForEarlyFailure(failed);
+                }
+                boolean finalChunk = last && buffer.size() <= maxRequestSize;
+                currentRequest.append(takeChunk(buffer, Math.min(maxRequestSize, buffer.size())), finalChunk);
+                dispatchedFinalChunk |= finalChunk;
+            }
+            if (last && buffer.size() == 0 && currentRequest != null
+                && !dispatchedFinalChunk && !currentRequest.hasDispatchedFinalChunk()) {
+                currentRequest.append(new byte[0], true);
+            }
+            if (currentRequest != null) {
+                chunkedRequest.set(currentRequest);
+            }
+        } catch (Throwable e) {
+            if (failed.compareAndSet(false, true)) {
+                completeResponse(null, e, webRequest, se);
+            }
+        }
+    }
+
+    protected byte[] takeChunk(ByteArrayOutputStream buffer, int length) {
+        byte[] allBytes = buffer.toByteArray();
+        byte[] chunk = Arrays.copyOfRange(allBytes, 0, length);
+        buffer.reset();
+        if (allBytes.length > length) {
+            buffer.write(allBytes, length, allBytes.length - length);
+        }
+        return chunk;
+    }
+
+    protected void awaitChunkDispatch(HttpServerExchange se, WebRequest webRequest, ChunkedProxyRequest currentRequest,
+                                      boolean last, AtomicBoolean failed) {
+        if (failed.get() || currentRequest == null) {
+            return;
+        }
+        try {
+            currentRequest.dispatchFuture().join();
+        } catch (Throwable error) {
+            if (failed.compareAndSet(false, true)) {
+                completeResponse(null, error, webRequest, se);
+            }
+            return;
+        }
+        if (last) {
+            currentRequest.responseFuture().whenComplete((response, responseError) -> se.dispatch(
+                    chunkedResponseExecutor, () -> completeResponse(response, responseError, webRequest, se)));
+        }
+    }
+
+    protected SerializedMessage createChunkedRequestMessage(WebRequest webRequest, byte[] chunk, long chunkIndex,
+                                                            boolean firstChunk, boolean finalChunk) {
+        var metadata = webRequest.getMetadata()
+                .with(HasMetadata.CHUNK_INDEX, chunkIndex)
+                .with(HasMetadata.FIRST_CHUNK, Boolean.toString(firstChunk))
+                .with(HasMetadata.FINAL_CHUNK, Boolean.toString(finalChunk));
+        SerializedMessage chunkMessage = new SerializedMessage(
+                new Data<>(chunk, byte[].class.getName(), 0, "application/octet-stream"),
+                metadata, webRequest.getMessageId(), webRequest.getTimestamp().toEpochMilli());
+        return chunkMessage;
+    }
+
+    protected void logChunkDispatch(WebRequest webRequest, SerializedMessage chunkMessage) {
+        if (!logChunkDispatches || !log.isInfoEnabled()) {
+            return;
+        }
+        log.info(
+                "Dispatching proxy chunk for request {} (messageId={}, chunkIndex={}, firstChunk={}, finalChunk={}, bytes={})",
+                webRequest.getPath(), chunkMessage.getMessageId(), chunkMessage.getMetadata().get(HasMetadata.CHUNK_INDEX),
+                chunkMessage.firstChunk(), chunkMessage.lastChunk(),
+                chunkMessage.getData() == null || chunkMessage.getData().getValue() == null
+                        ? 0 : chunkMessage.getData().getValue().length);
+    }
+
+    protected class ChunkedProxyRequest {
+        private final WebRequest webRequest;
+        private final HttpServerExchange exchange;
+        private final CompletableFuture<SerializedMessage> responseFuture = new CompletableFuture<>();
+        private final AtomicReference<CompletableFuture<Void>> lastDispatch =
+                new AtomicReference<>(CompletableFuture.completedFuture(null));
+        private final AtomicBoolean watchingFailure = new AtomicBoolean();
+        private final AtomicBoolean finalChunkDispatched = new AtomicBoolean();
+        private long nextChunkIndex;
+        private SerializedMessage firstChunk;
+
+        protected ChunkedProxyRequest(WebRequest webRequest, HttpServerExchange exchange) {
+            this.webRequest = webRequest;
+            this.exchange = exchange;
+        }
+
+        protected synchronized void append(byte[] chunk, boolean finalChunk) {
+            if (responseFuture.isDone()) {
+                throw new IllegalStateException("Cannot append chunks after the request has already completed");
+            }
+            if (finalChunkDispatched.get()) {
+                throw new IllegalStateException("Cannot append chunks after the final chunk has been dispatched");
+            }
+            if (firstChunk == null) {
+                sendFirstChunk(chunk, finalChunk);
+                return;
+            }
+            SerializedMessage continuation = prepareContinuation(createChunkedRequestMessage(
+                    webRequest, chunk, nextChunkIndex++, false, finalChunk));
+            if (finalChunk) {
+                finalChunkDispatched.set(true);
+            }
+            dispatch(lastDispatch.get().thenCompose(ignored -> {
+                logChunkDispatch(webRequest, continuation);
+                return requestGateway.append(Guarantee.SENT, continuation);
+            }));
+        }
+
+        protected CompletableFuture<Void> dispatchFuture() {
+            return lastDispatch.get();
+        }
+
+        protected boolean hasDispatchedFinalChunk() {
+            return finalChunkDispatched.get();
+        }
+
+        protected CompletableFuture<SerializedMessage> responseFuture() {
+            return responseFuture;
+        }
+
+        protected void watchForEarlyFailure(AtomicBoolean failed) {
+            if (watchingFailure.compareAndSet(false, true)) {
+                responseFuture.whenComplete((response, error) -> {
+                    if (error != null && failed.compareAndSet(false, true)) {
+                        exchange.dispatch(chunkedResponseExecutor,
+                                          () -> completeResponse(null, error, webRequest, exchange));
                     }
                 });
+            }
+        }
+
+        private void sendFirstChunk(byte[] chunk, boolean finalChunk) {
+            firstChunk = createChunkedRequestMessage(webRequest, chunk, nextChunkIndex++, true, finalChunk);
+            if (finalChunk) {
+                finalChunkDispatched.set(true);
+            }
+            firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+            AtomicReference<CompletableFuture<Void>> initialDispatch =
+                    new AtomicReference<>(CompletableFuture.completedFuture(null));
+            requestHandler.sendRequest(firstChunk, message -> {
+                try {
+                    logChunkDispatch(webRequest, message);
+                    initialDispatch.set(requestGateway.append(Guarantee.SENT, message));
+                } catch (Throwable e) {
+                    initialDispatch.set(CompletableFuture.failedFuture(e));
+                    throw e;
+                }
+            }, null, intermediateResponse -> handleResponse(intermediateResponse, webRequest, exchange))
+                    .whenComplete((response, error) -> {
+                        if (error == null) {
+                            responseFuture.complete(response);
+                        } else {
+                            responseFuture.completeExceptionally(unwrapException(error));
+                        }
+                    });
+            dispatch(initialDispatch.get());
+        }
+
+        private SerializedMessage prepareContinuation(SerializedMessage chunk) {
+            chunk.setMessageId(firstChunk.getMessageId());
+            chunk.setRequestId(firstChunk.getRequestId());
+            chunk.setSource(firstChunk.getSource());
+            chunk.setSegment(firstChunk.getSegment());
+            return chunk;
+        }
+
+        private void dispatch(CompletableFuture<Void> future) {
+            lastDispatch.set(future);
+            future.whenComplete((r, e) -> {
+                if (e != null) {
+                    responseFuture.completeExceptionally(unwrapException(e));
+                }
+            });
+        }
+    }
+
+    protected void completeResponse(SerializedMessage response, Throwable error, WebRequest webRequest,
+                                    HttpServerExchange se) {
+        try {
+            error = unwrapException(error);
+            if (error == null) {
+                handleResponse(response, webRequest, se);
+            } else if (error instanceof TimeoutException) {
+                log.warn("Request {} timed out (messageId: {}). This is possibly due to a missing handler.",
+                         webRequest, webRequest.getMessageId(), error);
+                sendGatewayTimeout(se);
+            } else {
+                log.error("Failed to complete {} (messageId: {})", webRequest, webRequest.getMessageId(), error);
+                sendServerError(se);
+            }
+        } catch (Throwable t) {
+            log.error("Failed to process response {} to request {}", error == null ? response : error, webRequest, t);
+            sendServerError(se);
+        }
     }
 
     @SuppressWarnings("resource")
@@ -353,6 +665,7 @@ public class ProxyRequestHandler extends AbstractNamespaced<ProxyRequestHandler>
             websocketEndpoint.shutDown();
             requestHandler.close();
             requestGateway.close();
+            chunkedResponseExecutor.shutdown();
             super.close();
         }
     }

--- a/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 package io.fluxzero.proxy;
 
 import com.sun.net.httpserver.HttpServer;
+import io.fluxzero.common.MessageType;
 import io.fluxzero.common.TestUtils;
 import io.fluxzero.common.ThrowingConsumer;
 import io.fluxzero.common.ThrowingFunction;
 import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.common.serialization.ChunkedDeserializingMessage;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.tracking.Consumer;
 import io.fluxzero.sdk.tracking.ConsumerConfiguration;
@@ -30,8 +33,10 @@ import io.fluxzero.sdk.web.HandleSocketClose;
 import io.fluxzero.sdk.web.HandleSocketMessage;
 import io.fluxzero.sdk.web.HandleSocketOpen;
 import io.fluxzero.sdk.web.HandleSocketPong;
+import io.fluxzero.sdk.web.PathParam;
 import io.fluxzero.sdk.web.SocketSession;
 import io.fluxzero.sdk.web.WebRequest;
+import io.fluxzero.sdk.web.WebUtils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -39,7 +44,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -47,20 +58,26 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.fluxzero.proxy.NamespaceSelector.FLUXZERO_NAMESPACE_HEADER;
 import static io.fluxzero.proxy.NamespaceSelector.JWKS_URL_PROPERTY;
 import static java.lang.String.format;
 import static java.net.http.HttpRequest.newBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -115,6 +132,353 @@ class ProxyServerTest {
                     .expectResult("Hello Fluxzero");
         }
 
+        @Test
+        void postChunkedOctetStreamUpload() {
+            byte[] payload = "a".repeat(WebUtils.DEFAULT_CHUNK_SIZE + 1024).getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library;
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "application/octet-stream")
+                                    .POST(BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(payload)))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":books");
+        }
+
+        @Test
+        void postChunkedBinaryUploadAsByteArrayMatchesExpectedPayload() {
+            byte[] payload = new byte[WebUtils.DEFAULT_CHUNK_SIZE + 4096];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i % 251);
+            }
+            String expected = Base64.getEncoder().encodeToString(payload) + ":books";
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(byte[] body, @PathParam("library") String library) {
+                            return Base64.getEncoder().encodeToString(body) + ":" + library;
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "application/pdf")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(expected);
+        }
+
+        @Test
+        void postLargePlainTextUploadIsChunkedBySize() {
+            byte[] payload = "a".repeat(WebUtils.DEFAULT_CHUNK_SIZE + 1024).getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library;
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "text/plain")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":books");
+        }
+
+        @Test
+        void postChunkedOctetStreamUploadBuffersSmallPublisherPartsIntoTwoRequests() {
+            byte[] payload = "a".repeat((int) (WebUtils.DEFAULT_CHUNK_SIZE * 1.75)).getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library;
+                        }
+                    })
+                    .whenApplying(fc -> {
+                        AtomicInteger webRequestDispatches = new AtomicInteger();
+                        var registration = fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                .registerMonitor(messages -> webRequestDispatches.addAndGet(messages.size()));
+                        try {
+                            String result = httpClient.send(
+                                    newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                            .header("Content-Type", "application/octet-stream")
+                                            .POST(chunkedBodyPublisher(payload, 8192))
+                                            .build(),
+                                    BodyHandlers.ofString()).body();
+                            assertEquals(payload.length + ":books", result);
+                            assertEquals(2, webRequestDispatches.get());
+                            return result;
+                        } finally {
+                            registration.cancel();
+                        }
+                    })
+                    .expectResult(payload.length + ":books");
+        }
+
+        @Test
+        void postSmallOctetStreamUploadWithoutChunkMetadata() {
+            byte[] payload = "small upload".getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, DeserializingMessage message,
+                                      @PathParam("library") String library)
+                                throws Exception {
+                            return stream.readAllBytes().length + ":" + library + ":"
+                                   + (message instanceof ChunkedDeserializingMessage);
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "application/octet-stream")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .verifyResult(result -> {
+                        assertTrue(result.startsWith(payload.length + ":books:"),
+                                   () -> "Unexpected result: " + result);
+                        assertEquals(payload.length + ":books:false", result);
+                    });
+        }
+
+        @Test
+        void postThresholdMinusOneUploadWithoutChunkMetadata() {
+            assertChunkedFlagForPayloadSize(WebUtils.DEFAULT_CHUNK_SIZE - 1, false);
+        }
+
+        @Test
+        void postExactThresholdUploadWithoutChunkMetadata() {
+            assertChunkedFlagForPayloadSize(WebUtils.DEFAULT_CHUNK_SIZE, false);
+        }
+
+        @Test
+        void postThresholdPlusOneUploadWithChunkMetadata() {
+            assertChunkedFlagForPayloadSize(WebUtils.DEFAULT_CHUNK_SIZE + 1, true);
+        }
+
+        @Test
+        void postSmallVideoUploadWithoutChunkMetadata() {
+            byte[] payload = "small video".getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, DeserializingMessage message,
+                                      @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library + ":"
+                                   + (message instanceof ChunkedDeserializingMessage);
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/videos", proxyPort)))
+                                    .header("Content-Type", "video/mp4")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":videos:false");
+        }
+
+        @Test
+        void postEmptyChunkedOctetStreamUpload() {
+            byte[] payload = new byte[0];
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library;
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "application/octet-stream")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":books");
+        }
+
+        @Test
+        void postChunkedOctetStreamUploadWithAsyncResponse() {
+            byte[] payload = "a".repeat(WebUtils.DEFAULT_CHUNK_SIZE + 1024).getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        CompletionStage<String> upload(InputStream stream, @PathParam("library") String library) {
+                            return CompletableFuture.supplyAsync(() -> {
+                                try {
+                                    return stream.readAllBytes().length + ":" + library;
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }).completeOnTimeout("timeout", 1, TimeUnit.SECONDS);
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "application/octet-stream")
+                                    .POST(BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(payload)))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":books");
+        }
+
+        @Test
+        void requestChunkSizeCanBeConfiguredWithProxyProperty() {
+            String previous = System.getProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY);
+            System.setProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, "1024");
+            ProxyRequestHandler configuredHandler = new ProxyRequestHandler(testFixture.getFluxzero().client());
+            ProxyServer configuredServer = ProxyServer.start(0, configuredHandler);
+            try {
+                byte[] payload = "a".repeat(1500).getBytes(StandardCharsets.UTF_8);
+                AtomicInteger webRequestDispatches = new AtomicInteger();
+                var registration = testFixture.getFluxzero().client().getGatewayClient(MessageType.WEBREQUEST)
+                        .registerMonitor(messages -> webRequestDispatches.addAndGet(messages.size()));
+                try {
+                    testFixture.registerHandlers(new Object() {
+                                @HandlePost("/upload")
+                                String upload(InputStream stream) throws Exception {
+                                    return String.valueOf(stream.readAllBytes().length);
+                                }
+                            })
+                            .whenApplying(fc -> httpClient.send(
+                                    newBuilder(URI.create(format("http://0.0.0.0:%s/upload", configuredServer.getPort())))
+                                            .header("Content-Type", "text/plain")
+                                            .POST(BodyPublishers.ofByteArray(payload))
+                                            .build(),
+                                    BodyHandlers.ofString()).body())
+                            .expectResult(String.valueOf(payload.length));
+                    assertEquals(2, webRequestDispatches.get());
+                } finally {
+                    registration.cancel();
+                }
+            } finally {
+                configuredServer.cancel();
+                restoreProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, previous);
+            }
+        }
+
+        @Test
+        void postChunkedStreamUploadPreservesExactPayloadWithSmallConfiguredChunks() {
+            String previous = System.getProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY);
+            System.setProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, "1024");
+            ProxyRequestHandler configuredHandler = new ProxyRequestHandler(testFixture.getFluxzero().client());
+            ProxyServer configuredServer = ProxyServer.start(0, configuredHandler);
+            try {
+                byte[] payload = new byte[10 * 1024 + 333];
+                for (int i = 0; i < payload.length; i++) {
+                    payload[i] = (byte) (i % 251);
+                }
+                String expected = Base64.getEncoder().encodeToString(payload);
+                testFixture.registerHandlers(new Object() {
+                            @HandlePost("/upload")
+                            String upload(InputStream stream) throws Exception {
+                                return Base64.getEncoder().encodeToString(stream.readAllBytes());
+                            }
+                        })
+                        .whenApplying(fc -> httpClient.send(
+                                newBuilder(URI.create(format("http://0.0.0.0:%s/upload", configuredServer.getPort())))
+                                        .header("Content-Type", "application/octet-stream")
+                                        .POST(BodyPublishers.ofByteArray(payload))
+                                        .build(),
+                                BodyHandlers.ofString()).body())
+                        .expectResult(expected);
+            } finally {
+                configuredServer.cancel();
+                restoreProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, previous);
+            }
+        }
+
+        @Test
+        void invalidRequestChunkSizePropertyIsRejected() {
+            String previous = System.getProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY);
+            System.setProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, "0");
+            try {
+                IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                                                              () -> new ProxyRequestHandler(
+                                                                      testFixture.getFluxzero().client()));
+                assertEquals(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY + " must be greater than 0",
+                             error.getMessage());
+            } finally {
+                restoreProperty(ProxyRequestHandler.REQUEST_CHUNK_SIZE_PROPERTY, previous);
+            }
+        }
+
+        @Test
+        void stalledChunkedUploadTimesOut() throws Exception {
+            ProxyRequestHandler timeoutHandler =
+                    new ProxyRequestHandler(testFixture.getFluxzero().client(), 1024, java.time.Duration.ofMillis(200));
+            ProxyServer timeoutServer = ProxyServer.start(0, timeoutHandler);
+            try (Socket socket = new Socket("0.0.0.0", timeoutServer.getPort())) {
+                socket.setSoTimeout(3000);
+                OutputStream output = socket.getOutputStream();
+                output.write(("POST /upload HTTP/1.1\r\n"
+                              + "Host: localhost\r\n"
+                              + "Content-Type: application/octet-stream\r\n"
+                              + "Content-Length: 2048\r\n"
+                              + "\r\n").getBytes(StandardCharsets.UTF_8));
+                output.write(new byte[1024]);
+                output.flush();
+
+                BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                                                                                 StandardCharsets.UTF_8));
+                assertEquals("HTTP/1.1 504 Gateway Time-out", reader.readLine());
+            } finally {
+                timeoutServer.cancel();
+            }
+        }
+
+        @Test
+        void disconnectedChunkedUploadDoesNotInvokeTypedPayloadHandler() throws Exception {
+            ProxyRequestHandler timeoutHandler =
+                    new ProxyRequestHandler(testFixture.getFluxzero().client(), 1024, java.time.Duration.ofMillis(200));
+            ProxyServer timeoutServer = ProxyServer.start(0, timeoutHandler);
+            CountDownLatch handled = new CountDownLatch(1);
+            try {
+                testFixture.registerHandlers(new Object() {
+                    @HandlePost("/upload")
+                    String upload(byte[] body) {
+                        handled.countDown();
+                        return String.valueOf(body.length);
+                    }
+                });
+
+                try (Socket socket = new Socket("0.0.0.0", timeoutServer.getPort())) {
+                    OutputStream output = socket.getOutputStream();
+                    output.write(("POST /upload HTTP/1.1\r\n"
+                                  + "Host: localhost\r\n"
+                                  + "Content-Type: application/octet-stream\r\n"
+                                  + "Content-Length: 2048\r\n"
+                                  + "\r\n").getBytes(StandardCharsets.UTF_8));
+                    output.write(new byte[1024]);
+                    output.flush();
+                }
+
+                assertFalse(handled.await(500, TimeUnit.MILLISECONDS),
+                            "Typed payload handler should not be invoked for a disconnected chunked upload");
+            } finally {
+                timeoutServer.cancel();
+            }
+        }
+
+        private void assertChunkedFlagForPayloadSize(int size, boolean expectedChunked) {
+            byte[] payload = "a".repeat(size).getBytes(StandardCharsets.UTF_8);
+            testFixture.registerHandlers(new Object() {
+                        @HandlePost("/upload/{library}")
+                        String upload(InputStream stream, DeserializingMessage message,
+                                      @PathParam("library") String library) throws Exception {
+                            return stream.readAllBytes().length + ":" + library + ":"
+                                   + (message instanceof ChunkedDeserializingMessage);
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://0.0.0.0:%s/upload/books", proxyPort)))
+                                    .header("Content-Type", "text/plain")
+                                    .POST(BodyPublishers.ofByteArray(payload))
+                                    .build(),
+                            BodyHandlers.ofString()).body())
+                    .expectResult(payload.length + ":books:" + expectedChunked);
+        }
+
         private HttpRequest.Builder newRequest() {
             return newBuilder(baseUri());
         }
@@ -122,6 +486,66 @@ class ProxyServerTest {
         private URI baseUri() {
             return URI.create(format("http://0.0.0.0:%s/", proxyPort));
         }
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    private static HttpRequest.BodyPublisher chunkedBodyPublisher(byte[] payload, int publisherChunkSize) {
+        return new HttpRequest.BodyPublisher() {
+            @Override
+            public long contentLength() {
+                return payload.length;
+            }
+
+            @Override
+            public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    private int offset;
+                    private boolean cancelled;
+                    private boolean completed;
+                    private long demand;
+                    private boolean draining;
+
+                    @Override
+                    public synchronized void request(long n) {
+                        if (cancelled || completed || n <= 0) {
+                            return;
+                        }
+                        demand = Math.addExact(demand, n);
+                        if (draining) {
+                            return;
+                        }
+                        draining = true;
+                        try {
+                            while (!cancelled && !completed && demand > 0 && offset < payload.length) {
+                                demand--;
+                                int start = offset;
+                            int length = Math.min(publisherChunkSize, payload.length - offset);
+                                offset += length;
+                                subscriber.onNext(ByteBuffer.wrap(Arrays.copyOfRange(payload, start, start + length)));
+                            }
+                            if (!cancelled && !completed && offset >= payload.length) {
+                                completed = true;
+                                subscriber.onComplete();
+                            }
+                        } finally {
+                            draining = false;
+                        }
+                    }
+
+                    @Override
+                    public synchronized void cancel() {
+                        cancelled = true;
+                    }
+                });
+            }
+        };
     }
 
     @Nested
@@ -268,15 +692,18 @@ class ProxyServerTest {
 
         @Test
         void closeSocketExternally() {
+            CountDownLatch socketClosed = new CountDownLatch(1);
             testFixture.registerHandlers(new Object() {
                         @HandleSocketClose("/")
                         void close(Integer reason) {
                             Fluxzero.publishEvent("ws closed with " + reason);
+                            socketClosed.countDown();
                         }
                     })
                     .whenApplying(openSocketAnd(ws -> {
                         ws.sendClose(1000, "bla");
-                        Thread.sleep(100);
+                        assertTrue(socketClosed.await(1, TimeUnit.SECONDS),
+                                   "Timed out waiting for websocket close callback");
                     }))
                     .expectResult("1000")
                     .expectEvents("ws closed with 1000");
@@ -284,6 +711,7 @@ class ProxyServerTest {
 
         @Test
         void closeSocketFromApplication() {
+            CountDownLatch socketClosed = new CountDownLatch(1);
             testFixture.registerHandlers(new Object() {
                         @HandleSocketOpen("/")
                         void open(SocketSession session) {
@@ -294,9 +722,11 @@ class ProxyServerTest {
                         void close(Integer reason) {
                             log.info("ws closed with " + reason);
                             Fluxzero.publishEvent("ws closed with " + reason);
+                            socketClosed.countDown();
                         }
                     })
-                    .whenApplying(openSocketAnd(ws -> Thread.sleep(100)))
+                    .whenApplying(openSocketAnd(ws -> assertTrue(socketClosed.await(1, TimeUnit.SECONDS),
+                                                                 "Timed out waiting for websocket close callback")))
                     .expectResult("1001")
                     .expectEvents("ws closed with 1001");
         }

--- a/proxy/src/test/java/io/fluxzero/proxy/UploadTestApp.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/UploadTestApp.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.proxy;
+
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.configuration.DefaultFluxzero;
+import io.fluxzero.sdk.configuration.client.WebSocketClient;
+import io.fluxzero.sdk.web.FormParam;
+import io.fluxzero.sdk.web.HandleGet;
+import io.fluxzero.sdk.web.HandlePost;
+import io.fluxzero.sdk.web.MultipartFormPart;
+import io.fluxzero.sdk.web.WebRequest;
+import io.fluxzero.testserver.TestServer;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Small runnable app for manually testing end-to-end proxied web uploads against a local runtime.
+ * <p>
+ * By default it connects to {@code ws://localhost:8888}, registers a few {@code POST} handlers for different payload
+ * shapes, and keeps running until the process is stopped. If no local runtime is reachable on port {@code 8888}, it
+ * starts a {@link TestServer}. If no proxy is reachable on port {@code 8080}, it starts a local {@link ProxyServer}
+ * wired to the same client connection.
+ */
+@Slf4j
+public class UploadTestApp {
+    private static final String DEFAULT_ENDPOINT = "ws://localhost:8888";
+    private static final int DEFAULT_RUNTIME_PORT = 8888;
+    private static final int DEFAULT_PROXY_PORT = 8080;
+    private static final long STREAM_PROGRESS_LOG_INTERVAL_BYTES = 128L << 20;
+    private static final String DEFAULT_PROXY_MAX_REQUEST_BODY_SIZE = String.valueOf(16L << 30);
+    private static final String DEFAULT_PROXY_MAX_MULTIPART_REQUEST_BODY_SIZE = String.valueOf(16L << 30);
+
+    public static void main(String[] args) throws InterruptedException {
+        String endpoint = System.getProperty("endpoint.messaging", DEFAULT_ENDPOINT);
+        String clientName = System.getProperty("fluxzero.client.name", "upload-test-app");
+        HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+
+        if (shouldManageLocalRuntime(endpoint) && !isHealthy(httpClient,
+                                                             "http://localhost:" + DEFAULT_RUNTIME_PORT + "/health")) {
+            log.info("No Fluxzero test server detected on port {}, starting one", DEFAULT_RUNTIME_PORT);
+            TestServer.start(DEFAULT_RUNTIME_PORT);
+        }
+
+        WebSocketClient client = WebSocketClient.newInstance(
+                WebSocketClient.ClientConfig.builder()
+                        .name(clientName)
+                        .runtimeBaseUrl(endpoint)
+                        .build());
+
+        ProxyServer proxyServer = null;
+        if (shouldManageLocalRuntime(endpoint)
+            && !isHealthy(httpClient, "http://localhost:" + DEFAULT_PROXY_PORT + "/proxy/health")) {
+            log.info("No Fluxzero proxy detected on port {}, starting one", DEFAULT_PROXY_PORT);
+            configureLocalProxyLimits();
+            proxyServer = ProxyServer.start(DEFAULT_PROXY_PORT, new ProxyRequestHandler(client));
+        }
+
+        Fluxzero fluxzero = DefaultFluxzero.builder().build(client);
+        fluxzero.registerHandlers(new UploadHandler());
+        ProxyServer startedProxy = proxyServer;
+
+        Runtime.getRuntime().addShutdownHook(Thread.ofPlatform().name("upload-test-app-shutdown").unstarted(() -> {
+            log.info("Shutting down upload test app");
+            fluxzero.close();
+            if (startedProxy != null) {
+                startedProxy.cancel();
+            }
+        }));
+
+        log.info("Upload test app connected to {}", endpoint);
+        log.info("Ready to handle:");
+        log.info("  GET  /");
+        log.info("  POST /upload            (byte[])");
+        log.info("  POST /upload/stream     (InputStream)");
+        log.info("  POST /upload/text       (String)");
+        log.info("  POST /upload/form       (object-bound form body)");
+        log.info("  POST /upload/form-field (@FormParam)");
+        log.info("  POST /upload/multipart  (MultipartFormPart)");
+        new CountDownLatch(1).await();
+    }
+
+    public static class UploadHandler {
+        @HandleGet("/")
+        String index() {
+            return "upload-test-app ready";
+        }
+
+        @HandlePost("/upload")
+        String upload(byte[] payload) {
+            log.info("Received upload of {} bytes", payload.length);
+            return "received " + payload.length + " bytes";
+        }
+
+        @HandlePost("/upload/stream")
+        String uploadStream(InputStream payload, WebRequest request) throws Exception {
+            Long expectedBytes = parseContentLength(request.getHeader("Content-Length"));
+            Instant startedAt = Instant.now();
+            log.info("Started receiving stream upload{}", expectedBytes == null ? "" :
+                    " (" + formatMiB(expectedBytes) + " MiB expected)");
+            byte[] buffer = new byte[64 * 1024];
+            long totalBytes = 0;
+            long nextLogAt = STREAM_PROGRESS_LOG_INTERVAL_BYTES;
+            while (true) {
+                int read = payload.read(buffer);
+                if (read < 0) {
+                    break;
+                }
+                totalBytes += read;
+                if (totalBytes >= nextLogAt) {
+                    logProgress(totalBytes, expectedBytes, startedAt);
+                    nextLogAt += STREAM_PROGRESS_LOG_INTERVAL_BYTES;
+                }
+            }
+            logCompleted(totalBytes, expectedBytes, startedAt);
+            return "received stream of " + totalBytes + " bytes";
+        }
+
+        @HandlePost("/upload/text")
+        String uploadText(String payload) {
+            log.info("Received text upload of {} chars", payload.length());
+            return "received text: " + payload;
+        }
+
+        @HandlePost("/upload/form")
+        String uploadForm(UploadForm form) {
+            log.info("Received form upload for {} ({})", form.getName(), form.getDescription());
+            return form.getName() + "|" + form.getDescription();
+        }
+
+        @HandlePost("/upload/form-field")
+        String uploadFormField(@FormParam("name") String name, @FormParam("description") String description) {
+            log.info("Received form fields for {} ({})", name, description);
+            return name + "|" + description;
+        }
+
+        @HandlePost("/upload/multipart")
+        String uploadMultipart(@FormParam("document") MultipartFormPart document) {
+            String contents = document.asString(StandardCharsets.ISO_8859_1);
+            log.info("Received multipart file {} with {} bytes", document.getFilename(), document.getBytes().length);
+            return document.getFilename() + "|" + document.getContentType() + "|" + contents;
+        }
+    }
+
+    @Value
+    public static class UploadForm {
+        String name;
+        String description;
+    }
+
+    private static boolean shouldManageLocalRuntime(String endpoint) {
+        return DEFAULT_ENDPOINT.equals(endpoint);
+    }
+
+    private static boolean isHealthy(HttpClient httpClient, String url) {
+        try {
+            HttpResponse<String> response = httpClient.send(
+                    HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(1)).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            return response.statusCode() >= 200 && response.statusCode() < 300;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private static void configureLocalProxyLimits() {
+        setPropertyIfMissing("FLUXZERO_PROXY_LOG_CHUNK_DISPATCHES", "false");
+        setPropertyIfMissing("FLUXZERO_PROXY_MAX_REQUEST_BODY_SIZE", DEFAULT_PROXY_MAX_REQUEST_BODY_SIZE);
+        setPropertyIfMissing("FLUXZERO_PROXY_MAX_MULTIPART_REQUEST_BODY_SIZE",
+                             DEFAULT_PROXY_MAX_MULTIPART_REQUEST_BODY_SIZE);
+    }
+
+    private static void setPropertyIfMissing(String property, String value) {
+        if (System.getProperty(property) == null) {
+            System.setProperty(property, value);
+            log.info("Using {}={} for local upload testing", property, value);
+        }
+    }
+
+    private static void logProgress(long totalBytes, Long expectedBytes, Instant startedAt) {
+        Duration elapsed = Duration.between(startedAt, Instant.now());
+        String throughput = formatThroughput(totalBytes, elapsed);
+        if (expectedBytes == null || expectedBytes <= 0) {
+            log.info("Receiving stream upload progress: {} MiB after {}, avg {}",
+                     formatMiB(totalBytes), formatDuration(elapsed), throughput);
+            return;
+        }
+        double progress = Math.min(1d, totalBytes / (double) expectedBytes);
+        Duration remaining = estimateRemaining(elapsed, progress);
+        log.info("Receiving stream upload progress: {} MiB / {} MiB ({}%) after {}, avg {}, remaining {}",
+                 formatMiB(totalBytes), formatMiB(expectedBytes), Math.round(progress * 100),
+                 formatDuration(elapsed), throughput, formatDuration(remaining));
+    }
+
+    private static void logCompleted(long totalBytes, Long expectedBytes, Instant startedAt) {
+        Duration elapsed = Duration.between(startedAt, Instant.now());
+        String throughput = formatThroughput(totalBytes, elapsed);
+        if (expectedBytes == null || expectedBytes <= 0) {
+            log.info("Received stream upload of {} bytes after {}, avg {}", totalBytes, formatDuration(elapsed),
+                     throughput);
+            return;
+        }
+        log.info("Received stream upload of {} bytes ({} MiB / {} MiB, {}%) after {}, avg {}",
+                 totalBytes, formatMiB(totalBytes), formatMiB(expectedBytes),
+                 Math.round(Math.min(1d, totalBytes / (double) expectedBytes) * 100),
+                 formatDuration(elapsed), throughput);
+    }
+
+    private static Duration estimateRemaining(Duration elapsed, double progress) {
+        if (progress <= 0d || progress >= 1d) {
+            return Duration.ZERO;
+        }
+        long estimatedTotalMillis = Math.round(elapsed.toMillis() / progress);
+        return Duration.ofMillis(Math.max(0L, estimatedTotalMillis - elapsed.toMillis()));
+    }
+
+    private static Long parseContentLength(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static long formatMiB(long bytes) {
+        return bytes >> 20;
+    }
+
+    private static String formatDuration(Duration duration) {
+        long seconds = Math.max(0L, duration.toSeconds());
+        long minutes = seconds / 60;
+        long remainingSeconds = seconds % 60;
+        return minutes > 0 ? minutes + "m" + remainingSeconds + "s" : remainingSeconds + "s";
+    }
+
+    private static String formatThroughput(long totalBytes, Duration elapsed) {
+        long millis = Math.max(1L, elapsed.toMillis());
+        double mibPerSecond = (totalBytes / 1024d / 1024d) / (millis / 1000d);
+        return String.format("%.1f MiB/s", mibPerSecond);
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/common/serialization/ChunkedDeserializingMessage.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/serialization/ChunkedDeserializingMessage.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.sdk.common.serialization;
+
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.HasMetadata;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.common.reflection.ReflectionUtils;
+import io.fluxzero.sdk.common.Message;
+import io.fluxzero.sdk.web.WebRequest;
+import io.fluxzero.sdk.web.WebResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.fluxzero.common.ObjectUtils.join;
+
+/**
+ * Represents a chunked message that can expose its payload as an {@link InputStream} while additional chunks arrive.
+ * <p>
+ * Handlers can consume the payload as a stream immediately by requesting {@link InputStream}. They can also request a
+ * regular payload type such as a POJO; in that case deserialization waits until the final chunk has arrived and then
+ * materializes the full payload from the aggregated byte stream.
+ */
+public class ChunkedDeserializingMessage extends DeserializingMessage {
+    private final Serializer serializer;
+    private final MessageType aggregatedMessageType;
+    private final SerializedMessage representativeChunk;
+    private final StreamingInputStream inputStream = new StreamingInputStream();
+    private final List<byte[]> chunks = new ArrayList<>();
+    private final CompletableFuture<Void> completed = new CompletableFuture<>();
+
+    private volatile SerializedMessage aggregatedSerializedMessage;
+    private volatile DeserializingMessage aggregatedMessage;
+    private volatile Message streamingMessage;
+    private volatile boolean streamingOnly;
+
+    /**
+     * Creates a new chunked message view starting at the first observed chunk.
+     */
+    public ChunkedDeserializingMessage(SerializedMessage firstChunk, MessageType messageType, String topic,
+                                       Serializer serializer) {
+        super(firstChunk, __ -> null, messageType, topic, serializer);
+        this.serializer = serializer;
+        this.aggregatedMessageType = messageType;
+        this.representativeChunk = firstChunk.withMetadata(firstChunk.getMetadata().with(HasMetadata.FINAL_CHUNK, null));
+        appendChunk(firstChunk);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <R> R getPayloadAs(Type type) {
+        if (type instanceof Class<?> c && InputStream.class.isAssignableFrom(c)) {
+            return (R) inputStream;
+        }
+        return aggregatedMessage().getPayloadAs(type);
+    }
+
+    @Override
+    public <V> V getPayload() {
+        return aggregatedMessage().getPayload();
+    }
+
+    @Override
+    public Message toMessage() {
+        if (completed.isDone()) {
+            return super.toMessage();
+        }
+        Message result = streamingMessage;
+        if (result == null) {
+            Message message = new Message(inputStream, getMetadata(), getMessageId(), getTimestamp());
+            result = switch (aggregatedMessageType) {
+                case WEBREQUEST -> new WebRequest(message);
+                case WEBRESPONSE -> new WebResponse(message);
+                default -> message;
+            };
+            streamingMessage = result;
+        }
+        return result;
+    }
+
+    @Override
+    public Class<?> getPayloadClass() {
+        return ReflectionUtils.classForName(serializer.upcastType(representativeChunk.getType()), Void.class);
+    }
+
+    @Override
+    public SerializedMessage getSerializedObject() {
+        return representativeChunk;
+    }
+
+    /**
+     * Returns the fully aggregated payload bytes, waiting for the final chunk when necessary.
+     */
+    public byte[] getAggregatedPayloadBytes() {
+        return aggregatedSerializedMessage().getData().getValue();
+    }
+
+    /**
+     * Switches this message to streaming-only mode. Subsequent chunks are exposed through the input stream but are no
+     * longer retained in heap for full-payload aggregation.
+     */
+    public synchronized void enableStreamingOnlyMode() {
+        streamingOnly = true;
+        chunks.clear();
+        aggregatedSerializedMessage = null;
+        aggregatedMessage = null;
+    }
+
+    /**
+     * Appends an additional chunk to this message.
+     */
+    public synchronized void appendChunk(SerializedMessage chunk) {
+        aggregatedSerializedMessage = null;
+        aggregatedMessage = null;
+        byte[] bytes = chunk.getData().getValue();
+        if (!streamingOnly) {
+            chunks.add(bytes);
+        }
+        inputStream.append(bytes);
+        if (chunk.lastChunk()) {
+            inputStream.complete();
+            completed.complete(null);
+        }
+    }
+
+    /**
+     * Fails the stream and any pending aggregated deserialization with the given error.
+     */
+    public void fail(Throwable error) {
+        inputStream.fail(error);
+        completed.completeExceptionally(error);
+    }
+
+    protected DeserializingMessage aggregatedMessage() {
+        DeserializingMessage result = aggregatedMessage;
+        if (result == null) {
+            result = serializer.deserializeMessage(aggregatedSerializedMessage(), aggregatedMessageType);
+            aggregatedMessage = result;
+        }
+        return result;
+    }
+
+    protected SerializedMessage aggregatedSerializedMessage() {
+        if (streamingOnly) {
+            throw new IllegalStateException("Chunked payload aggregation is disabled for this streaming-only message");
+        }
+        completed.join();
+        SerializedMessage result = aggregatedSerializedMessage;
+        if (result == null) {
+            byte[] bytes;
+            synchronized (this) {
+                bytes = join(chunks.toArray(byte[][]::new));
+            }
+            var first = representativeChunk;
+            result = first.withData(new Data<>(
+                    bytes, first.getData().getType(), first.getData().getRevision(), first.getData().getFormat()));
+            result.setSource(first.getSource());
+            result.setTarget(first.getTarget());
+            result.setRequestId(first.getRequestId());
+            result.setIndex(first.getIndex());
+            result.setSegment(first.getSegment());
+            aggregatedSerializedMessage = result;
+        }
+        return result;
+    }
+
+    protected static class StreamingInputStream extends InputStream {
+        private final BlockingQueue<Chunk> queue = new LinkedBlockingQueue<>();
+        private byte[] current = new byte[0];
+        private int position;
+
+        public void append(byte[] bytes) {
+            queue.add(new Chunk(bytes, null, false));
+        }
+
+        public void complete() {
+            queue.add(new Chunk(null, null, true));
+        }
+
+        public void fail(Throwable error) {
+            queue.add(new Chunk(null, error, true));
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] single = new byte[1];
+            int read = read(single, 0, 1);
+            return read == -1 ? -1 : Byte.toUnsignedInt(single[0]);
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) throws IOException {
+            if (len == 0) {
+                return 0;
+            }
+            while (position >= current.length) {
+                Chunk chunk;
+                try {
+                    chunk = queue.take();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for request chunk", e);
+                }
+                if (chunk.error() != null) {
+                    throw new IOException("Failed to read request stream", chunk.error());
+                }
+                if (chunk.end()) {
+                    current = new byte[0];
+                    position = 0;
+                    return -1;
+                }
+                current = chunk.bytes();
+                position = 0;
+            }
+            int read = Math.min(len, current.length - position);
+            System.arraycopy(current, position, buffer, off, read);
+            position += read;
+            return read;
+        }
+    }
+
+    protected record Chunk(byte[] bytes, Throwable error, boolean end) {
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/DefaultRequestHandler.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/DefaultRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,11 @@ public class DefaultRequestHandler implements RequestHandler {
                                                             Consumer<SerializedMessage> intermediateCallback) {
         ensureStarted();
         CompletableFuture<SerializedMessage> future = prepareRequest(request, timeout, intermediateCallback);
-        requestSender.accept(request);
+        try {
+            requestSender.accept(request);
+        } catch (Throwable e) {
+            future.completeExceptionally(e);
+        }
         return future;
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/RequestHandler.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/RequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@ import java.util.function.Consumer;
 /**
  * Handles the lifecycle of request/response interactions in a Fluxzero client.
  * <p>
- * A {@code RequestHandler} is responsible for sending requests—such as commands, queries, or web requests—
- * and asynchronously completing them when a corresponding response is received. Requests may be handled locally
- * or remotely via the Fluxzero Runtime.
+ * A {@code RequestHandler} is responsible for sending requests—such as commands, queries, or web requests— and
+ * asynchronously completing them when a corresponding response is received. Requests may be handled locally or remotely
+ * via the Fluxzero Runtime.
  *
  * <h2>Handling Strategies</h2>
  * <ul>
@@ -108,6 +108,17 @@ public interface RequestHandler extends Namespaced<RequestHandler>, AutoCloseabl
                                                             Consumer<List<SerializedMessage>> requestSender,
                                                             @Nullable Duration timeout);
 
+    /**
+     * Sends a single request and returns a future that completes when the corresponding response is received.
+     * <p>
+     * The request is assigned a unique identifier and dispatched using the provided sender. During processing, a
+     * callback can optionally handle intermediate results.
+     *
+     * @param request              The request message to be sent.
+     * @param requestSender        A callback used to dispatch the request (e.g., to a gateway or transport layer).
+     * @param intermediateCallback A callback invoked with intermediate results while waiting for the response.
+     * @return A {@link CompletableFuture} that completes with the response message or fails on timeout.
+     */
     default CompletableFuture<SerializedMessage> sendRequest(
             SerializedMessage request,
             Consumer<SerializedMessage> requestSender,
@@ -115,6 +126,16 @@ public interface RequestHandler extends Namespaced<RequestHandler>, AutoCloseabl
         return sendRequest(request, requestSender, null, intermediateCallback);
     }
 
+    /**
+     * Sends a single request with a custom timeout and allows processing of intermediate responses, returning a future
+     * that completes when the corresponding response is received.
+     *
+     * @param request              The request message to be sent.
+     * @param requestSender        A callback used to dispatch the request (e.g., to a gateway or transport layer).
+     * @param timeout              The maximum duration to wait for a response. A negative value disables the timeout.
+     * @param intermediateCallback A callback invoked with intermediate results while waiting for the response.
+     * @return A {@link CompletableFuture} that completes with the response message or fails on timeout.
+     */
     CompletableFuture<SerializedMessage> sendRequest(
             SerializedMessage request,
             Consumer<SerializedMessage> requestSender, Duration timeout,

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/client/WebsocketGatewayClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/client/WebsocketGatewayClient.java
@@ -28,8 +28,12 @@ import jakarta.websocket.ClientEndpoint;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -114,7 +118,12 @@ public class WebsocketGatewayClient extends AbstractWebsocketClient implements G
     @Override
     public CompletableFuture<Void> append(Guarantee guarantee, SerializedMessage... messages) {
         try {
-            return sendCommand(new Append(messageType, Arrays.asList(messages), guarantee));
+            if (messages.length == 0) {
+                return CompletableFuture.completedFuture(null);
+            }
+            List<CompletableFuture<Void>> futures = partitionByRoutingKey(Arrays.asList(messages)).stream()
+                    .map(batch -> sendCommand(new Append(messageType, batch, guarantee))).toList();
+            return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
         } finally {
             if (!monitors.isEmpty()) {
                 monitors.forEach(m -> m.accept(Arrays.asList(messages)));
@@ -141,5 +150,30 @@ public class WebsocketGatewayClient extends AbstractWebsocketClient implements G
     public Registration registerMonitor(Consumer<List<SerializedMessage>> monitor) {
         monitors.add(monitor);
         return () -> monitors.remove(monitor);
+    }
+
+    static List<List<SerializedMessage>> partitionByRoutingKey(List<SerializedMessage> messages) {
+        if (messages.isEmpty()) {
+            return List.of();
+        }
+        if (messages.size() == 1) {
+            return List.of(messages);
+        }
+        String firstKey = Append.routingKeyFor(messages.getFirst());
+        for (int i = 1; i < messages.size(); i++) {
+            SerializedMessage message = messages.get(i);
+            String key = Append.routingKeyFor(message);
+            if (!Objects.equals(firstKey, key)) {
+                Map<String, List<SerializedMessage>> partitions = new LinkedHashMap<>();
+                partitions.put(firstKey, new ArrayList<>(messages.subList(0, i)));
+                partitions.computeIfAbsent(key, k -> new ArrayList<>()).add(message);
+                for (int j = i + 1; j < messages.size(); j++) {
+                    SerializedMessage remaining = messages.get(j);
+                    partitions.computeIfAbsent(Append.routingKeyFor(remaining), k -> new ArrayList<>()).add(remaining);
+                }
+                return new ArrayList<>(partitions.values());
+            }
+        }
+        return List.of(messages);
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/DefaultTracking.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/DefaultTracking.java
@@ -17,6 +17,7 @@ package io.fluxzero.sdk.tracking;
 
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.Registration;
+import io.fluxzero.common.api.HasMetadata;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.handling.Handler;
 import io.fluxzero.common.handling.HandlerFilter;
@@ -26,6 +27,7 @@ import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.ClientUtils;
 import io.fluxzero.sdk.common.exception.FunctionalException;
 import io.fluxzero.sdk.common.exception.TechnicalException;
+import io.fluxzero.sdk.common.serialization.ChunkedDeserializingMessage;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.common.serialization.Serializer;
 import io.fluxzero.sdk.publishing.ResultGateway;
@@ -34,6 +36,7 @@ import io.fluxzero.sdk.tracking.handling.HandlerDecorator;
 import io.fluxzero.sdk.tracking.handling.HandlerFactory;
 import io.fluxzero.sdk.tracking.handling.Invocation;
 import io.fluxzero.sdk.tracking.handling.LocalHandler;
+import io.fluxzero.sdk.tracking.handling.authentication.User;
 import io.fluxzero.sdk.web.WebRequest;
 import lombok.AllArgsConstructor;
 import lombok.Synchronized;
@@ -56,12 +59,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static io.fluxzero.common.ObjectUtils.newWorkerPool;
 import static io.fluxzero.common.ObjectUtils.unwrapException;
 import static io.fluxzero.sdk.common.ClientUtils.getLocalHandlerAnnotation;
 import static io.fluxzero.sdk.common.ClientUtils.waitForResults;
@@ -70,6 +77,7 @@ import static io.fluxzero.sdk.web.HttpRequestMethod.WS_HANDSHAKE;
 import static io.fluxzero.sdk.web.HttpRequestMethod.WS_MESSAGE;
 import static io.fluxzero.sdk.web.HttpRequestMethod.WS_OPEN;
 import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -116,6 +124,7 @@ public class DefaultTracking implements Tracking {
 
     private final Set<ConsumerConfiguration> startedConfigurations = new HashSet<>();
     private final Collection<CompletableFuture<?>> outstandingRequests = new CopyOnWriteArrayList<>();
+    private final ExecutorService chunkedMessageExecutor = newWorkerPool("tracking-chunked-message", 8);
     private final AtomicReference<Registration> shutdownFunction = new AtomicReference<>(Registration.noOp());
 
     /**
@@ -256,21 +265,94 @@ public class DefaultTracking implements Tracking {
 
     protected Consumer<List<SerializedMessage>> createConsumer(ConsumerConfiguration config,
                                                                List<Handler<DeserializingMessage>> handlers) {
+        Map<String, ChunkedDeserializingMessage> activeChunkedMessages = new ConcurrentHashMap<>();
+        Map<String, Long> expectedChunkIndices = new ConcurrentHashMap<>();
         return serializedMessages -> {
             String topic = Tracker.current().orElseThrow().getTopic();
             try {
-                handleBatch(serializer.deserializeMessages(serializedMessages.stream(), messageType, topic))
+                handleBatch(deserializeMessages(serializedMessages, topic, activeChunkedMessages, expectedChunkIndices))
                         .forEach(m -> handlers.forEach(h -> tryHandle(m, h, config, true)));
             } catch (BatchProcessingException e) {
                 throw e;
             } catch (Throwable e) {
                 config.getErrorHandler().handleError(
                         e, format("Failed to handle batch of consumer %s", config.getName()),
-                        () -> handleBatch(
-                                serializer.deserializeMessages(serializedMessages.stream(), messageType, topic))
+                        () -> handleBatch(deserializeMessages(serializedMessages, topic, activeChunkedMessages,
+                                                              expectedChunkIndices))
                                 .forEach(m -> handlers.forEach(h -> tryHandle(m, h, config, false))));
             }
         };
+    }
+
+    protected Stream<DeserializingMessage> deserializeMessages(List<SerializedMessage> serializedMessages, String topic,
+                                                               Map<String, ChunkedDeserializingMessage> activeChunkedMessages,
+                                                               Map<String, Long> expectedChunkIndices) {
+        List<DeserializingMessage> result = new ArrayList<>();
+        for (SerializedMessage message : serializedMessages) {
+            if (!message.chunked()) {
+                result.add(serializer.deserializeMessages(Stream.of(message), messageType, topic)
+                                   .findAny().orElseThrow());
+                continue;
+            }
+            ChunkedDeserializingMessage chunkedMessage = activeChunkedMessages.get(message.getMessageId());
+            if (chunkedMessage == null) {
+                if (!message.firstChunk()) {
+                    log.warn(
+                            "Skipping chunked {} message {} at index {} because the first chunk was not observed "
+                            + "(firstChunk={}, finalChunk={}, chunkIndex={})",
+                            messageType, message.getMessageId(), message.getIndex(),
+                            message.firstChunk(), message.lastChunk(),
+                            message.getMetadata().get(HasMetadata.CHUNK_INDEX));
+                    continue;
+                }
+                chunkedMessage = new ChunkedDeserializingMessage(message, messageType, topic, serializer);
+                if (!message.lastChunk()) {
+                    activeChunkedMessages.put(message.getMessageId(), chunkedMessage);
+                    Long nextChunkIndex = nextProxyChunkIndex(message);
+                    if (nextChunkIndex != null) {
+                        expectedChunkIndices.put(message.getMessageId(), nextChunkIndex);
+                    }
+                }
+                result.add(chunkedMessage);
+            } else {
+                checkChunkSequence(message, expectedChunkIndices.get(message.getMessageId()));
+                chunkedMessage.appendChunk(message);
+                if (message.lastChunk()) {
+                    activeChunkedMessages.remove(message.getMessageId());
+                    expectedChunkIndices.remove(message.getMessageId());
+                } else {
+                    Long nextChunkIndex = nextProxyChunkIndex(message);
+                    if (nextChunkIndex != null) {
+                        expectedChunkIndices.put(message.getMessageId(), nextChunkIndex);
+                    }
+                }
+            }
+        }
+        return result.stream();
+    }
+
+    protected void checkChunkSequence(SerializedMessage message, Long expectedChunkIndex) {
+        Long actualChunkIndex = chunkIndex(message);
+        if (actualChunkIndex != null && expectedChunkIndex != null && !actualChunkIndex.equals(expectedChunkIndex)) {
+            log.warn("Observed out-of-sequence chunked {} message {}: expected chunkIndex={} but got {} "
+                     + "(firstChunk={}, finalChunk={}, index={})",
+                     messageType, message.getMessageId(), expectedChunkIndex, actualChunkIndex,
+                     message.firstChunk(), message.lastChunk(), message.getIndex());
+        }
+    }
+
+    protected Long nextProxyChunkIndex(SerializedMessage message) {
+        Long current = chunkIndex(message);
+        return current == null ? null : current + 1;
+    }
+
+    protected Long chunkIndex(SerializedMessage message) {
+        try {
+            String value = message.getMetadata().get(HasMetadata.CHUNK_INDEX);
+            return value == null ? null : Long.valueOf(value);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
     }
 
     protected void tryHandle(DeserializingMessage message, Handler<DeserializingMessage> handler,
@@ -317,15 +399,61 @@ public class DefaultTracking implements Tracking {
         }
     }
 
-    @SuppressWarnings("unchecked")
     protected Object handle(DeserializingMessage message, HandlerInvoker h, Handler<DeserializingMessage> handler,
                             ConsumerConfiguration config) {
+        if (message instanceof ChunkedDeserializingMessage) {
+            Fluxzero fluxzero = Fluxzero.getOptionally().orElse(null);
+            Tracker tracker = Tracker.current().orElse(null);
+            User user = User.getCurrent();
+            return trackOutstanding(supplyAsync(
+                    () -> withHandlerContext(message, fluxzero, tracker, user,
+                                             () -> doHandle(message, h, handler, config)),
+                    chunkedMessageExecutor));
+        }
+        return doHandle(message, h, handler, config);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Object doHandle(DeserializingMessage message, HandlerInvoker h, Handler<DeserializingMessage> handler,
+                              ConsumerConfiguration config) {
         try {
             Object result = Invocation.performInvocation(h::invoke);
-            return result instanceof CompletionStage<?> ? ((CompletionStage<Object>) result)
-                    .exceptionally(e -> message.apply(m -> processError(e, message, h, handler, config))) : result;
+            return result instanceof CompletionStage<?> ? trackOutstanding(((CompletionStage<Object>) result)
+                    .exceptionally(e -> message.apply(
+                            m -> processError(e, message, h, handler, config)))) : result;
         } catch (Throwable e) {
             return processError(e, message, h, handler, config);
+        }
+    }
+
+    protected <T> CompletionStage<T> trackOutstanding(CompletionStage<T> stage) {
+        var future = stage.toCompletableFuture();
+        outstandingRequests.add(future);
+        return future.whenComplete((r, e) -> outstandingRequests.remove(future));
+    }
+
+    protected <T> T withHandlerContext(DeserializingMessage message, Fluxzero fluxzero, Tracker tracker, User user,
+                                       Supplier<T> task) {
+        Fluxzero previousFluxzero = Fluxzero.instance.get();
+        Tracker previousTracker = Tracker.current.get();
+        User previousUser = User.getCurrent();
+        try {
+            setThreadLocal(Fluxzero.instance, fluxzero);
+            setThreadLocal(Tracker.current, tracker);
+            setThreadLocal(User.current, user);
+            return message.apply(m -> task.get());
+        } finally {
+            setThreadLocal(Fluxzero.instance, previousFluxzero);
+            setThreadLocal(Tracker.current, previousTracker);
+            setThreadLocal(User.current, previousUser);
+        }
+    }
+
+    protected <T> void setThreadLocal(ThreadLocal<T> threadLocal, T value) {
+        if (value == null) {
+            threadLocal.remove();
+        } else {
+            threadLocal.set(value);
         }
     }
 
@@ -399,6 +527,8 @@ public class DefaultTracking implements Tracking {
     @Override
     @Synchronized
     public void close() {
-        shutdownFunction.get().merge(() -> waitForResults(Duration.ofSeconds(2), outstandingRequests)).cancel();
+        shutdownFunction.get().merge(() -> waitForResults(Duration.ofSeconds(2), outstandingRequests))
+                .merge(chunkedMessageExecutor::shutdown)
+                .cancel();
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/PayloadParameterResolver.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/PayloadParameterResolver.java
@@ -18,6 +18,7 @@ package io.fluxzero.sdk.tracking.handling;
 import io.fluxzero.common.handling.ParameterResolver;
 import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.sdk.common.HasMessage;
+import io.fluxzero.sdk.common.serialization.ChunkedDeserializingMessage;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
@@ -52,6 +53,9 @@ public class PayloadParameterResolver implements ParameterResolver<HasMessage> {
 
     @Override
     public boolean test(HasMessage message, Parameter parameter) {
+        if (message instanceof ChunkedDeserializingMessage) {
+            return message.getPayloadClass() != Void.class || ReflectionUtils.isNullable(parameter);
+        }
         return message.getPayload() != null || ReflectionUtils.isNullable(parameter); //may be the case after upcasting
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestContext.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestContext.java
@@ -19,6 +19,7 @@ import io.fluxzero.common.MessageType;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.common.serialization.JsonUtils;
+import io.fluxzero.sdk.common.serialization.ChunkedDeserializingMessage;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.web.internal.WebUtilsInternal;
 import io.jooby.Body;
@@ -70,8 +71,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -212,7 +213,7 @@ public class DefaultWebRequestContext implements DefaultContext, WebRequestConte
     Formdata form = parseForm();
     @Getter(lazy = true)
     @Accessors(fluent = true)
-    Map<String, List<String>> formParameters = parseFormParameters(bodySupplier.get());
+    Map<String, List<Object>> formParameters = parseFormParameters(bodySupplier.get());
     @Getter(lazy = true)
     JsonNode jsonBody = parseJsonBody(bodySupplier.get());
 
@@ -220,7 +221,9 @@ public class DefaultWebRequestContext implements DefaultContext, WebRequestConte
         if (message.getMessageType() != MessageType.WEBREQUEST) {
             throw new IllegalArgumentException("Invalid message type: " + message.getMessageType());
         }
-        bodySupplier = () -> message.getSerializedObject().getData().getValue();
+        bodySupplier = () -> message instanceof ChunkedDeserializingMessage chunked
+                ? chunked.getAggregatedPayloadBytes()
+                : message.getSerializedObject().getData().getValue();
         metadata = message.getMetadata();
         method = WebRequest.getMethod(metadata);
     }
@@ -239,8 +242,8 @@ public class DefaultWebRequestContext implements DefaultContext, WebRequestConte
                 case HEADER -> new ParameterValue(lookup(name, ParamSource.HEADER));
                 case COOKIE -> new ParameterValue(lookup(name, ParamSource.COOKIE));
                 case FORM -> new ParameterValue(Optional.ofNullable(formParameters().get(name))
-                        .map(values -> io.jooby.value.Value.create(getValueFactory(), name, values))
-                        .orElseGet(() -> io.jooby.value.Value.missing(getValueFactory(), name)));
+                        .map(values -> values.size() == 1 ? values.getFirst() : values)
+                        .orElse(null));
                 case QUERY -> new ParameterValue(lookup(name, ParamSource.QUERY));
                 case BODY -> ReflectionUtils.readProperty(name, getJsonBody())
                         .map(ParameterValue::new).orElseGet(() -> new ParameterValue(null));
@@ -266,24 +269,65 @@ public class DefaultWebRequestContext implements DefaultContext, WebRequestConte
     Formdata parseForm() {
         Formdata result = Formdata.create(getValueFactory());
         formParameters().forEach((key, formValues) -> {
-            if (formValues.size() == 1) {
-                result.put(key, formValues.getFirst());
+            List<String> stringValues = formValues.stream().filter(String.class::isInstance).map(String.class::cast)
+                    .toList();
+            if (stringValues.isEmpty()) {
+                return;
+            }
+            if (stringValues.size() == 1) {
+                result.put(key, stringValues.getFirst());
             } else {
-                result.put(key, formValues);
+                result.put(key, stringValues);
             }
         });
         return result;
     }
 
-    Map<String, List<String>> parseFormParameters(byte[] body) {
-        String contentType = WebRequest.getHeader(metadata, "Content-Type").map(String::toLowerCase).orElse("");
-        if (!contentType.startsWith("application/x-www-form-urlencoded")) {
-            return Map.of();
+    Map<String, Object> formObject() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        formParameters().forEach((key, values) -> {
+            Object value = values.size() == 1 ? values.getFirst() : values;
+            result.put(key, value);
+            String camelCaseKey = toCamelCase(key);
+            if (!camelCaseKey.equals(key)) {
+                result.putIfAbsent(camelCaseKey, value);
+            }
+        });
+        return result;
+    }
+
+    String toCamelCase(String key) {
+        StringBuilder result = new StringBuilder(key.length());
+        boolean upperNext = false;
+        for (int i = 0; i < key.length(); i++) {
+            char c = key.charAt(i);
+            if (c == '_' || c == '-' || c == ' ') {
+                upperNext = true;
+                continue;
+            }
+            result.append(upperNext ? Character.toUpperCase(c) : c);
+            upperNext = false;
         }
+        return result.toString();
+    }
+
+    Map<String, List<Object>> parseFormParameters(byte[] body) {
+        String contentType = WebRequest.getHeader(metadata, "Content-Type").orElse("");
+        String normalizedContentType = contentType.toLowerCase();
         if (body == null || body.length == 0) {
             return Map.of();
         }
-        Map<String, List<String>> values = new LinkedHashMap<>();
+        if (normalizedContentType.startsWith("application/x-www-form-urlencoded")) {
+            return parseUrlEncodedFormParameters(body);
+        }
+        if (normalizedContentType.startsWith("multipart/form-data")) {
+            return parseMultipartFormParameters(body, contentType);
+        }
+        return Map.of();
+    }
+
+    Map<String, List<Object>> parseUrlEncodedFormParameters(byte[] body) {
+        Map<String, List<Object>> values = new LinkedHashMap<>();
         for (String pair : new String(body, StandardCharsets.UTF_8).split("&")) {
             if (pair.isEmpty()) {
                 continue;
@@ -296,6 +340,128 @@ public class DefaultWebRequestContext implements DefaultContext, WebRequestConte
             values.computeIfAbsent(key, __ -> new java.util.ArrayList<>()).add(value);
         }
         return values;
+    }
+
+    Map<String, List<Object>> parseMultipartFormParameters(byte[] body, String contentType) {
+        String boundary = extractMultipartBoundary(contentType);
+        if (boundary == null || boundary.isBlank()) {
+            return Map.of();
+        }
+        String payload = new String(body, StandardCharsets.ISO_8859_1);
+        String delimiter = "--" + boundary;
+        Map<String, List<Object>> values = new LinkedHashMap<>();
+        int boundaryStart = findMultipartBoundary(payload, delimiter, 0);
+        while (boundaryStart >= 0) {
+            int afterDelimiter = boundaryStart + delimiter.length();
+            if (payload.startsWith("--", afterDelimiter)) {
+                break;
+            }
+            if (!payload.startsWith("\r\n", afterDelimiter)) {
+                boundaryStart = findMultipartBoundary(payload, delimiter, afterDelimiter);
+                continue;
+            }
+            int partStart = afterDelimiter + 2;
+            int nextBoundary = findMultipartBoundary(payload, delimiter, partStart);
+            if (nextBoundary < 0) {
+                break;
+            }
+            String part = payload.substring(partStart, nextBoundary >= 2 ? nextBoundary - 2 : nextBoundary);
+            int separator = part.indexOf("\r\n\r\n");
+            if (separator < 0) {
+                boundaryStart = nextBoundary;
+                continue;
+            }
+            String headers = part.substring(0, separator);
+            String bodyPart = part.substring(separator + 4);
+            String name = extractMultipartFieldName(headers);
+            if (name == null) {
+                boundaryStart = nextBoundary;
+                continue;
+            }
+            String filename = extractMultipartFilename(headers);
+            byte[] bytes = bodyPart.getBytes(StandardCharsets.ISO_8859_1);
+            Object value = filename == null
+                    ? new String(bytes, extractMultipartCharset(headers))
+                    : new MultipartFormPart(name, filename, extractMultipartContentType(headers), bytes);
+            values.computeIfAbsent(name, __ -> new java.util.ArrayList<>()).add(value);
+            boundaryStart = nextBoundary;
+        }
+        return values;
+    }
+
+    int findMultipartBoundary(String payload, String delimiter, int fromIndex) {
+        int index = Math.max(0, fromIndex);
+        while (index < payload.length()) {
+            int candidate = payload.indexOf(delimiter, index);
+            if (candidate < 0) {
+                return -1;
+            }
+            boolean validStart = candidate == 0
+                                 || (candidate >= 2 && payload.charAt(candidate - 2) == '\r'
+                                     && payload.charAt(candidate - 1) == '\n');
+            int afterDelimiter = candidate + delimiter.length();
+            boolean validEnd = afterDelimiter == payload.length()
+                               || payload.startsWith("\r\n", afterDelimiter)
+                               || payload.startsWith("--", afterDelimiter);
+            if (validStart && validEnd) {
+                return candidate;
+            }
+            index = candidate + delimiter.length();
+        }
+        return -1;
+    }
+
+    String extractMultipartBoundary(String contentType) {
+        for (String part : contentType.split(";")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("boundary=")) {
+                String boundary = trimmed.substring("boundary=".length()).trim();
+                if (boundary.startsWith("\"") && boundary.endsWith("\"") && boundary.length() >= 2) {
+                    return boundary.substring(1, boundary.length() - 1);
+                }
+                return boundary;
+            }
+        }
+        return null;
+    }
+
+    String extractMultipartFieldName(String headers) {
+        return extractMultipartContentDispositionParameter(headers, "name");
+    }
+
+    String extractMultipartFilename(String headers) {
+        return extractMultipartContentDispositionParameter(headers, "filename");
+    }
+
+    String extractMultipartContentType(String headers) {
+        Matcher matcher = Pattern.compile("(?i)content-type:\\s*([^\\r\\n;]+(?:;[^\\r\\n]+)?)").matcher(headers);
+        return matcher.find() ? matcher.group(1).trim() : "application/octet-stream";
+    }
+
+    String extractMultipartContentDispositionParameter(String headers, String parameterName) {
+        return headers.lines()
+                .filter(line -> line.regionMatches(true, 0, "Content-Disposition:", 0, "Content-Disposition:".length()))
+                .findFirst()
+                .flatMap(line -> Stream.of(line.substring("Content-Disposition:".length()).split(";"))
+                        .map(String::trim)
+                        .filter(part -> part.regionMatches(true, 0, parameterName + "=", 0, parameterName.length() + 1))
+                        .map(part -> part.substring(parameterName.length() + 1).trim())
+                        .findFirst())
+                .map(value -> value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2
+                        ? value.substring(1, value.length() - 1)
+                        : value)
+                .orElse(null);
+    }
+
+    Charset extractMultipartCharset(String headers) {
+        Matcher matcher = Pattern.compile("(?i)content-type:.*charset=([A-Za-z0-9_\\-]+)").matcher(headers);
+        if (matcher.find()) {
+            try {
+                return Charset.forName(matcher.group(1));
+            } catch (RuntimeException ignored) {
+            }
+        }
+        return StandardCharsets.UTF_8;
     }
 
     /*

--- a/sdk/src/main/java/io/fluxzero/sdk/web/FormParam.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/FormParam.java
@@ -20,19 +20,34 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Injects an individual form field or a complete form object into a handler method parameter.
+ * Injects form data from {@code application/x-www-form-urlencoded} or {@code multipart/form-data}
+ * requests into a handler method parameter.
  * <p>
- * The request must use {@code application/x-www-form-urlencoded} or {@code multipart/form-data}.
+ * {@code @FormParam} can resolve:
+ * <ul>
+ *   <li>text form fields such as {@code String}, numbers, enums, or custom value objects</li>
+ *   <li>multipart file parts as {@link MultipartFormPart}, {@code byte[]}, or {@code InputStream}</li>
+ *   <li>repeated form keys as collection types such as {@code List<String>} or
+ *   {@code List<MultipartFormPart>}</li>
+ * </ul>
+ * For chunked web requests, form values are materialized only after the full request body has arrived,
+ * while the handler itself is still invoked off the tracker thread.
+ * <p>
  * Standard validation annotations may be declared directly on the injected parameter.
- * </p>
  *
- * <h2>Examples:</h2>
+ * <h2>Examples</h2>
  * <pre>{@code
  * @HandlePost("/newsletter")
  * void subscribe(@FormParam @NotBlank String email) { ... }
  *
- * @HandlePost("/user")
- * UserId createUser(@FormParam UserForm form) { ... }
+ * @HandlePost("/token")
+ * void token(@FormParam("client_id") String clientId) { ... }
+ *
+ * @HandlePost("/upload")
+ * void upload(@FormParam("document") MultipartFormPart document) { ... }
+ *
+ * @HandlePost("/upload-many")
+ * void upload(@FormParam("document") List<MultipartFormPart> documents) { ... }
  * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -41,7 +56,7 @@ import java.lang.annotation.Target;
 public @interface FormParam {
 
     /**
-     * Form parameter name. If left empty, it defaults to the method parameter's name;
+     * Form parameter name. If left empty, it defaults to the method parameter's name.
      */
     String value() default "";
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/MultipartFormPart.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/MultipartFormPart.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.fluxzero.sdk.web;
+
+import lombok.Value;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a single multipart file part resolved through {@link FormParam}.
+ * <p>
+ * Fluxzero creates this value for {@code multipart/form-data} parts that have a
+ * {@code Content-Disposition} {@code filename=} attribute. The part exposes the original field name,
+ * submitted filename, declared content type, and raw bytes.
+ * <p>
+ * This type is intended for handler parameters such as:
+ * <pre>{@code
+ * @HandlePost("/upload")
+ * void upload(@FormParam("document") MultipartFormPart document) { ... }
+ *
+ * @HandlePost("/upload-many")
+ * void upload(@FormParam("document") List<MultipartFormPart> documents) { ... }
+ * }</pre>
+ * The same multipart field can also be injected as {@code byte[]}, {@code InputStream}, or a collection
+ * of those types when more convenient for the handler.
+ */
+@Value
+public class MultipartFormPart {
+    /**
+     * The multipart form field name, for example {@code document}.
+     */
+    String name;
+
+    /**
+     * The submitted filename from the multipart {@code Content-Disposition} header.
+     */
+    String filename;
+
+    /**
+     * The declared part content type, or {@code application/octet-stream} when absent.
+     */
+    String contentType;
+
+    /**
+     * The full raw bytes of this part.
+     */
+    byte[] bytes;
+
+    /**
+     * Returns a fresh {@link InputStream} over the part bytes.
+     */
+    public InputStream asInputStream() {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    /**
+     * Decodes the part bytes as UTF-8 text.
+     */
+    public String asString() {
+        return asString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Decodes the part bytes using the given charset.
+     */
+    public String asString(Charset charset) {
+        return new String(bytes, charset);
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/web/ParameterValue.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/ParameterValue.java
@@ -14,8 +14,16 @@
 
 package io.fluxzero.sdk.web;
 
+import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.common.serialization.JsonUtils;
 import lombok.Value;
+
+import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Wrapper around a resolved parameter value in a web request.
@@ -65,26 +73,66 @@ public class ParameterValue {
      * @return the converted value or {@code null} if unavailable
      */
     public <V> V as(Class<V> type) {
+        return as((Type) type);
+    }
+
+    /**
+     * Converts the underlying value to the specified target type, including parameterized collection types.
+     */
+    @SuppressWarnings("unchecked")
+    public <V> V as(Type type) {
         Object rawValue = value;
         if (rawValue == null) {
             return null;
         }
-        if (type.isInstance(rawValue)) {
-            return type.cast(rawValue);
+        if (isSingleValueTarget(type) && rawValue instanceof List<?> list && list.size() == 1) {
+            rawValue = list.getFirst();
+        }
+        if (type instanceof Class<?> c && c.isInstance(rawValue)) {
+            return (V) c.cast(rawValue);
+        }
+        if (type instanceof ParameterizedType pt && rawValue instanceof List<?> list
+                && pt.getRawType() instanceof Class<?> rawClass && Collection.class.isAssignableFrom(rawClass)) {
+            Type elementType = ReflectionUtils.getFirstTypeArgument(type);
+            List<Object> converted = new ArrayList<>(list.size());
+            for (Object element : list) {
+                converted.add(new ParameterValue(element).as(elementType));
+            }
+            return (V) converted;
+        }
+        if (rawValue instanceof MultipartFormPart part) {
+            if (type == byte[].class) {
+                return (V) part.getBytes();
+            }
+            if (type instanceof Class<?> c && InputStream.class.isAssignableFrom(c)) {
+                return (V) c.cast(part.asInputStream());
+            }
         }
         if (rawValue instanceof io.jooby.value.Value joobyValue) {
-            V converted = joobyValue.toNullable(type);
-            if (converted != null) {
-                return converted;
+            if (type instanceof Class<?> c) {
+                Object converted = joobyValue.toNullable(c);
+                if (converted != null) {
+                    return (V) converted;
+                }
             }
             rawValue = joobyValue.valueOrNull();
             if (rawValue == null) {
                 return null;
             }
-            if (type.isInstance(rawValue)) {
-                return type.cast(rawValue);
+            if (type instanceof Class<?> c && c.isInstance(rawValue)) {
+                return (V) c.cast(rawValue);
             }
         }
         return JsonUtils.convertValue(JsonUtils.valueToTree(rawValue), type);
+    }
+
+    boolean isSingleValueTarget(Type type) {
+        if (type instanceof Class<?> c) {
+            return !Collection.class.isAssignableFrom(c);
+        }
+        if (type instanceof ParameterizedType pt && pt.getRawType() instanceof Class<?> c) {
+            return !Collection.class.isAssignableFrom(c);
+        }
+        return true;
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebParamParameterResolver.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebParamParameterResolver.java
@@ -17,8 +17,8 @@ package io.fluxzero.sdk.web;
 
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.handling.ParameterResolver;
-import io.fluxzero.common.reflection.ParameterRegistry;
 import io.fluxzero.common.reflection.ReflectionUtils;
+import io.fluxzero.common.reflection.ParameterRegistry;
 import io.fluxzero.sdk.common.HasMessage;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import lombok.AllArgsConstructor;
@@ -91,7 +91,7 @@ public class WebParamParameterResolver implements ParameterResolver<HasMessage> 
                             name = value;
                         }
                         return context.getParameter(name, f.getType());
-                    }).map(v -> v.as(p.getType())).orElse(null);
+                    }).map(v -> v.as(p.getParameterizedType())).orElse(null);
         };
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebPayloadParameterResolver.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebPayloadParameterResolver.java
@@ -17,13 +17,21 @@ package io.fluxzero.sdk.web;
 
 import io.fluxzero.common.handling.ParameterResolver;
 import io.fluxzero.common.reflection.ReflectionUtils;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.common.serialization.JsonUtils;
 import io.fluxzero.sdk.common.HasMessage;
+import io.fluxzero.sdk.common.serialization.ChunkedDeserializingMessage;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.tracking.handling.authentication.User;
 import lombok.AllArgsConstructor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.Function;
 
 import static io.fluxzero.sdk.tracking.handling.validation.ValidationUtils.assertAuthorized;
@@ -60,7 +68,8 @@ public class WebPayloadParameterResolver implements ParameterResolver<HasMessage
     @Override
     public Function<HasMessage, Object> resolve(Parameter p, Annotation methodAnnotation) {
         return m -> {
-            Object payload = m.getPayloadAs(p.getType());
+            optimizeForStreamingHandler(m, p);
+            Object payload = resolvePayload(m, p, p.getParameterizedType());
             if (payload != null) {
                 if (validatePayload) {
                     assertValid(payload);
@@ -75,8 +84,11 @@ public class WebPayloadParameterResolver implements ParameterResolver<HasMessage
 
     @Override
     public boolean test(HasMessage m, Parameter p) {
+        if (m instanceof ChunkedDeserializingMessage) {
+            return !authoriseUser || !ignoreSilently(p.getType(), User.getCurrent());
+        }
         if (authoriseUser) {
-            Object payload = m.getPayloadAs(p.getType());
+            Object payload = resolvePayload(m, p, p.getParameterizedType());
             if (payload != null && ignoreSilently(payload.getClass(), User.getCurrent())) {
                 return false;
             }
@@ -101,5 +113,66 @@ public class WebPayloadParameterResolver implements ParameterResolver<HasMessage
     @Override
     public boolean mayApply(Executable method, Class<?> targetClass) {
         return ReflectionUtils.isMethodAnnotationPresent(method, HandleWeb.class);
+    }
+
+    protected void optimizeForStreamingHandler(HasMessage message, Parameter parameter) {
+        if (message instanceof ChunkedDeserializingMessage chunked
+            && chunked.getMessageType() == io.fluxzero.common.MessageType.WEBREQUEST
+            && isStreamingOnlyWebHandler(parameter.getDeclaringExecutable())) {
+            chunked.enableStreamingOnlyMode();
+        }
+    }
+
+    Object resolvePayload(HasMessage message, Parameter parameter, Type type) {
+        if (message instanceof DeserializingMessage m && shouldBindFormPayload(m, parameter)) {
+            return DefaultWebRequestContext.getWebRequestContext(m).formObject()
+                    .isEmpty() ? null : JsonUtils.convertValue(DefaultWebRequestContext.getWebRequestContext(m).formObject(), type);
+        }
+        return message.getPayloadAs(type);
+    }
+
+    boolean shouldBindFormPayload(DeserializingMessage message, Parameter parameter) {
+        String contentType = WebRequest.getHeader(message.getMetadata(), "Content-Type").orElse(null);
+        Class<?> type = parameter.getType();
+        return WebUtils.isFormContentType(contentType)
+               && !type.isPrimitive()
+               && !type.isArray()
+               && !type.isEnum()
+               && !String.class.isAssignableFrom(type)
+               && !Number.class.isAssignableFrom(type)
+               && !Boolean.class.isAssignableFrom(type)
+               && !Character.class.isAssignableFrom(type)
+               && !Collection.class.isAssignableFrom(type)
+               && !java.io.InputStream.class.isAssignableFrom(type)
+               && !MultipartFormPart.class.isAssignableFrom(type)
+               && !type.getPackageName().startsWith("java.");
+    }
+
+    protected boolean isStreamingOnlyWebHandler(Executable method) {
+        boolean hasInputStream = false;
+        for (Parameter parameter : method.getParameters()) {
+            if (java.io.InputStream.class.isAssignableFrom(parameter.getType())) {
+                hasInputStream = true;
+                continue;
+            }
+            if (WebRequest.class.isAssignableFrom(parameter.getType())
+                || WebResponse.class.isAssignableFrom(parameter.getType())
+                || DeserializingMessage.class.isAssignableFrom(parameter.getType())
+                || SerializedMessage.class.isAssignableFrom(parameter.getType())
+                || User.class.isAssignableFrom(parameter.getType())
+                || Instant.class.isAssignableFrom(parameter.getType())) {
+                continue;
+            }
+            Annotation webParam = Arrays.stream(parameter.getAnnotations())
+                    .filter(a -> ReflectionUtils.isOrHas(a.annotationType(), WebParam.class))
+                    .findFirst().orElse(null);
+            if (webParam != null
+                && !ReflectionUtils.isOrHas(webParam.annotationType(), BodyParam.class)
+                && !ReflectionUtils.isOrHas(webParam.annotationType(), FormParam.class)) {
+                continue;
+            }
+            return false;
+        }
+        return hasInputStream;
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebResponseGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebResponseGateway.java
@@ -53,7 +53,7 @@ import static io.fluxzero.common.MessageType.WEBRESPONSE;
 @AllArgsConstructor
 public class WebResponseGateway extends AbstractNamespaced<ResultGateway> implements ResultGateway {
 
-    public static final int MAX_RESPONSE_SIZE = 2 * 1024 * 1024;
+    public static final int MAX_RESPONSE_SIZE = WebUtils.DEFAULT_CHUNK_SIZE;
 
     @With
     private final Client client;
@@ -104,11 +104,17 @@ public class WebResponseGateway extends AbstractNamespaced<ResultGateway> implem
                                                    Function<SerializedMessage, CompletableFuture<Void>> dispatcher) {
         if (response.getPayload() instanceof InputStream inputStream) {
             List<CompletableFuture<Void>> futures = new ArrayList<>();
+            var firstChunk = new boolean[]{true};
+            var chunkIndex = new long[]{0};
             try (OutputStreamCapturer capturer = new OutputStreamCapturer(MAX_RESPONSE_SIZE, (chunk, last) -> {
-                Metadata metadata = response.getMetadata().with(HasMetadata.FINAL_CHUNK, last.toString());
+                Metadata metadata = response.getMetadata()
+                        .with(HasMetadata.CHUNK_INDEX, Long.toString(chunkIndex[0]++))
+                        .with(HasMetadata.FINAL_CHUNK, last.toString())
+                        .with(HasMetadata.FIRST_CHUNK, Boolean.toString(firstChunk[0]));
                 SerializedMessage message = new SerializedMessage(new Data<>(chunk, null, 0),
                                                                   metadata, response.getMessageId(),
                                                                   response.getTimestamp().toEpochMilli());
+                firstChunk[0] = false;
                 futures.add(dispatcher.apply(message));
             })) {
                 try (inputStream) {

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebUtils.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import io.fluxzero.sdk.configuration.ApplicationProperties;
 import jakarta.annotation.Nullable;
 import lombok.NonNull;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Type;
@@ -44,8 +46,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static io.fluxzero.common.api.Data.JSON_FORMAT;
 import static io.fluxzero.common.ObjectUtils.concat;
+import static io.fluxzero.common.api.Data.JSON_FORMAT;
 import static io.fluxzero.common.reflection.ReflectionUtils.getAnnotatedProperty;
 import static io.fluxzero.common.reflection.ReflectionUtils.getAnnotatedPropertyValue;
 import static io.fluxzero.common.reflection.ReflectionUtils.getAnnotation;
@@ -59,6 +61,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  * of {@link WebPattern} annotations on handler methods annotated with {@link HandleWeb}.
  */
 public class WebUtils {
+    /**
+     * Default chunk size, in bytes, used when splitting streamed web request and response payloads.
+     * <p>
+     * The current default is 2 MiB and is shared by the proxy upload path and chunked web responses.
+     */
+    public static final int DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024;
+
     private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z\\d+\\-.]*://.*");
     private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{([^/}]+)}");
 
@@ -261,6 +270,10 @@ public class WebUtils {
             return (R) (payload instanceof byte[] bytes ? bytes
                     : payload instanceof String s ? s.getBytes(StandardCharsets.UTF_8) : JsonUtils.asBytes(payload));
         }
+        if (type instanceof Class<?> c && InputStream.class.isAssignableFrom(c)) {
+            return (R) new ByteArrayInputStream(payload instanceof byte[] bytes ? bytes
+                    : payload instanceof String s ? s.getBytes(StandardCharsets.UTF_8) : JsonUtils.asBytes(payload));
+        }
         return isJsonContentType(contentType) && (payload instanceof byte[] || payload instanceof String)
                 ? payload instanceof byte[] bytes ? JsonUtils.fromJson(bytes, type) : JsonUtils.fromJson((String) payload, type)
                 : JsonUtils.convertValue(payload, type);
@@ -286,6 +299,23 @@ public class WebUtils {
         }
         normalized = normalized.trim();
         return JSON_FORMAT.equals(normalized) || normalized.endsWith("+json");
+    }
+
+    /**
+     * Checks whether a content type denotes HTML form data.
+     */
+    public static boolean isFormContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        String normalized = contentType.toLowerCase(Locale.ROOT);
+        int separatorIndex = normalized.indexOf(';');
+        if (separatorIndex >= 0) {
+            normalized = normalized.substring(0, separatorIndex);
+        }
+        normalized = normalized.trim();
+        return "application/x-www-form-urlencoded".equals(normalized)
+               || "multipart/form-data".equals(normalized);
     }
 
     /**

--- a/sdk/src/test/java/io/fluxzero/sdk/publishing/client/WebsocketGatewayClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/publishing/client/WebsocketGatewayClientTest.java
@@ -1,0 +1,42 @@
+package io.fluxzero.sdk.publishing.client;
+
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WebsocketGatewayClientTest {
+
+    @Test
+    void partitionByRoutingKeyKeepsMessagesWithSameSegmentTogether() {
+        SerializedMessage first = message("a", 3);
+        SerializedMessage second = message("b", 7);
+        SerializedMessage third = message("c", 3);
+
+        List<List<SerializedMessage>> partitions = WebsocketGatewayClient.partitionByRoutingKey(
+                List.of(first, second, third));
+
+        assertEquals(List.of(List.of(first, third), List.of(second)), partitions);
+    }
+
+    @Test
+    void partitionByRoutingKeyFallsBackToMessageId() {
+        SerializedMessage first = message("a", null);
+        SerializedMessage second = message("b", null);
+
+        List<List<SerializedMessage>> partitions = WebsocketGatewayClient.partitionByRoutingKey(List.of(first, second));
+
+        assertEquals(List.of(List.of(first), List.of(second)), partitions);
+    }
+
+    private static SerializedMessage message(String messageId, Integer segment) {
+        SerializedMessage message = new SerializedMessage(new Data<>(new byte[]{1}, byte[].class.getName(), 0,
+                                                                    Data.JSON_FORMAT), Metadata.empty(), messageId, 1L);
+        message.setSegment(segment);
+        return message;
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/test/ResultValidator.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/ResultValidator.java
@@ -14,6 +14,7 @@
 
 package io.fluxzero.sdk.test;
 
+import io.fluxzero.common.ThrowingConsumer;
 import io.fluxzero.common.ThrowingFunction;
 import io.fluxzero.common.ThrowingPredicate;
 import io.fluxzero.common.reflection.ReflectionUtils;
@@ -29,7 +30,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.hamcrest.Matcher;
 
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -453,7 +453,7 @@ public class ResultValidator<R> implements Then<R> {
     }
 
     @Override
-    public ResultValidator<R> expectThat(Consumer<Fluxzero> check) {
+    public ResultValidator<R> expectThat(ThrowingConsumer<Fluxzero> check) {
         return fluxzero.apply(fc -> {
             try {
                 check.accept(fc);

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
@@ -1460,6 +1460,11 @@ public class TestFixture implements Given<TestFixture>, When {
                             .map(DeserializingMessage::toMessage)
                             .forEach(m -> monitorDispatch(m, messageType, topic, namespace));
                 } catch (Exception ignored) {
+                    if (messages.stream().allMatch(SerializedMessage::chunked)) {
+                        // Chunked messages may be published as partial serialized frames that are only meaningful once
+                        // the consumer-side tracker stitches them back together.
+                        return;
+                    }
                     log.warn("Failed to intercept a published message. This may cause your test to fail.");
                 }
             }

--- a/sdk/src/test/java/io/fluxzero/sdk/test/Then.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/Then.java
@@ -30,7 +30,6 @@ import lombok.SneakyThrows;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import static io.fluxzero.common.ObjectUtils.run;
@@ -993,7 +992,7 @@ public interface Then<R> {
      *
      * @param check a consumer that performs assertions using the Fluxzero instance
      */
-    Then<R> expectThat(Consumer<Fluxzero> check);
+    Then<R> expectThat(ThrowingConsumer<Fluxzero> check);
 
     /**
      * Asserts that the provided {@link Predicate} evaluates to {@code true} when applied to the current Fluxzero

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/ChunkedMessageTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/ChunkedMessageTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.sdk.tracking;
+
+import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.HasMetadata;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.test.TestFixture;
+import io.fluxzero.sdk.tracking.handling.HandleEvent;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ChunkedMessageTest {
+
+    @Test
+    void streamChunkedEventPayloadIntoInputStreamHandler() {
+        CompletableFuture<String> handled = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(DeserializingMessage message) throws Exception {
+                InputStream stream = message.getPayloadAs(InputStream.class);
+                handled.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            SerializedMessage firstChunk = new SerializedMessage(
+                    new Data<>("hello ".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "false", HasMetadata.FIRST_CHUNK, "true"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            firstChunk.setSegment(0);
+            SerializedMessage secondChunk = new SerializedMessage(
+                    new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    firstChunk.getMessageId(), now + 1);
+            secondChunk.setSegment(firstChunk.getSegment());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, firstChunk).get();
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, secondChunk).get();
+        }).expectThat(fz -> assertEquals("hello world", handled.get(1, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    void startsHandlingChunkedEventOnFirstChunk() throws Exception {
+        CompletableFuture<String> firstBytesRead = new CompletableFuture<>();
+        CompletableFuture<String> completed = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(DeserializingMessage message) throws Exception {
+                InputStream stream = message.getPayloadAs(InputStream.class);
+                byte[] firstPart = stream.readNBytes(6);
+                firstBytesRead.complete(new String(firstPart, StandardCharsets.UTF_8));
+                completed.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            SerializedMessage firstChunk = new SerializedMessage(
+                    new Data<>("hello ".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "false", HasMetadata.FIRST_CHUNK, "true"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            firstChunk.setSegment(0);
+            SerializedMessage secondChunk = new SerializedMessage(
+                    new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    firstChunk.getMessageId(), now + 1);
+            secondChunk.setSegment(firstChunk.getSegment());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, firstChunk).get();
+            assertEquals("hello ", firstBytesRead.get(1, TimeUnit.SECONDS));
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, secondChunk).get();
+        }).expectThat(fz -> assertEquals("world", completed.get(1, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    void skipsChunkWhenFirstChunkWasNotObserved() {
+        CompletableFuture<String> handled = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(DeserializingMessage message) throws Exception {
+                InputStream stream = message.getPayloadAs(InputStream.class);
+                handled.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            SerializedMessage orphanChunk = new SerializedMessage(
+                    new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            orphanChunk.setSegment(0);
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, orphanChunk).get();
+        }).expectThat(fz -> assertNull(handled.completeOnTimeout(null, 200, TimeUnit.MILLISECONDS).join()));
+    }
+
+    @Test
+    void deserializesChunkedJsonPayloadIntoSingleObjectAfterFinalChunk() {
+        LargePayload expected = new LargePayload("hello world", 42);
+        CompletableFuture<LargePayload> handled = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(DeserializingMessage message) {
+                handled.complete(message.getPayloadAs(LargePayload.class));
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            Data<byte[]> serialized = fc.serializer().serialize(expected);
+            int split = serialized.getValue().length / 2;
+            SerializedMessage firstChunk = new SerializedMessage(
+                    new Data<>(Arrays.copyOfRange(serialized.getValue(), 0, split),
+                               serialized.getType(), serialized.getRevision(), serialized.getFormat()),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "false", HasMetadata.FIRST_CHUNK, "true"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            firstChunk.setSegment(0);
+            SerializedMessage secondChunk = new SerializedMessage(
+                    new Data<>(Arrays.copyOfRange(serialized.getValue(), split, serialized.getValue().length),
+                               serialized.getType(), serialized.getRevision(), serialized.getFormat()),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    firstChunk.getMessageId(), now + 1);
+            secondChunk.setSegment(firstChunk.getSegment());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, firstChunk).get();
+            assertFalse(handled.isDone());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, secondChunk).get();
+        }).expectThat(fz -> assertEquals(expected, handled.get(1, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    void handlesChunkedJsonPayloadAsTypedHandlerParameter() {
+        LargePayload expected = new LargePayload("hello world", 42);
+        CompletableFuture<LargePayload> handled = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(LargePayload payload) {
+                handled.complete(payload);
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            Data<byte[]> serialized = fc.serializer().serialize(expected);
+            int split = serialized.getValue().length / 2;
+            SerializedMessage firstChunk = new SerializedMessage(
+                    new Data<>(Arrays.copyOfRange(serialized.getValue(), 0, split),
+                               serialized.getType(), serialized.getRevision(), serialized.getFormat()),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "false", HasMetadata.FIRST_CHUNK, "true"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            firstChunk.setSegment(0);
+            SerializedMessage secondChunk = new SerializedMessage(
+                    new Data<>(Arrays.copyOfRange(serialized.getValue(), split, serialized.getValue().length),
+                               serialized.getType(), serialized.getRevision(), serialized.getFormat()),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    firstChunk.getMessageId(), now + 1);
+            secondChunk.setSegment(firstChunk.getSegment());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, firstChunk).get();
+            assertFalse(handled.isDone());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, secondChunk).get();
+        }).expectThat(fz -> assertEquals(expected, handled.get(1, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    void keepsThreadLocalContextForAsyncChunkedHandlers() {
+        CompletableFuture<Boolean> trackerPresent = new CompletableFuture<>();
+        CompletableFuture<Boolean> fluxzeroPresent = new CompletableFuture<>();
+        CompletableFuture<Boolean> currentMessagePresent = new CompletableFuture<>();
+        TestFixture.createAsync(new Object() {
+            @HandleEvent
+            void handle(DeserializingMessage message) throws Exception {
+                InputStream stream = message.getPayloadAs(InputStream.class);
+                trackerPresent.complete(Tracker.current().isPresent());
+                fluxzeroPresent.complete(Fluxzero.getOptionally().isPresent());
+                currentMessagePresent.complete(DeserializingMessage.getCurrent() == message);
+                stream.readAllBytes();
+            }
+        }).whenExecuting(fc -> {
+            long now = System.currentTimeMillis();
+            SerializedMessage firstChunk = new SerializedMessage(
+                    new Data<>("hello ".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "false", HasMetadata.FIRST_CHUNK, "true"),
+                    fc.identityProvider().nextTechnicalId(), now);
+            firstChunk.setSegment(0);
+            SerializedMessage secondChunk = new SerializedMessage(
+                    new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0, null),
+                    Metadata.of(HasMetadata.FINAL_CHUNK, "true", HasMetadata.FIRST_CHUNK, "false"),
+                    firstChunk.getMessageId(), now + 1);
+            secondChunk.setSegment(firstChunk.getSegment());
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, firstChunk).get();
+            fc.client().getGatewayClient(MessageType.EVENT).append(Guarantee.SENT, secondChunk).get();
+        }).expectThat(fz -> {
+            assertEquals(true, trackerPresent.get(1, TimeUnit.SECONDS));
+            assertEquals(true, fluxzeroPresent.get(1, TimeUnit.SECONDS));
+            assertEquals(true, currentMessagePresent.get(1, TimeUnit.SECONDS));
+        });
+    }
+
+    private record LargePayload(String value, int count) {
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,13 @@ package io.fluxzero.sdk.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import io.fluxzero.common.ConsistentHashing;
 import io.fluxzero.common.FileUtils;
+import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.ThrowingPredicate;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.HasMetadata;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.serialization.JsonUtils;
@@ -27,6 +31,7 @@ import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.MockException;
 import io.fluxzero.sdk.configuration.DefaultFluxzero;
 import io.fluxzero.sdk.persisting.search.Searchable;
+import io.fluxzero.sdk.publishing.DefaultRequestHandler;
 import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.tracking.handling.Association;
 import io.fluxzero.sdk.tracking.handling.HandleEvent;
@@ -58,9 +63,16 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.fluxzero.sdk.web.HttpRequestMethod.GET;
 import static io.fluxzero.sdk.web.HttpRequestMethod.POST;
@@ -71,6 +83,10 @@ import static io.fluxzero.sdk.web.HttpRequestMethod.WS_HANDSHAKE;
 import static io.fluxzero.sdk.web.HttpRequestMethod.WS_MESSAGE;
 import static io.fluxzero.sdk.web.HttpRequestMethod.WS_OPEN;
 import static io.fluxzero.sdk.web.HttpRequestMethod.WS_PONG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
@@ -99,6 +115,40 @@ public class HandleWebTest {
         @Test
         void testGet_disabled() {
             testFixture.whenGet("/disabled").expectExceptionalResult(TimeoutException.class);
+        }
+
+        @Test
+        void testChunkedResponseAddsChunkIndexes() {
+            byte[] payload = new byte[WebResponseGateway.MAX_RESPONSE_SIZE + 123];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i % 251);
+            }
+            TestFixture asyncFixture = TestFixture.createAsync().resultTimeout(Duration.ofSeconds(1))
+                    .consumerTimeout(Duration.ofSeconds(1));
+            List<SerializedMessage> observed = new ArrayList<>();
+            var registration = asyncFixture.getFluxzero().client().getGatewayClient(MessageType.WEBRESPONSE)
+                    .registerMonitor(observed::addAll);
+            try {
+                asyncFixture.registerHandlers(new Object() {
+                            @HandleGet("/chunkedResponse")
+                            WebResponse chunkedResponse() {
+                                return WebResponse.ok(() -> new java.io.ByteArrayInputStream(payload),
+                                                      Map.of("Content-Type", "application/octet-stream"));
+                            }
+                        })
+                        .whenGet("/chunkedResponse")
+                        .expectThat(fc -> {
+                            assertEquals(2, observed.size());
+                            assertEquals("0", observed.get(0).getMetadata().get(HasMetadata.CHUNK_INDEX));
+                            assertEquals("1", observed.get(1).getMetadata().get(HasMetadata.CHUNK_INDEX));
+                            assertEquals("true", observed.get(0).getMetadata().get(HasMetadata.FIRST_CHUNK));
+                            assertEquals("false", observed.get(0).getMetadata().get(HasMetadata.FINAL_CHUNK));
+                            assertEquals("false", observed.get(1).getMetadata().get(HasMetadata.FIRST_CHUNK));
+                            assertEquals("true", observed.get(1).getMetadata().get(HasMetadata.FINAL_CHUNK));
+                        });
+            } finally {
+                registration.cancel();
+            }
         }
 
         @Test
@@ -277,6 +327,102 @@ public class HandleWebTest {
 
         }
 
+        @Test
+        void testPostChunkedOctetStreamAsInputStream() {
+            TestFixture.createAsync(new Handler()).whenApplying(fc -> {
+                WebRequest request = WebRequest.builder().method(POST).url("/stream").payload(new byte[0])
+                        .header("Content-Type", "application/octet-stream").build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>("hello ".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-web-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    Thread.sleep(100);
+                    assertFalse(responseFuture.isDone());
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    assertNotNull(firstChunk.getSegment());
+                    assertEquals(firstChunk.getRequestId(), secondChunk.getRequestId());
+                    assertEquals(firstChunk.getSource(), secondChunk.getSource());
+                    assertEquals(firstChunk.getMessageId(), secondChunk.getMessageId());
+                    assertEquals(firstChunk.getSegment(), secondChunk.getSegment());
+                    WebResponse response = (WebResponse) fc.serializer()
+                            .deserializeMessage(responseFuture.get(), MessageType.WEBRESPONSE).toMessage();
+                    assertEquals("hello world", response.getPayloadAs(String.class));
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
+        @Test
+        void testPostChunkedOctetStreamStartsStreamHandlerWithWebRequestInjection() {
+            CountDownLatch handlerStarted = new CountDownLatch(1);
+            AtomicBoolean headerSeen = new AtomicBoolean();
+            TestFixture.createAsync(new Object() {
+                @HandlePost("/stream/request")
+                String stream(InputStream payload, WebRequest request) throws Exception {
+                    headerSeen.set("application/octet-stream".equals(request.getHeader("Content-Type")));
+                    handlerStarted.countDown();
+                    return request.getMethod() + ":" + new String(payload.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            }).whenApplying(fc -> {
+                WebRequest request = WebRequest.builder().method(POST).url("/stream/request").payload(new byte[0])
+                        .header("Content-Type", "application/octet-stream").build();
+                SerializedMessage firstChunk = new SerializedMessage(
+                        new Data<>("hello ".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                SerializedMessage secondChunk = new SerializedMessage(
+                        new Data<>("world".getBytes(StandardCharsets.UTF_8), byte[].class.getName(), 0,
+                                   "application/octet-stream"),
+                        request.getMetadata().with(HasMetadata.FINAL_CHUNK, "true").with(HasMetadata.FIRST_CHUNK,
+                                                                                           "false"),
+                        request.getMessageId(), request.getTimestamp().toEpochMilli());
+                try (DefaultRequestHandler requestHandler = new DefaultRequestHandler(fc.client(), MessageType.WEBRESPONSE,
+                                                                                      Duration.ofSeconds(5),
+                                                                                      "chunked-web-request-injection-test")) {
+                    firstChunk.setSegment(ConsistentHashing.computeSegment(firstChunk.getMessageId()));
+                    AtomicReference<CompletableFuture<Void>> firstDispatch =
+                            new AtomicReference<>(CompletableFuture.completedFuture(null));
+                    CompletableFuture<SerializedMessage> responseFuture = requestHandler.sendRequest(
+                            firstChunk, message -> firstDispatch.set(fc.client().getGatewayClient(MessageType.WEBREQUEST)
+                                    .append(Guarantee.SENT, message)), Duration.ofSeconds(5), null);
+                    firstDispatch.get().get();
+                    assertTrue(handlerStarted.await(250, TimeUnit.MILLISECONDS),
+                               "Chunked stream handler should start after the first chunk");
+                    assertTrue(headerSeen.get(), "Injected WebRequest should expose request headers");
+                    assertFalse(responseFuture.isDone());
+                    secondChunk.setRequestId(firstChunk.getRequestId());
+                    secondChunk.setSource(firstChunk.getSource());
+                    secondChunk.setSegment(firstChunk.getSegment());
+                    fc.client().getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.SENT, secondChunk).get();
+                    WebResponse response = (WebResponse) fc.serializer()
+                            .deserializeMessage(responseFuture.get(), MessageType.WEBRESPONSE).toMessage();
+                    assertEquals("POST:hello world", response.getPayloadAs(String.class));
+                }
+                return null;
+            }).expectNoErrors();
+        }
+
         private class Handler {
             @Path("/getViaPath")
             @HandleWeb(method = GET)
@@ -354,6 +500,11 @@ public class HandleWebTest {
             @HandleWeb(value = "/json", method = POST)
             Object post(JsonNode body) {
                 return body;
+            }
+
+            @HandlePost("/stream")
+            String post(InputStream stream) throws Exception {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             }
         }
     }

--- a/test-server/src/main/java/io/fluxzero/testserver/websocket/WebsocketEndpoint.java
+++ b/test-server/src/main/java/io/fluxzero/testserver/websocket/WebsocketEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package io.fluxzero.testserver.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.fluxzero.common.Backlog;
+import io.fluxzero.common.ConsistentHashing;
+import io.fluxzero.common.DirectExecutorService;
 import io.fluxzero.common.api.BooleanResult;
 import io.fluxzero.common.api.Command;
 import io.fluxzero.common.api.ConnectEvent;
@@ -38,7 +40,6 @@ import io.fluxzero.common.serialization.NullCollectionsAsEmptyModule;
 import io.fluxzero.common.serialization.compression.CompressionAlgorithm;
 import io.fluxzero.testserver.metrics.MetricsLog;
 import io.fluxzero.testserver.metrics.NoOpMetricsLog;
-import io.undertow.util.SameThreadExecutor;
 import jakarta.annotation.Nullable;
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.Endpoint;
@@ -62,19 +63,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static io.fluxzero.common.Guarantee.STORED;
+import static io.fluxzero.common.ObjectUtils.newPlatformThreadFactory;
 import static io.fluxzero.common.ObjectUtils.newWorkerPool;
 import static io.fluxzero.common.serialization.compression.CompressionUtils.compress;
 import static io.fluxzero.common.serialization.compression.CompressionUtils.decompress;
@@ -85,6 +89,7 @@ import static java.lang.String.format;
 
 @Slf4j
 public abstract class WebsocketEndpoint extends Endpoint {
+    private static final int DEFAULT_COMMAND_REQUEST_STRIPES = 16;
 
     private static final ObjectMapper defaultObjectMapper = JsonMapper.builder()
             .findAndAddModules().disable(WRITE_DATES_AS_TIMESTAMPS)
@@ -98,25 +103,26 @@ public abstract class WebsocketEndpoint extends Endpoint {
 
     @Getter(AccessLevel.PROTECTED)
     private final ObjectMapper objectMapper;
-    private final Executor requestExecutor;
-    private final ExecutorService ownedRequestExecutor;
+    private final ExecutorService queryExecutor;
+    private final ExecutorService[] commandExecutors;
 
     private final Map<String, SessionBacklog> sessionBacklogs = new ConcurrentHashMap<>();
+    private final Set<String> activeSessionIds = ConcurrentHashMap.newKeySet();
     protected final AtomicBoolean shuttingDown = new AtomicBoolean();
     protected volatile boolean shutDown;
 
     protected WebsocketEndpoint() {
         this.objectMapper = defaultObjectMapper;
-        this.ownedRequestExecutor = newWorkerPool(getClass().getSimpleName(), 64);
-        this.requestExecutor = ownedRequestExecutor;
+        this.queryExecutor = newWorkerPool(getClass().getSimpleName(), 64);
+        this.commandExecutors = newRequestStripeExecutors(DEFAULT_COMMAND_REQUEST_STRIPES);
         getRuntime().addShutdownHook(
                 Thread.ofPlatform().name(getClass().getSimpleName() + "-shutdown").unstarted(this::shutDown));
     }
 
-    protected WebsocketEndpoint(@Nullable Executor requestExecutor) {
+    protected WebsocketEndpoint(@Nullable ExecutorService queryExecutor) {
         this.objectMapper = defaultObjectMapper;
-        this.ownedRequestExecutor = null;
-        this.requestExecutor = Optional.ofNullable(requestExecutor).orElse(SameThreadExecutor.INSTANCE);
+        this.queryExecutor = Optional.ofNullable(queryExecutor).orElseGet(DirectExecutorService::newInstance);
+        this.commandExecutors = newRequestStripeExecutors(DEFAULT_COMMAND_REQUEST_STRIPES);
         getRuntime().addShutdownHook(
                 Thread.ofPlatform().name(getClass().getSimpleName() + "-shutdown").unstarted(this::shutDown));
     }
@@ -147,77 +153,96 @@ public abstract class WebsocketEndpoint extends Endpoint {
         if (shuttingDown.get()) {
             throw new IllegalStateException("Cannot accept client. Endpoint is shutting down");
         }
+        activeSessionIds.add(session.getId());
         sessionBacklogs.put(session.getId(), new SessionBacklog(
                 Backlog.forConsumer(results -> sendResultBatch(session, results)), session));
 
         session.addMessageHandler(byte[].class, bytes -> {
-            Runnable task = () -> {
-                try {
-                    JsonType request = deserializeRequest(session, bytes);
-                    if (shutDown) {
-                        throw new IllegalStateException(
-                                format("Rejecting request %s from client %s with id %s because the service is shutting down",
-                                       request, getClientName(session), getClientId(session)));
-                    }
-                    if (shuttingDown.get()) {
-                        log.info(
-                                "Silently ignoring request {} from client {} with id {} because the service is shutting down",
-                                request, getClientName(session), getClientId(session));
-                        return;
-                    }
-                    handleMessage(session, request);
-                } catch (Throwable e) {
-                    log.error("Failed to handle request", e);
-                }
-            };
-            requestExecutor.execute(task);
+            try {
+                dispatchRequest(session, deserializeRequest(session, bytes));
+            } catch (Throwable e) {
+                log.error("Failed to handle request", e);
+            }
         });
         registerMetrics(new ConnectEvent(getClientName(session), getClientId(session), session.getId(), toString()),
                         session);
     }
 
-    @SneakyThrows
-    protected JsonType deserializeRequest(Session session, byte[] bytes) {
-        return objectMapper.readValue(decompress(bytes, getCompressionAlgorithm(session)), JsonType.class);
+    protected void dispatchRequest(Session session, JsonType request) {
+        if (request instanceof RequestBatch<?> batch) {
+            batch.getRequests().forEach(r -> dispatchRequest(session, r));
+        } else {
+            submitRequestTask(session, request, () -> processRequest(session, request));
+        }
+    }
+
+    protected void submitRequestTask(Session session, @Nullable JsonType request, Runnable task) {
+        if (!activeSessionIds.contains(session.getId())) {
+            log.info("Ignoring request for closed websocket session {}", session.getId());
+        } else {
+            try {
+                executorFor(request).execute(task);
+            } catch (RejectedExecutionException ignored) {
+            }
+        }
+    }
+
+    private Executor executorFor(@Nullable JsonType request) {
+        return request instanceof Command command && command.routingKey() != null
+                ? commandExecutors[ConsistentHashing.computeSegment(command.routingKey(),
+                                                                    commandExecutors.length)]
+                : queryExecutor;
+    }
+
+    private void processRequest(Session session, JsonType request) {
+        try {
+            if (shutDown) {
+                throw new IllegalStateException(
+                        format("Rejecting request %s from client %s with id %s because the service is shutting down",
+                               request, getClientName(session), getClientId(session)));
+            }
+            if (shuttingDown.get()) {
+                log.info(
+                        "Silently ignoring request {} from client {} with id {} because the service is shutting down",
+                        request, getClientName(session), getClientId(session));
+                return;
+            }
+            handleMessage(session, request);
+        } catch (Throwable e) {
+            log.error("Failed to handle request", e);
+        }
     }
 
     protected void handleMessage(Session session, JsonType message) {
-        if (message instanceof RequestBatch<?> batch) {
-            createTasks(batch, session).forEach(requestExecutor::execute);
-        } else {
-            try {
-                Object result = handler.getInvoker(new ClientMessage(message, session)).orElseThrow().invoke();
-                trySendResult(session, message, result);
-            } catch (Throwable e) {
-                log.error("Could not handle request {}", message, e);
-            }
+        try {
+            Object result = handler.getInvoker(new ClientMessage(message, session)).orElseThrow().invoke();
+            trySendResult(session, message, result);
+        } catch (Throwable e) {
+            log.error("Could not handle request {}", message, e);
         }
     }
 
     private void trySendResult(Session session, JsonType message, Object result) {
         if (message instanceof Request request && (!(request instanceof Command command)
                                                    || command.getGuarantee().compareTo(STORED) >= 0)) {
-            if (result instanceof RequestResult response) {
-                doSendResult(session, response);
-            } else if (result == null) {
-                if (request instanceof Command) {
-                    doSendResult(session, new VoidResult(request.getRequestId()));
+            switch (result) {
+                case RequestResult response -> doSendResult(session, response);
+                case null -> {
+                    if (request instanceof Command) {
+                        doSendResult(session, new VoidResult(request.getRequestId()));
+                    }
                 }
-            } else if (result instanceof Boolean v) {
-                doSendResult(session, new BooleanResult(request.getRequestId(), v));
-            } else if (result instanceof String v) {
-                doSendResult(session, new StringResult(request.getRequestId(), v));
-            } else if (result instanceof CompletableFuture<?> future) {
-                future.whenComplete((r, e) -> {
+                case Boolean v -> doSendResult(session, new BooleanResult(request.getRequestId(), v));
+                case String v -> doSendResult(session, new StringResult(request.getRequestId(), v));
+                case CompletableFuture<?> future -> future.whenComplete((r, e) -> {
                     if (e != null) {
                         log.error("Request {} failed. Not sending back result to client.", message, e);
                     } else {
                         trySendResult(session, message, r);
                     }
                 });
-            } else {
-                log.warn("Not able to send back result of type {} to client. Contents: {}. Request: {}",
-                         result.getClass(), result, request);
+                default -> log.warn("Not able to send back result of type {} to client. Contents: {}. Request: {}",
+                                    result.getClass(), result, request);
             }
         }
     }
@@ -227,10 +252,6 @@ public abstract class WebsocketEndpoint extends Endpoint {
                 .ifPresentOrElse(backlog -> backlog.add(result), () ->
                         log.info("Not sending result {}. Could not find any suitable sessions for client {}.",
                                  result, getClientId(session)));
-    }
-
-    protected Stream<Runnable> createTasks(RequestBatch<?> batch, Session session) {
-        return batch.getRequests().stream().map(r -> () -> handleMessage(session, r));
     }
 
     protected void sendResultBatch(Session session, List<RequestResult> results) {
@@ -263,9 +284,25 @@ public abstract class WebsocketEndpoint extends Endpoint {
                         .equals(b.getSession().getId())).findFirst();
     }
 
+    @SuppressWarnings({"SameParameterValue", "resource"})
+    protected ExecutorService[] newRequestStripeExecutors(int stripes) {
+        ExecutorService[] result = new ExecutorService[stripes];
+        for (int i = 0; i < stripes; i++) {
+            result[i] = Executors.newSingleThreadExecutor(newPlatformThreadFactory(
+                    getClass().getSimpleName() + "-command-stripe-" + i));
+        }
+        return result;
+    }
+
+    @SneakyThrows
+    protected JsonType deserializeRequest(Session session, byte[] bytes) {
+        return objectMapper.readValue(decompress(bytes, getCompressionAlgorithm(session)), JsonType.class);
+    }
+
     @Override
     public void onClose(Session session, CloseReason closeReason) {
         sessionBacklogs.remove(session.getId());
+        activeSessionIds.remove(session.getId());
         if (!shuttingDown.get()) {
             if (closeReason.getCloseCode() != UNEXPECTED_CONDITION
                 && closeReason.getCloseCode().getCode() > NO_STATUS_CODE.getCode()) {
@@ -299,7 +336,8 @@ public abstract class WebsocketEndpoint extends Endpoint {
                 Thread.currentThread().interrupt();
             } finally {
                 shutDown = true;
-                Optional.ofNullable(ownedRequestExecutor).ifPresent(ExecutorService::shutdown);
+                Optional.ofNullable(queryExecutor).ifPresent(ExecutorService::shutdown);
+                Arrays.stream(commandExecutors).forEach(ExecutorService::shutdownNow);
                 sessionBacklogs.values().stream().map(SessionBacklog::getSession).filter(Session::isOpen).forEach(s -> {
                     try {
                         s.close();

--- a/test-server/src/test/java/io/fluxzero/testserver/TestServerTest.java
+++ b/test-server/src/test/java/io/fluxzero/testserver/TestServerTest.java
@@ -43,6 +43,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @ExtendWith(SpringExtension.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ContextConfiguration(classes = {FluxzeroTestConfig.class, TestServerTest.FooConfig.class, TestServerTest.BarConfig.class})
@@ -122,7 +127,6 @@ class TestServerTest {
         }
         testFixture.registerHandlers(new Handler()).whenExecuting(fc -> {
                     fc.eventGateway().publish("test");
-                    Thread.sleep(100);
                 })
                 .expectNoMetricsLike(SearchDocumentsResult.Metric.class)
                 .expectNoMetricsLike(SearchDocuments.class)
@@ -132,8 +136,20 @@ class TestServerTest {
     @Test
     void handleDocument() {
         testFixture.whenExecuting(fc -> {
+                    CountDownLatch published = new CountDownLatch(1);
+                    var registration = fc.client().getGatewayClient(io.fluxzero.common.MessageType.EVENT)
+                            .registerMonitor(messages -> {
+                                if (!messages.isEmpty()) {
+                                    published.countDown();
+                                }
+                            });
                     Fluxzero.index("testDoc", "test").get();
-                    Thread.sleep(100);
+                    try {
+                        assertTrue(published.await(1, TimeUnit.SECONDS),
+                                   "Timed out waiting for document handler event");
+                    } finally {
+                        registration.cancel();
+                    }
                 })
                 .expectEvents("testDoc");
     }
@@ -148,8 +164,20 @@ class TestServerTest {
     void handleSchedule() {
         testFixture
                 .whenExecuting(fc -> {
+                    CountDownLatch published = new CountDownLatch(1);
+                    var registration = fc.client().getGatewayClient(io.fluxzero.common.MessageType.EVENT)
+                            .registerMonitor(messages -> {
+                                if (!messages.isEmpty()) {
+                                    published.countDown();
+                                }
+                            });
                     Fluxzero.schedule("foo", Fluxzero.currentTime().minusSeconds(1));
-                    Thread.sleep(500);
+                    try {
+                        assertTrue(published.await(1, TimeUnit.SECONDS),
+                                   "Timed out waiting for scheduling handler event");
+                    } finally {
+                        registration.cancel();
+                    }
                 })
                 .expectEvents("foo");
     }
@@ -244,4 +272,3 @@ class TestServerTest {
     }
 
 }
-

--- a/test-server/src/test/java/io/fluxzero/testserver/websocket/WebsocketEndpointTest.java
+++ b/test-server/src/test/java/io/fluxzero/testserver/websocket/WebsocketEndpointTest.java
@@ -1,0 +1,249 @@
+package io.fluxzero.testserver.websocket;
+
+import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.api.Command;
+import io.fluxzero.common.api.RequestBatch;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.Session;
+import lombok.Value;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WebsocketEndpointTest {
+
+    @Test
+    void requestBatchWithSameRoutingKeyIsHandledInOrder() throws Exception {
+        CountDownLatch secondHandled = new CountDownLatch(1);
+        CountDownLatch allowFirstToFinish = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<String> handled = new CopyOnWriteArrayList<>();
+            TestEndpoint endpoint = new TestEndpoint(executor, handled, secondHandled, allowFirstToFinish);
+            Session session = mock(Session.class);
+            prepareOpenSession(session);
+            endpoint.openSessionForTest(session);
+
+            executor.submit(() -> endpoint.dispatchRequest(session, new RequestBatch<>(List.of(new FirstCommand(),
+                                                                                               new SecondCommand()))));
+
+            assertFalseWithMessage(secondHandled.await(200, TimeUnit.MILLISECONDS),
+                                   "Second request should not overtake the first within a batch");
+            allowFirstToFinish.countDown();
+            assertEventually(() -> assertEquals(List.of("first", "second"), handled));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void requestsWithSameRoutingKeyAreHandledInOrder() throws Exception {
+        CountDownLatch secondHandled = new CountDownLatch(1);
+        CountDownLatch allowFirstToFinish = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<String> handled = new CopyOnWriteArrayList<>();
+            TestEndpoint endpoint = new TestEndpoint(executor, handled, secondHandled, allowFirstToFinish);
+            Session session = mock(Session.class);
+            prepareOpenSession(session);
+            endpoint.openSessionForTest(session);
+
+            endpoint.submitRequestTask(session, new FirstCommand(), () -> {
+                try {
+                    assertTrue(allowFirstToFinish.await(1, TimeUnit.SECONDS),
+                               "First task did not get released in time");
+                    handled.add("first");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            });
+            endpoint.submitRequestTask(session, new SecondCommand(), () -> {
+                handled.add("second");
+                secondHandled.countDown();
+            });
+
+            assertFalseWithMessage(secondHandled.await(200, TimeUnit.MILLISECONDS),
+                                   "Second request should not overtake the first within a routing key");
+            allowFirstToFinish.countDown();
+            assertEventually(() -> assertEquals(List.of("first", "second"), handled));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void requestsWithDifferentRoutingKeysMayRunIndependently() throws Exception {
+        CountDownLatch secondHandled = new CountDownLatch(1);
+        CountDownLatch allowFirstToFinish = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<String> handled = new CopyOnWriteArrayList<>();
+            TestEndpoint endpoint = new TestEndpoint(executor, handled, secondHandled, allowFirstToFinish);
+            Session session = mock(Session.class);
+            prepareOpenSession(session);
+            endpoint.openSessionForTest(session);
+
+            endpoint.submitRequestTask(session, new FirstCommand(), () -> {
+                try {
+                    assertTrue(allowFirstToFinish.await(1, TimeUnit.SECONDS),
+                               "First task did not get released in time");
+                    handled.add("first");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            });
+            endpoint.submitRequestTask(session, new OtherKeyCommand(), () -> {
+                handled.add("second");
+                secondHandled.countDown();
+            });
+
+            assertTrue(secondHandled.await(200, TimeUnit.MILLISECONDS),
+                       "Request with different routing key should not be blocked by the first");
+            allowFirstToFinish.countDown();
+            assertEventually(() -> assertEquals(List.of("second", "first"), handled));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void requestForClosedSessionIsIgnored() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            TestEndpoint endpoint = new TestEndpoint(executor, new CopyOnWriteArrayList<>(), new CountDownLatch(1),
+                                                     new CountDownLatch(0));
+            Session session = mock(Session.class);
+            prepareOpenSession(session);
+            AtomicBoolean invoked = new AtomicBoolean();
+
+            endpoint.openSessionForTest(session);
+            endpoint.onClose(session, new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "test"));
+            endpoint.submitRequestTask(session, null, () -> invoked.set(true));
+
+            Thread.sleep(50);
+            assertTrue(!invoked.get(), "Task for a closed session should be ignored");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void assertEventually(ThrowingRunnable assertion) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        AssertionError lastError = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                assertion.run();
+                return;
+            } catch (AssertionError e) {
+                lastError = e;
+                Thread.sleep(10);
+            }
+        }
+        if (lastError != null) {
+            throw lastError;
+        }
+    }
+
+    private static void assertFalseWithMessage(boolean value, String message) {
+        assertTrue(!value, message);
+    }
+
+    private static void prepareOpenSession(Session session) {
+        when(session.getId()).thenReturn("session");
+        when(session.getRequestParameterMap()).thenReturn(
+                Map.of("clientId", List.of("client"), "clientName", List.of("test-client")));
+        doNothing().when(session).addMessageHandler(any(Class.class), any(MessageHandler.Whole.class));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private static class TestEndpoint extends WebsocketEndpoint {
+        private final List<String> handled;
+        private final CountDownLatch secondHandled;
+        private final CountDownLatch allowFirstToFinish;
+
+        private TestEndpoint(ExecutorService executor, List<String> handled, CountDownLatch secondHandled,
+                             CountDownLatch allowFirstToFinish) {
+            super(executor);
+            this.handled = handled;
+            this.secondHandled = secondHandled;
+            this.allowFirstToFinish = allowFirstToFinish;
+        }
+
+        @Handle
+        void handle(FirstCommand command) throws Exception {
+            assertTrue(allowFirstToFinish.await(1, TimeUnit.SECONDS), "First command did not get released in time");
+            handled.add("first");
+        }
+
+        @Handle
+        void handle(SecondCommand command) {
+            handled.add("second");
+            secondHandled.countDown();
+        }
+
+        void openSessionForTest(Session session) {
+            onOpen(session, mock(EndpointConfig.class));
+        }
+    }
+
+    @Value
+    private static class FirstCommand extends Command {
+        @Override
+        public Guarantee getGuarantee() {
+            return Guarantee.NONE;
+        }
+
+        @Override
+        public String routingKey() {
+            return "key";
+        }
+    }
+
+    @Value
+    private static class SecondCommand extends Command {
+        @Override
+        public Guarantee getGuarantee() {
+            return Guarantee.NONE;
+        }
+
+        @Override
+        public String routingKey() {
+            return "key";
+        }
+    }
+
+    @Value
+    private static class OtherKeyCommand extends Command {
+        @Override
+        public Guarantee getGuarantee() {
+            return Guarantee.NONE;
+        }
+
+        @Override
+        public String routingKey() {
+            return "other";
+        }
+    }
+}


### PR DESCRIPTION
Add end-to-end support for chunked web request handling so large uploads can be forwarded by the proxy in bounded parts and consumed safely by client handlers.

Handlers can now start on the first chunk for streaming use cases such as InputStream-based uploads, while typed handlers still receive the fully reconstructed payload once all chunks have arrived. This applies cleanly to proxied web uploads and preserves payload integrity for binary and textual request bodies.

Form handling is also expanded to match the new request model. Whole form bodies can bind directly to object parameters, @FormParam remains focused on individual fields and named parts, and multipart/form-data supports text fields, file parts, and repeated parts as MultipartFormPart, byte[], InputStream, or collections.

On the proxy side, request chunking is driven by request size, uses capped chunk sizes, preserves routing consistency across parts, and supports configurable request chunk sizing. Test coverage now includes payload reconstruction, boundary cases, timeouts, disconnects, multipart forms, and manual upload verification support.