### PR TITLE
fix(modeling): limit message entity injection

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityParameterResolver.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityParameterResolver.java
@@ -16,12 +16,17 @@
 package io.fluxzero.sdk.modeling;
 
 import io.fluxzero.common.handling.PreparedParameterResolver;
+import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.HasMessage;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.tracking.handling.HandleEvent;
+import io.fluxzero.sdk.tracking.handling.HandleMessage;
+import io.fluxzero.sdk.tracking.handling.HandleNotification;
 import lombok.AllArgsConstructor;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -63,12 +68,26 @@ public class EntityParameterResolver implements PreparedParameterResolver<Object
         this(true);
     }
 
+    @Override
+    public boolean mayApply(Executable method, Class<?> targetClass) {
+        return ReflectionUtils.getMethodAnnotation(method, HandleMessage.class)
+                .map(EntityParameterResolver::supportsMessageEntityInjection)
+                .orElse(true);
+    }
+
+    private static boolean supportsMessageEntityInjection(Annotation methodAnnotation) {
+        if (methodAnnotation == null || methodAnnotation.annotationType().getAnnotation(HandleMessage.class) == null) {
+            return true;
+        }
+        return methodAnnotation instanceof HandleEvent || methodAnnotation instanceof HandleNotification;
+    }
+
     /**
      * Provides a {@link Supplier} that returns the matching entity or its value for the given parameter. Will
      * recursively traverse parent entities if needed.
      *
      * @param parameter        the parameter for which a value must be injected
-     * @param methodAnnotation the annotation on the handler method (unused here)
+     * @param methodAnnotation the annotation on the handler method
      * @return a function that supplies the resolved value
      */
     @Override
@@ -81,7 +100,7 @@ public class EntityParameterResolver implements PreparedParameterResolver<Object
      * value can be found in the message or entity context.
      *
      * @param parameter        the method parameter
-     * @param methodAnnotation the annotation on the handler method (unused here)
+     * @param methodAnnotation the annotation on the handler method
      * @param input            the handler input (e.g., {@link DeserializingMessage} or {@link HasEntity})
      * @return true if the parameter can be resolved from the input, false otherwise
      */
@@ -120,8 +139,11 @@ public class EntityParameterResolver implements PreparedParameterResolver<Object
             var type = Entity.getAggregateType(message);
             String aggregateId = Entity.getAggregateId(message);
             if (aggregateId != null) {
+                if (!isCompatibleAggregateParameter(parameter, type)) {
+                    return null;
+                }
                 return Fluxzero.getOptionally()
-                        .map(fc -> loadAggregate(aggregateId, type, parameter))
+                        .map(fc -> loadAggregate(aggregateId, type))
                         .filter(e -> isAssignable(parameter, e))
                         .filter(e -> e.isPresent() || e.sequenceNumber() > -1L)
                         .orElse(null);
@@ -140,13 +162,16 @@ public class EntityParameterResolver implements PreparedParameterResolver<Object
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Entity<?> loadAggregate(String aggregateId, Class<?> aggregateType, Parameter parameter) {
-        Class<?> parameterType = getEntityParameterType(parameter);
-        Class<?> type = aggregateType;
-        if (type == null && !Object.class.equals(parameterType)) {
-            type = parameterType;
+    private Entity<?> loadAggregate(String aggregateId, Class<?> aggregateType) {
+        return Fluxzero.loadAggregate(aggregateId, (Class) aggregateType);
+    }
+
+    private boolean isCompatibleAggregateParameter(Parameter parameter, Class<?> aggregateType) {
+        if (aggregateType == null) {
+            return false;
         }
-        return type == null ? Fluxzero.loadAggregate(aggregateId) : Fluxzero.loadAggregate(aggregateId, (Class) type);
+        Class<?> parameterType = getEntityParameterType(parameter);
+        return parameterType.isAssignableFrom(aggregateType);
     }
 
     /**

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/AggregatePlaybackTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/AggregatePlaybackTest.java
@@ -17,11 +17,14 @@ package io.fluxzero.sdk.modeling;
 
 import io.fluxzero.common.ConsistentHashing;
 import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.api.Data;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.api.tracking.MessageBatch;
+import io.fluxzero.common.handling.HandlerInspector;
 import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.Message;
+import io.fluxzero.sdk.common.logging.ConsoleError;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.configuration.DefaultFluxzero;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
@@ -32,13 +35,16 @@ import io.fluxzero.sdk.tracking.BatchInterceptor;
 import io.fluxzero.sdk.tracking.Consumer;
 import io.fluxzero.sdk.tracking.Tracker;
 import io.fluxzero.sdk.tracking.handling.HandleCommand;
+import io.fluxzero.sdk.tracking.handling.HandleError;
 import io.fluxzero.sdk.tracking.handling.HandleEvent;
+import io.fluxzero.sdk.tracking.handling.HandleNotification;
 import lombok.Builder;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
@@ -47,6 +53,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import static io.fluxzero.common.MessageType.COMMAND;
+import static io.fluxzero.common.MessageType.EVENT;
+import static io.fluxzero.common.MessageType.ERROR;
 import static io.fluxzero.sdk.Fluxzero.loadAggregate;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -128,6 +137,75 @@ class AggregatePlaybackTest {
             assertNotNull(resolved.previous());
             assertNull(resolved.previous().get().primaryValue());
         }).expectNoErrors();
+    }
+
+    @Test
+    void aggregateMetadataDoesNotLoadAggregateForIncompatiblePayloadParameter() throws NoSuchMethodException {
+        Method method = IncompatibleErrorHandler.class.getDeclaredMethod("handle", SetPrimaryValue.class);
+        Parameter parameter = method.getParameters()[0];
+        HandleError handleError = method.getAnnotation(HandleError.class);
+        EntityParameterResolver resolver = new EntityParameterResolver();
+
+        testFixture.whenExecuting(fc -> {
+            storeUnknownEvent(fc, "legacy", SampleAggregate.class);
+            Message error = new Message(new ConsoleError(), Metadata.of(
+                    Entity.AGGREGATE_ID_METADATA_KEY, "legacy",
+                    Entity.AGGREGATE_TYPE_METADATA_KEY, SampleAggregate.class.getName()));
+            DeserializingMessage message = fc.serializer().deserializeMessage(error.serialize(fc.serializer()), ERROR);
+
+            assertEquals(ConsoleError.class, message.getPayloadClass());
+            assertFalse(resolver.matches(parameter, handleError, message));
+        }).expectNoErrors();
+    }
+
+    @Test
+    void aggregateMetadataDoesNotInferAggregateTypeWhenMetadataTypeCannotResolve() throws NoSuchMethodException {
+        Method method = ProbeHandler.class.getDeclaredMethod("handle", Entity.class);
+        Parameter parameter = method.getParameters()[0];
+        HandleEvent handleEvent = method.getAnnotation(HandleEvent.class);
+        EntityParameterResolver resolver = new EntityParameterResolver();
+
+        testFixture.whenExecuting(fc -> {
+            storeUnknownEvent(fc, "legacy", SampleAggregate.class);
+            Message event = new Message(new SetPrimaryValue("value-1"), Metadata.of(
+                    Entity.AGGREGATE_ID_METADATA_KEY, "legacy",
+                    Entity.AGGREGATE_TYPE_METADATA_KEY, "com.example.MovedAggregate"));
+            DeserializingMessage message = fc.serializer().deserializeMessage(event.serialize(fc.serializer()), EVENT);
+
+            assertNull(Entity.getAggregateType(message));
+            assertFalse(resolver.matches(parameter, handleEvent, message));
+        }).expectNoErrors();
+    }
+
+    @Test
+    void aggregateMetadataDoesNotInjectEntityIntoCommandHandler() throws NoSuchMethodException {
+        Method method = CommandEntityHandler.class.getDeclaredMethod("handle", Entity.class);
+        EntityParameterResolver resolver = new EntityParameterResolver();
+
+        testFixture.whenExecuting(fc -> {
+            storeUnknownEvent(fc, "legacy", SampleAggregate.class);
+            Message command = new Message(new SetPrimaryValue("value-1"), Metadata.of(
+                    Entity.AGGREGATE_ID_METADATA_KEY, "legacy",
+                    Entity.AGGREGATE_TYPE_METADATA_KEY, SampleAggregate.class.getName()));
+            DeserializingMessage message = fc.serializer().deserializeMessage(command.serialize(fc.serializer()), COMMAND);
+
+            assertFalse(resolver.mayApply(method, CommandEntityHandler.class));
+            assertFalse(HandlerInspector.createHandler(new CommandEntityHandler(), HandleCommand.class, List.of(resolver))
+                                .getInvoker(message).isPresent());
+        }).expectNoErrors();
+    }
+
+    @Test
+    void entityResolverMayApplyOnlyToEventAndNotificationMessageHandlers() throws NoSuchMethodException {
+        EntityParameterResolver resolver = new EntityParameterResolver();
+
+        assertTrue(resolver.mayApply(entityMethod("handleEvent"), EntityInjectionEligibilityHandler.class));
+        assertTrue(resolver.mayApply(entityMethod("handleNotification"), EntityInjectionEligibilityHandler.class));
+        assertTrue(resolver.mayApply(entityMethod("validate"), EntityInjectionEligibilityHandler.class));
+        assertFalse(resolver.mayApply(entityMethod("handleCommand"), EntityInjectionEligibilityHandler.class));
+        assertFalse(resolver.mayApply(entityMethod("handleError"), EntityInjectionEligibilityHandler.class));
+        assertFalse(resolver.mayApply(OverridingCommandEntityHandler.class.getDeclaredMethod("handle", Entity.class),
+                                      OverridingCommandEntityHandler.class));
     }
 
     @Test
@@ -590,6 +668,10 @@ class AggregatePlaybackTest {
         return "$Aggregate:" + aggregateId;
     }
 
+    private static Method entityMethod(String methodName) throws NoSuchMethodException {
+        return EntityInjectionEligibilityHandler.class.getDeclaredMethod(methodName, Entity.class);
+    }
+
     private static void storeLegacyEvent(Fluxzero fluxzero, String aggregateId, Object payload, String source) throws Exception {
         SerializedMessage serializedMessage = new Message(payload).serialize(fluxzero.serializer());
         serializedMessage.setSource(source);
@@ -611,6 +693,16 @@ class AggregatePlaybackTest {
         fluxzero.client().getEventStoreClient().storeEvents(aggregateId, List.of(serializedMessage), false).get();
     }
 
+    private static void storeUnknownEvent(Fluxzero fluxzero, String aggregateId, Class<?> aggregateType) throws Exception {
+        SerializedMessage serializedMessage = new SerializedMessage(
+                new Data<>("{}".getBytes(StandardCharsets.UTF_8),
+                           aggregateType.getPackageName() + ".MissingHistoricalEvent", 0, Data.JSON_FORMAT),
+                Metadata.empty(), "unknown-event", System.currentTimeMillis());
+        serializedMessage.setSource("legacy-client");
+        serializedMessage.setSegment(ConsistentHashing.computeSegment(aggregateId));
+        fluxzero.client().getEventStoreClient().storeEvents(aggregateId, List.of(serializedMessage), false).get();
+    }
+
     private static void storeForeignCreateEvent(io.fluxzero.sdk.Fluxzero fluxzero) throws Exception {
         storeEvent(fluxzero, AsyncPlaybackScenario.aggregateId, AsyncSampleAggregate.class,
                    new CreateSampleAggregateEvent(AsyncPlaybackScenario.aggregateId), "foreign-client", 0L);
@@ -618,6 +710,51 @@ class AggregatePlaybackTest {
 
     static class ProbeHandler {
         @HandleEvent
+        void handle(Entity<SampleAggregate> entity) {
+        }
+    }
+
+    static class IncompatibleErrorHandler {
+        @HandleError
+        void handle(SetPrimaryValue event) {
+        }
+    }
+
+    static class CommandEntityHandler {
+        @HandleCommand
+        void handle(Entity<SampleAggregate> entity) {
+        }
+    }
+
+    static class EntityInjectionEligibilityHandler {
+        @HandleEvent
+        void handleEvent(Entity<SampleAggregate> entity) {
+        }
+
+        @HandleNotification
+        void handleNotification(Entity<SampleAggregate> entity) {
+        }
+
+        @HandleCommand
+        void handleCommand(Entity<SampleAggregate> entity) {
+        }
+
+        @HandleError
+        void handleError(Entity<SampleAggregate> entity) {
+        }
+
+        void validate(Entity<SampleAggregate> entity) {
+        }
+    }
+
+    static class BaseCommandEntityHandler {
+        @HandleCommand
+        void handle(Entity<SampleAggregate> entity) {
+        }
+    }
+
+    static class OverridingCommandEntityHandler extends BaseCommandEntityHandler {
+        @Override
         void handle(Entity<SampleAggregate> entity) {
         }
     }


### PR DESCRIPTION
Prevent EntityParameterResolver from participating in non-event/notification tracking handlers while preserving internal HasEntity resolution paths.

Require aggregate metadata to resolve to a compatible aggregate type before replaying an aggregate from metadata, avoiding accidental aggregate loads from copied error metadata or moved unknown types.

Tests: ./mvnw -pl sdk -Dtest=AggregatePlaybackTest test (cherry picked from commit 9cf35df4fd0a7d25eedb96be1ebe76d2fdca57d7)