### PR TITLE
[codex] Diagnose mutable entity CI race

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DefaultEntityHelper.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DefaultEntityHelper.java
@@ -30,6 +30,7 @@ import io.fluxzero.sdk.persisting.eventsourcing.InterceptApply;
 import io.fluxzero.sdk.tracking.handling.Invocation;
 import io.fluxzero.sdk.tracking.handling.validation.ValidationUtils;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -65,7 +66,9 @@ import static java.util.stream.Collectors.joining;
  * The class supports efficient handler resolution through memoized lookups, enabling fast, repeatable application of
  * complex domain behaviors.
  */
+@Slf4j
 public class DefaultEntityHelper implements EntityHelper {
+    private static final String MUTABLE_ENTITY_DIAGNOSTIC = "FLUXZERO_MUTABLE_ENTITY_DIAGNOSTIC";
 
     /**
      * Default aggregate annotation used when no explicit @Aggregate is found.
@@ -245,11 +248,14 @@ public class DefaultEntityHelper implements EntityHelper {
                                                  boolean checkCompatibility) {
         var message = new DeserializingMessageWithEntity(event, entity);
         Class<?> entityType = entity.type();
-        Optional<HandlerInvoker> result =
-                applyMatchers.apply(entityType, checkCompatibility).getInvoker(entity.get(), message)
-                        .or(() -> applyMatchers.apply(message.getPayloadClass(), checkCompatibility)
-                                .getInvoker(message.getPayload(), message))
-                        .map(i -> new HandlerInvoker.DelegatingHandlerInvoker(i) {
+        Optional<HandlerInvoker> entityInvoker =
+                applyMatchers.apply(entityType, checkCompatibility).getInvoker(entity.get(), message);
+        Optional<HandlerInvoker> payloadInvoker = entityInvoker.isPresent()
+                ? Optional.empty()
+                : applyMatchers.apply(message.getPayloadClass(), checkCompatibility)
+                        .getInvoker(message.getPayload(), message);
+        Optional<HandlerInvoker> result = entityInvoker.or(() -> payloadInvoker)
+                .map(i -> new HandlerInvoker.DelegatingHandlerInvoker(i) {
                             @Override
                             public Object invoke(BiFunction<Object, Object, Object> combiner) {
                                 return message.apply(m -> {
@@ -267,8 +273,19 @@ public class DefaultEntityHelper implements EntityHelper {
                                 });
                             }
                         });
+        boolean diagnose = shouldDiagnose(event, checkCompatibility);
+        if (diagnose) {
+            log.error("{} applyInvoker payload={} entity={} searchChildren={} checkCompatibility={} entityInvoker={} "
+                      + "payloadInvoker={} selected={}", MUTABLE_ENTITY_DIAGNOSTIC, payloadDescription(event),
+                      entityDescription(entity), searchChildren, checkCompatibility, invokerDescription(entityInvoker),
+                      invokerDescription(payloadInvoker), invokerDescription(result));
+        }
         if (result.isEmpty() && searchChildren) {
             for (Entity<?> e : entity.possibleTargets(event.getPayload())) {
+                if (diagnose) {
+                    log.error("{} applyInvoker childCandidate payload={} child={}", MUTABLE_ENTITY_DIAGNOSTIC,
+                              payloadDescription(event), entityDescription(e));
+                }
                 result = applyInvoker(event, e, true, checkCompatibility);
                 if (result.isPresent()) {
                     return result;
@@ -276,6 +293,53 @@ public class DefaultEntityHelper implements EntityHelper {
             }
         }
         return result;
+    }
+
+    private static boolean shouldDiagnose(DeserializingMessage event, boolean checkCompatibility) {
+        return isMutableEntityDiagnosticPayload(event)
+               && (!checkCompatibility || Boolean.getBoolean("fluxzero.diagnostic.apply.verbose"));
+    }
+
+    private static boolean isMutableEntityDiagnosticPayload(DeserializingMessage event) {
+        Class<?> payloadClass = event.getPayloadClass();
+        return Boolean.getBoolean("fluxzero.diagnostic.apply")
+               || payloadClass != null
+                  && payloadClass.getName().contains("AggregateEntitiesTest$CreateMutableEntity");
+    }
+
+    private static String payloadDescription(DeserializingMessage event) {
+        Object payload = event.getPayload();
+        Class<?> payloadClass = event.getPayloadClass();
+        return "class=" + className(payloadClass)
+               + ", payload=" + payload
+               + ", payloadIdentity=" + System.identityHashCode(payload);
+    }
+
+    private static String entityDescription(Entity<?> entity) {
+        return "id=" + entity.id()
+               + ", idProperty=" + entity.idProperty()
+               + ", type=" + className(entity.type())
+               + ", present=" + entity.isPresent()
+               + ", empty=" + entity.isEmpty()
+               + ", valueClass=" + className(entity.get() == null ? null : entity.get().getClass())
+               + ", entityIdentity=" + System.identityHashCode(entity);
+    }
+
+    private static String invokerDescription(Optional<HandlerInvoker> invoker) {
+        return invoker.map(DefaultEntityHelper::invokerDescription).orElse("<empty>");
+    }
+
+    private static String invokerDescription(HandlerInvoker invoker) {
+        Executable method = invoker.getMethod();
+        return invoker.getTargetClass().getName()
+               + "#" + method.getName()
+               + "(" + parameterTypeNames(method) + ")"
+               + ", expectResult=" + invoker.expectResult()
+               + ", passive=" + invoker.isPassive();
+    }
+
+    private static String className(Class<?> type) {
+        return type == null ? "<null>" : type.getName();
     }
 
     /**

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ImmutableEntity.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ImmutableEntity.java
@@ -111,6 +111,7 @@ import static java.util.Collections.emptyList;
 @Accessors(fluent = true)
 @Slf4j
 public class ImmutableEntity<T> implements Entity<T> {
+    private static final String MUTABLE_ENTITY_DIAGNOSTIC = "FLUXZERO_MUTABLE_ENTITY_DIAGNOSTIC";
     private static final ThreadLocal<Map<RouteCacheKey, String>> loadingRouteCache = ThreadLocal.withInitial(HashMap::new);
     private static final Map<RoutingKeyOverlapCacheKey, Boolean> routingKeyOverlapsCurrentIdCache =
             new ConcurrentHashMap<>();
@@ -246,7 +247,20 @@ public class ImmutableEntity<T> implements Entity<T> {
         }
         if (result == this && !Entity.isLoading()
             && getBooleanProperty("fluxzero.assert.apply-compatibility", true)) {
-            assertApplyCompatibility(message, this);
+            try {
+                assertApplyCompatibility(message, this);
+            } catch (RuntimeException e) {
+                if (isMutableEntityDiagnosticPayload(message)) {
+                    log.error("{} compatibilityFailure payloadClass={} payload={} currentEntity={} resultEntity={} "
+                              + "directInvoker={} finalInvoker={} explicitTarget={} possibleTargets={} "
+                              + "thread={} loading={} applying={}", MUTABLE_ENTITY_DIAGNOSTIC,
+                              className(message.getPayloadClass()), message.getPayload(), entityDescription(this),
+                              entityDescription(result), invokerDescription(directInvoker), invokerDescription(invoker),
+                              explicitTarget(message.getPayload()), possibleTargetsDescription(this, message.getPayload()),
+                              Thread.currentThread().getName(), Entity.isLoading(), Entity.isApplying(), e);
+                }
+                throw e;
+            }
         }
         return result;
     }
@@ -296,6 +310,50 @@ public class ImmutableEntity<T> implements Entity<T> {
             return false;
         }
         return ReflectionUtils.readProperty(idProperty(), payload).map(id()::equals).orElse(false);
+    }
+
+    private static boolean isMutableEntityDiagnosticPayload(DeserializingMessage message) {
+        Class<?> payloadClass = message.getPayloadClass();
+        return Boolean.getBoolean("fluxzero.diagnostic.apply")
+               || payloadClass != null
+                  && payloadClass.getName().contains("AggregateEntitiesTest$CreateMutableEntity");
+    }
+
+    private static String entityDescription(Entity<?> entity) {
+        return "id=" + entity.id()
+               + ", idProperty=" + entity.idProperty()
+               + ", type=" + className(entity.type())
+               + ", present=" + entity.isPresent()
+               + ", empty=" + entity.isEmpty()
+               + ", valueClass=" + className(entity.get() == null ? null : entity.get().getClass())
+               + ", entityIdentity=" + System.identityHashCode(entity);
+    }
+
+    private static String possibleTargetsDescription(Entity<?> entity, Object payload) {
+        try {
+            List<String> descriptions = new ArrayList<>();
+            for (Entity<?> target : entity.possibleTargets(payload)) {
+                descriptions.add(entityDescription(target));
+            }
+            return String.join(" | ", descriptions);
+        } catch (RuntimeException e) {
+            return "<failed: " + e.getClass().getName() + ": " + e.getMessage() + ">";
+        }
+    }
+
+    private static String invokerDescription(Optional<HandlerInvoker> invoker) {
+        return invoker.map(ImmutableEntity::invokerDescription).orElse("<empty>");
+    }
+
+    private static String invokerDescription(HandlerInvoker invoker) {
+        return invoker.getTargetClass().getName()
+               + "#" + invoker.getMethod().getName()
+               + ", expectResult=" + invoker.expectResult()
+               + ", passive=" + invoker.isPassive();
+    }
+
+    private static String className(Class<?> type) {
+        return type == null ? "<null>" : type.getName();
     }
 
     private ExplicitTarget explicitTarget(Object payload) {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/AggregateEntitiesTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/AggregateEntitiesTest.java
@@ -41,6 +41,7 @@ import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.ElementType;
@@ -1570,7 +1571,7 @@ public class AggregateEntitiesTest {
                 fc -> loadAggregate("test", MutableAggregate.class)
                         .update(s -> new MutableAggregate(null)));
 
-        @Test
+        @RepeatedTest(100)
         void createMutableEntity() {
             testFixture.whenCommand(new CreateMutableEntity("childId")).expectThat(
                     fc -> expectEntity(MutableAggregate.class, e -> "childId".equals(e.id())));
@@ -1586,7 +1587,15 @@ public class AggregateEntitiesTest {
         class CommandHandler {
             @HandleCommand
             void handle(Object command) {
-                loadAggregate("test", MutableAggregate.class).apply(command);
+                try {
+                    loadAggregate("test", MutableAggregate.class).apply(command);
+                } catch (RuntimeException e) {
+                    log.error("FLUXZERO_MUTABLE_ENTITY_DIAGNOSTIC commandHandlerFailure command={} commandClass={} "
+                              + "thread={} loading={} applying={}", command,
+                              command == null ? "<null>" : command.getClass().getName(),
+                              Thread.currentThread().getName(), Entity.isLoading(), Entity.isApplying(), e);
+                    throw e;
+                }
             }
         }
 


### PR DESCRIPTION
Temporary diagnostic PR, not intended to merge. This removes no production behavior intentionally beyond adding diagnostic logging around mutable entity @Apply resolution and repeating AggregateEntitiesTest.MutableEntityTests#createMutableEntity to increase the chance of reproducing the intermittent CI failure. If CI hits the issue, search logs for FLUXZERO_MUTABLE_ENTITY_DIAGNOSTIC to see handler resolution, entity state, possible targets, and ThreadLocal state at the failure point. Local focused check: ./mvnw -q -pl sdk -am -Dtest='AggregateEntitiesTest' -Dsurefire.failIfNoSpecifiedTests=false test.