### PR TITLE
ci(performance): add hot-path regression gate

### DIFF
--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Compare paired JMH JSON runs and fail on material scenario regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", action="append", required=True, type=Path)
+    parser.add_argument("--head", action="append", required=True, type=Path)
+    parser.add_argument("--time-threshold", type=float, default=0.15)
+    parser.add_argument("--allocation-threshold", type=float, default=0.15)
+    parser.add_argument("--allocation-min-bytes", type=float, default=256.0)
+    return parser.parse_args()
+
+
+def load_runs(paths: list[Path]) -> dict[str, list[dict]]:
+    result: dict[str, list[dict]] = {}
+    for path in paths:
+        with path.open(encoding="utf-8") as source:
+            run = json.load(source)
+        for entry in run:
+            result.setdefault(entry["benchmark"], []).append(entry)
+    return result
+
+
+def mean_metric(entries: list[dict], metric: str | None = None) -> tuple[float, str]:
+    if metric is None:
+        values = [entry["primaryMetric"]["score"] for entry in entries]
+        units = {entry["primaryMetric"]["scoreUnit"] for entry in entries}
+    else:
+        values = [entry["secondaryMetrics"][metric]["score"] for entry in entries]
+        units = {entry["secondaryMetrics"][metric]["scoreUnit"] for entry in entries}
+    if len(units) != 1:
+        raise ValueError(f"Inconsistent metric units: {sorted(units)}")
+    return statistics.fmean(values), units.pop()
+
+
+def short_name(benchmark: str) -> str:
+    parts = benchmark.split(".")
+    return ".".join(parts[-2:])
+
+
+def delta(before: float, after: float) -> float:
+    if before == 0.0:
+        return 0.0 if after == 0.0 else float("inf")
+    return after / before - 1.0
+
+
+def percent(value: float) -> str:
+    return f"{value:+.1%}"
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.base) != 2 or len(args.head) != 2:
+        raise ValueError("Exactly two base and two head runs are required for the ABBA comparison")
+    base = load_runs(args.base)
+    head = load_runs(args.head)
+    if not base or not head:
+        raise ValueError("No benchmark results were produced")
+    if base.keys() != head.keys():
+        missing_from_head = sorted(base.keys() - head.keys())
+        missing_from_base = sorted(head.keys() - base.keys())
+        raise ValueError(
+            f"Benchmark sets differ; missing from head={missing_from_head}, missing from base={missing_from_base}"
+        )
+
+    rows: list[str] = []
+    failures: list[str] = []
+    for benchmark in sorted(base):
+        if len(base[benchmark]) != 2 or len(head[benchmark]) != 2:
+            raise ValueError(f"Expected two base and two head results for {benchmark}")
+        base_time, time_unit = mean_metric(base[benchmark])
+        head_time, head_time_unit = mean_metric(head[benchmark])
+        if time_unit != head_time_unit:
+            raise ValueError(f"Time units differ for {benchmark}: {time_unit} vs {head_time_unit}")
+
+        allocation_metric = "gc.alloc.rate.norm"
+        base_alloc, allocation_unit = mean_metric(base[benchmark], allocation_metric)
+        head_alloc, head_allocation_unit = mean_metric(head[benchmark], allocation_metric)
+        if allocation_unit != head_allocation_unit:
+            raise ValueError(
+                f"Allocation units differ for {benchmark}: {allocation_unit} vs {head_allocation_unit}"
+            )
+        values = (base_time, head_time, base_alloc, head_alloc)
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError(f"Non-finite metric detected for {benchmark}")
+        if base_time <= 0.0 or head_time <= 0.0 or base_alloc < 0.0 or head_alloc < 0.0:
+            raise ValueError(f"Invalid metric detected for {benchmark}")
+
+        time_delta = delta(base_time, head_time)
+        allocation_delta = delta(base_alloc, head_alloc)
+        time_regression = time_delta > args.time_threshold
+        allocation_regression = (
+            allocation_delta > args.allocation_threshold
+            and head_alloc - base_alloc >= args.allocation_min_bytes
+        )
+        status = "fail" if time_regression or allocation_regression else "pass"
+        rows.append(
+            f"| `{short_name(benchmark)}` | {base_time:.3f} | {head_time:.3f} | "
+            f"{percent(time_delta)} | {base_alloc:.0f} | {head_alloc:.0f} | "
+            f"{percent(allocation_delta)} | {status} |"
+        )
+        if time_regression:
+            failures.append(
+                f"{short_name(benchmark)} time increased by {percent(time_delta)} "
+                f"(limit {args.time_threshold:.0%})"
+            )
+        if allocation_regression:
+            failures.append(
+                f"{short_name(benchmark)} allocation increased by {percent(allocation_delta)} "
+                f"and {head_alloc - base_alloc:.0f} B/op "
+                f"(limits {args.allocation_threshold:.0%} and {args.allocation_min_bytes:.0f} B/op)"
+            )
+
+    report = "\n".join(
+        [
+            "## SDK performance APK",
+            "",
+            "Base and head are the means of two ABBA-ordered JMH runs on the same machine.",
+            "",
+            "| Scenario | Base time | Head time | Time | Base B/op | Head B/op | Allocation | Gate |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | :---: |",
+            *rows,
+            "",
+            f"Time unit: `{time_unit}`. Allocation unit: `{allocation_unit}`.",
+        ]
+    )
+    if failures:
+        report += "\n\nRegressions:\n\n" + "\n".join(f"- {failure}" for failure in failures)
+    else:
+        report += "\n\nNo material performance regression detected."
+
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write(report + "\n")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (KeyError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Could not compare benchmark results: {error}", file=sys.stderr)
+        sys.exit(2)

--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -124,7 +124,7 @@ def main() -> int:
 
     report = "\n".join(
         [
-            "## SDK performance APK",
+            "## SDK performance regression gate",
             "",
             "Base and head are the means of two ABBA-ordered JMH runs on the same machine.",
             "",

--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -16,8 +16,13 @@ from pathlib import Path
 SCENARIO_UNITS = {
     "aggregateLifecycle": "lifecycle (50 replay + 3 apply)",
     "localCommandHandling": "command",
+    "localSelfHandlingQueries": "self-handled query",
+    "localStandaloneQueryHandling": "query handled by a multi-method local handler",
     "outboundDispatch": "event in a 32-event batch",
-    "trackingHandling": "message in a 32-message batch",
+    "selfTrackedCommandHandling": "self-tracked command in a 32-command batch",
+    "standaloneTrackedCommandHandling": "command in a 32-command tracked batch",
+    "standaloneTrackedEventHandling": "entity-resolving event in a 32-event tracked batch",
+    "statefulAndStandaloneTrackedEventHandling": "event in a 32-event tracked batch",
 }
 
 

--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -19,10 +19,7 @@ SCENARIO_UNITS = {
     "localSelfHandlingQueries": "self-handled query",
     "localStandaloneQueryHandling": "query handled by a multi-method local handler",
     "outboundDispatch": "event in a 32-event batch",
-    "selfTrackedCommandHandling": "self-tracked command in a 32-command batch",
-    "standaloneTrackedCommandHandling": "command in a 32-command tracked batch",
-    "standaloneTrackedEventHandling": "entity-resolving event in a 32-event tracked batch",
-    "statefulAndStandaloneTrackedEventHandling": "event in a 32-event tracked batch",
+    "trackedHandlingRoutes": "message across four representative tracked route batches",
 }
 
 

--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -7,9 +7,18 @@ import argparse
 import json
 import math
 import os
+import re
 import statistics
 import sys
 from pathlib import Path
+
+
+SCENARIO_UNITS = {
+    "aggregateLifecycle": "lifecycle (50 replay + 3 apply)",
+    "localCommandHandling": "command",
+    "outboundDispatch": "event in a 32-event batch",
+    "trackingHandling": "message in a 32-message batch",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -49,6 +58,15 @@ def short_name(benchmark: str) -> str:
     return ".".join(parts[-2:])
 
 
+def scenario_name(benchmark: str) -> str:
+    method_name = benchmark.rsplit(".", 1)[-1]
+    return re.sub(r"(?<!^)(?=[A-Z])", " ", method_name).capitalize()
+
+
+def scenario_unit(benchmark: str) -> str:
+    return SCENARIO_UNITS.get(benchmark.rsplit(".", 1)[-1], "invocation")
+
+
 def delta(before: float, after: float) -> float:
     if before == 0.0:
         return 0.0 if after == 0.0 else float("inf")
@@ -74,7 +92,8 @@ def main() -> int:
             f"Benchmark sets differ; missing from head={missing_from_head}, missing from base={missing_from_base}"
         )
 
-    rows: list[str] = []
+    summary_rows: list[str] = []
+    detail_rows: list[str] = []
     failures: list[str] = []
     for benchmark in sorted(base):
         if len(base[benchmark]) != 2 or len(head[benchmark]) != 2:
@@ -104,11 +123,18 @@ def main() -> int:
             allocation_delta > args.allocation_threshold
             and head_alloc - base_alloc >= args.allocation_min_bytes
         )
-        status = "fail" if time_regression or allocation_regression else "pass"
-        rows.append(
-            f"| `{short_name(benchmark)}` | {base_time:.3f} | {head_time:.3f} | "
-            f"{percent(time_delta)} | {base_alloc:.0f} | {head_alloc:.0f} | "
-            f"{percent(allocation_delta)} | {status} |"
+        failed = time_regression or allocation_regression
+        status = "❌ Regression" if failed else "✅ Pass"
+        name = scenario_name(benchmark)
+        operation = scenario_unit(benchmark)
+        time_change = percent(time_delta)
+        allocation_change = percent(allocation_delta)
+        summary_rows.append(
+            f"| {name} | {time_change} | {allocation_change} | {status} |"
+        )
+        detail_rows.append(
+            f"| {name} | {operation} | {base_time:.3f} → {head_time:.3f} | {time_change} | "
+            f"{base_alloc:.0f} → {head_alloc:.0f} | {allocation_change} |"
         )
         if time_regression:
             failures.append(
@@ -122,23 +148,46 @@ def main() -> int:
                 f"(limits {args.allocation_threshold:.0%} and {args.allocation_min_bytes:.0f} B/op)"
             )
 
+    headline = "❌ Performance regression gate failed" if failures else "✅ Performance regression gate passed"
+    outcome = (
+        "1 regression criterion was exceeded."
+        if len(failures) == 1
+        else f"{len(failures)} regression criteria were exceeded."
+        if failures
+        else "No material regression was detected against the pull-request base."
+    )
     report = "\n".join(
         [
-            "## SDK performance regression gate",
+            f"## {headline}",
             "",
-            "Base and head are the means of two ABBA-ordered JMH runs on the same machine.",
+            outcome,
             "",
-            "| Scenario | Base time | Head time | Time | Base B/op | Head B/op | Allocation | Gate |",
-            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | :---: |",
-            *rows,
+            "| Hot-path scenario | Time vs base | Allocation vs base | Result |",
+            "| --- | ---: | ---: | :---: |",
+            *summary_rows,
             "",
-            f"Time unit: `{time_unit}`. Allocation unit: `{allocation_unit}`.",
+            "<details>",
+            "<summary>Measurement details and regression limits</summary>",
+            "",
+            "Lower is better. Base and head are the means of two ABBA-ordered JMH runs on the same machine.",
+            "",
+            f"The gate fails above **+{args.time_threshold:.0%} time**, or above "
+            f"**+{args.allocation_threshold:.0%} allocation** with at least "
+            f"**+{args.allocation_min_bytes:.0f} B/op**.",
+            "",
+            f"| Hot-path scenario | Measured operation | Time: base → head ({time_unit}) | Change | "
+            f"Allocation: base → head ({allocation_unit}) | Change |",
+            "| --- | --- | ---: | ---: | ---: | ---: |",
+            *detail_rows,
+            "",
+            "</details>",
         ]
     )
     if failures:
-        report += "\n\nRegressions:\n\n" + "\n".join(f"- {failure}" for failure in failures)
-    else:
-        report += "\n\nNo material performance regression detected."
+        report += "\n\n### Regressions\n\n" + "\n".join(f"- {failure}" for failure in failures)
+        if os.environ.get("GITHUB_ACTIONS"):
+            for failure in failures:
+                print(f"::error title=Performance regression::{failure}")
 
     print(report)
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/.github/scripts/compare-benchmarks.test.py
+++ b/.github/scripts/compare-benchmarks.test.py
@@ -80,13 +80,13 @@ class CompareBenchmarksTest(unittest.TestCase):
 
     def test_known_scenario_describes_the_normalized_operation(self):
         benchmark = [result(
-            "io.fluxzero.sdk.tracking.TrackingHotPathBenchmark.standaloneTrackedEventHandling",
+            "io.fluxzero.sdk.tracking.TrackingHotPathBenchmark.trackedHandlingRoutes",
             100.0,
             1_000.0,
         )]
         comparison = self.compare(benchmark, benchmark)
         self.assertEqual(0, comparison.returncode)
-        self.assertIn("entity-resolving event in a 32-event tracked batch", comparison.stdout)
+        self.assertIn("message across four representative tracked route batches", comparison.stdout)
 
     def test_different_benchmark_sets_are_configuration_error(self):
         comparison = self.compare(

--- a/.github/scripts/compare-benchmarks.test.py
+++ b/.github/scripts/compare-benchmarks.test.py
@@ -78,6 +78,16 @@ class CompareBenchmarksTest(unittest.TestCase):
         )
         self.assertEqual(0, comparison.returncode)
 
+    def test_known_scenario_describes_the_normalized_operation(self):
+        benchmark = [result(
+            "io.fluxzero.sdk.tracking.TrackingHotPathBenchmark.standaloneTrackedEventHandling",
+            100.0,
+            1_000.0,
+        )]
+        comparison = self.compare(benchmark, benchmark)
+        self.assertEqual(0, comparison.returncode)
+        self.assertIn("entity-resolving event in a 32-event tracked batch", comparison.stdout)
+
     def test_different_benchmark_sets_are_configuration_error(self):
         comparison = self.compare(
             [result("example.Scenario.base", 100.0, 1_000.0)],

--- a/.github/scripts/compare-benchmarks.test.py
+++ b/.github/scripts/compare-benchmarks.test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("compare-benchmarks.py")
+
+
+def result(benchmark: str, time: float, allocation: float) -> dict:
+    return {
+        "benchmark": benchmark,
+        "primaryMetric": {"score": time, "scoreUnit": "us/op"},
+        "secondaryMetrics": {
+            "gc.alloc.rate.norm": {"score": allocation, "scoreUnit": "B/op"}
+        },
+    }
+
+
+class CompareBenchmarksTest(unittest.TestCase):
+    def compare(self, base: list[dict], head: list[dict]) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            paths = [directory_path / name for name in ("base-1.json", "base-2.json", "head-1.json", "head-2.json")]
+            for path, value in zip(paths, (base, base, head, head)):
+                path.write_text(json.dumps(value), encoding="utf-8")
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--base", str(paths[0]),
+                    "--base", str(paths[1]),
+                    "--head", str(paths[2]),
+                    "--head", str(paths[3]),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_equal_results_pass(self):
+        benchmark = [result("example.Scenario.run", 100.0, 1_000.0)]
+        self.assertEqual(0, self.compare(benchmark, benchmark).returncode)
+
+    def test_time_regression_fails(self):
+        comparison = self.compare(
+            [result("example.Scenario.run", 100.0, 1_000.0)],
+            [result("example.Scenario.run", 116.0, 1_000.0)],
+        )
+        self.assertEqual(1, comparison.returncode)
+        self.assertIn("time increased", comparison.stdout)
+
+    def test_material_allocation_regression_fails(self):
+        comparison = self.compare(
+            [result("example.Scenario.run", 100.0, 1_000.0)],
+            [result("example.Scenario.run", 100.0, 1_300.0)],
+        )
+        self.assertEqual(1, comparison.returncode)
+        self.assertIn("allocation increased", comparison.stdout)
+
+    def test_small_absolute_allocation_change_passes(self):
+        comparison = self.compare(
+            [result("example.Scenario.run", 100.0, 1_000.0)],
+            [result("example.Scenario.run", 100.0, 1_200.0)],
+        )
+        self.assertEqual(0, comparison.returncode)
+
+    def test_different_benchmark_sets_are_configuration_error(self):
+        comparison = self.compare(
+            [result("example.Scenario.base", 100.0, 1_000.0)],
+            [result("example.Scenario.head", 100.0, 1_000.0)],
+        )
+        self.assertEqual(2, comparison.returncode)
+        self.assertIn("Benchmark sets differ", comparison.stderr)
+
+    def test_non_finite_metric_is_configuration_error(self):
+        comparison = self.compare(
+            [result("example.Scenario.run", 100.0, 1_000.0)],
+            [result("example.Scenario.run", float("nan"), 1_000.0)],
+        )
+        self.assertEqual(2, comparison.returncode)
+        self.assertIn("Non-finite metric", comparison.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/compare-benchmarks.test.py
+++ b/.github/scripts/compare-benchmarks.test.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).with_name("compare-benchmarks.py")
@@ -28,6 +30,9 @@ class CompareBenchmarksTest(unittest.TestCase):
             paths = [directory_path / name for name in ("base-1.json", "base-2.json", "head-1.json", "head-2.json")]
             for path, value in zip(paths, (base, base, head, head)):
                 path.write_text(json.dumps(value), encoding="utf-8")
+            environment = os.environ.copy()
+            environment.pop("GITHUB_ACTIONS", None)
+            environment.pop("GITHUB_STEP_SUMMARY", None)
             return subprocess.run(
                 [
                     sys.executable,
@@ -40,11 +45,14 @@ class CompareBenchmarksTest(unittest.TestCase):
                 text=True,
                 capture_output=True,
                 check=False,
+                env=environment,
             )
 
     def test_equal_results_pass(self):
         benchmark = [result("example.Scenario.run", 100.0, 1_000.0)]
-        self.assertEqual(0, self.compare(benchmark, benchmark).returncode)
+        comparison = self.compare(benchmark, benchmark)
+        self.assertEqual(0, comparison.returncode)
+        self.assertIn("✅ Performance regression gate passed", comparison.stdout)
 
     def test_time_regression_fails(self):
         comparison = self.compare(
@@ -52,6 +60,7 @@ class CompareBenchmarksTest(unittest.TestCase):
             [result("example.Scenario.run", 116.0, 1_000.0)],
         )
         self.assertEqual(1, comparison.returncode)
+        self.assertIn("❌ Performance regression gate failed", comparison.stdout)
         self.assertIn("time increased", comparison.stdout)
 
     def test_material_allocation_regression_fails(self):
@@ -84,6 +93,17 @@ class CompareBenchmarksTest(unittest.TestCase):
         )
         self.assertEqual(2, comparison.returncode)
         self.assertIn("Non-finite metric", comparison.stderr)
+
+    def test_test_comparisons_do_not_write_the_github_summary(self):
+        benchmark = [result("example.Scenario.run", 100.0, 1_000.0)]
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            with patch.dict(
+                os.environ,
+                {"GITHUB_ACTIONS": "true", "GITHUB_STEP_SUMMARY": str(summary)},
+            ):
+                self.assertEqual(0, self.compare(benchmark, benchmark).returncode)
+            self.assertFalse(summary.exists())
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run-performance-regression.sh
+++ b/.github/scripts/run-performance-regression.sh
@@ -43,7 +43,7 @@ run_jmh() {
     local output="$2"
     local log_file="${output%.json}.log"
     if ! java -jar "${jar}" '.*HotPathBenchmark.*' \
-            -t 1 -f 1 -wi 2 -i 3 -w 400ms -r 600ms \
+            -t 1 -f 1 \
             -prof gc -rf json -rff "${output}" >"${log_file}" 2>&1; then
         cat "${log_file}" >&2
         return 1

--- a/.github/scripts/run-performance-regression.sh
+++ b/.github/scripts/run-performance-regression.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(git rev-parse --show-toplevel)"
+base_sha="${PERFORMANCE_BASE_SHA:-}"
+if [[ -z "${base_sha}" ]]; then
+    echo "PERFORMANCE_BASE_SHA must contain the pull request base commit" >&2
+    exit 2
+fi
+
+work_dir="$(mktemp -d)"
+base_worktree="${work_dir}/base-worktree"
+cleanup() {
+    if [[ -d "${base_worktree}" ]]; then
+        git -C "${root_dir}" worktree remove --force "${base_worktree}" >/dev/null 2>&1 || true
+    fi
+    rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+echo "Preparing benchmark jars for base ${base_sha} and head $(git -C "${root_dir}" rev-parse HEAD)"
+git -C "${root_dir}" worktree add --detach "${base_worktree}" "${base_sha}"
+
+(
+    cd "${base_worktree}"
+    ./mvnw -q -pl sdk -am -DskipTests install
+)
+(
+    cd "${root_dir}"
+    ./mvnw -q -f benchmarks/pom.xml -DskipTests clean package
+)
+cp "${root_dir}/benchmarks/target/fluxzero-benchmarks.jar" "${work_dir}/base.jar"
+
+(
+    cd "${root_dir}"
+    ./mvnw -q -pl sdk -am -DskipTests install
+    ./mvnw -q -f benchmarks/pom.xml -DskipTests clean package
+)
+cp "${root_dir}/benchmarks/target/fluxzero-benchmarks.jar" "${work_dir}/head.jar"
+
+run_jmh() {
+    local jar="$1"
+    local output="$2"
+    local log_file="${output%.json}.log"
+    if ! java -jar "${jar}" '.*HotPathBenchmark.*' \
+            -t 1 -f 1 -wi 2 -i 3 -w 400ms -r 600ms \
+            -prof gc -rf json -rff "${output}" >"${log_file}" 2>&1; then
+        cat "${log_file}" >&2
+        return 1
+    fi
+}
+
+echo "Running scenarios in ABBA order"
+run_jmh "${work_dir}/base.jar" "${work_dir}/base-1.json"
+run_jmh "${work_dir}/head.jar" "${work_dir}/head-1.json"
+run_jmh "${work_dir}/head.jar" "${work_dir}/head-2.json"
+run_jmh "${work_dir}/base.jar" "${work_dir}/base-2.json"
+
+python3 "${root_dir}/.github/scripts/compare-benchmarks.py" \
+    --base "${work_dir}/base-1.json" --base "${work_dir}/base-2.json" \
+    --head "${work_dir}/head-1.json" --head "${work_dir}/head-2.json" \
+    --time-threshold "${PERFORMANCE_TIME_THRESHOLD:-0.15}" \
+    --allocation-threshold "${PERFORMANCE_ALLOCATION_THRESHOLD:-0.15}" \
+    --allocation-min-bytes "${PERFORMANCE_ALLOCATION_MIN_BYTES:-256}"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -8,7 +8,8 @@ env:
   BUILD_ENVIRONMENT: github
 
 jobs:
-  build-pr:
+  maven-build:
+    name: Maven build
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
@@ -26,3 +27,44 @@ jobs:
 
       - name: Run Maven build
         run: ./mvnw -B install
+
+  performance-apk:
+    name: Performance APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          cache: 'maven'
+
+      - name: Test performance comparison gate
+        run: python3 .github/scripts/compare-benchmarks.test.py
+
+      - name: Compare hot-path scenarios with the PR base
+        env:
+          PERFORMANCE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: .github/scripts/run-performance-regression.sh
+
+  build-pr:
+    if: always()
+    needs: [maven-build, performance-apk]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require build and performance APK
+        env:
+          MAVEN_RESULT: ${{ needs.maven-build.result }}
+          PERFORMANCE_RESULT: ${{ needs.performance-apk.result }}
+        run: |
+          if [[ "$MAVEN_RESULT" != "success" || "$PERFORMANCE_RESULT" != "success" ]]; then
+            echo "Maven build: $MAVEN_RESULT"
+            echo "Performance APK: $PERFORMANCE_RESULT"
+            exit 1
+          fi

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Install Java and Maven
         uses: actions/setup-java@v5

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
   performance-regression:
     name: Performance regression gate
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Run Maven build
         run: ./mvnw -B install
 
-  performance-apk:
-    name: Performance APK
+  performance-regression:
+    name: Performance regression gate
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -55,16 +55,16 @@ jobs:
 
   build-pr:
     if: always()
-    needs: [maven-build, performance-apk]
+    needs: [maven-build, performance-regression]
     runs-on: ubuntu-latest
     steps:
-      - name: Require build and performance APK
+      - name: Require build and performance regression gate
         env:
           MAVEN_RESULT: ${{ needs.maven-build.result }}
-          PERFORMANCE_RESULT: ${{ needs.performance-apk.result }}
+          PERFORMANCE_RESULT: ${{ needs.performance-regression.result }}
         run: |
           if [[ "$MAVEN_RESULT" != "success" || "$PERFORMANCE_RESULT" != "success" ]]; then
             echo "Maven build: $MAVEN_RESULT"
-            echo "Performance APK: $PERFORMANCE_RESULT"
+            echo "Performance regression gate: $PERFORMANCE_RESULT"
             exit 1
           fi

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,18 @@
+# Fluxzero CI performance scenarios
+
+This module contains a small set of application-shaped JMH scenarios. They are intentionally broad: a failure says
+that a representative SDK hot path regressed, not which internal unit caused it.
+
+The scenarios cover outbound dispatch, local command handling, tracking handling, and an event-sourced aggregate
+lifecycle. Network and external storage are replaced with deterministic in-memory boundaries so GitHub-hosted runners
+measure SDK work instead of I/O variance.
+
+Build and run the scenarios locally with:
+
+```shell
+./mvnw -Pbenchmarks -pl benchmarks -am -DskipTests package
+java -jar benchmarks/target/fluxzero-benchmarks.jar -prof gc
+```
+
+The pull-request job builds the same benchmark sources against the pull-request base and the proposed SDK, runs the resulting
+jars in ABBA order on one runner, and blocks material time or allocation regressions.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,8 @@
 This module contains a small set of application-shaped JMH scenarios. They are intentionally broad: a failure says
 that a representative SDK hot path regressed, not which internal unit caused it.
 
-The scenarios cover outbound dispatch, local command handling, tracking handling, and an event-sourced aggregate
+The scenarios cover outbound dispatch; local command, self-query, and standalone query handling; self-tracked,
+standalone, and stateful tracked handling; entity injection in tracked event handlers; and an event-sourced aggregate
 lifecycle. Network and external storage are replaced with deterministic in-memory boundaries so GitHub-hosted runners
 measure SDK work instead of I/O variance.
 
@@ -11,7 +12,14 @@ Reported time and allocation are normalized to one representative operation:
 
 - outbound dispatch: one event within a 32-event batch;
 - local command handling: one command through the public gateway and default local handler stack;
-- tracking handling: one message within a 32-message batch;
+- local self handling: one query whose payload contains a no-argument `@HandleQuery` method;
+- local standalone handling: one query routed to a multi-method local query handler;
+- self-tracked command handling: one concrete command handled by an `@HandleCommand` method on its `@TrackSelf`
+  interface, within a 32-command batch;
+- standalone tracked command handling: one command routed to a multi-method handler within a 32-command batch;
+- standalone tracked event handling: one event routed to a multi-method, multi-parameter handler that injects either
+  `Entity<T>` or `T`, within a 32-event batch;
+- mixed tracking handling: one message handled by standalone and `@Stateful` handlers within a 32-message batch;
 - aggregate lifecycle: one load that replays 50 events, applies three new events, and commits them.
 
 Build and run the scenarios locally with:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,6 +7,13 @@ The scenarios cover outbound dispatch, local command handling, tracking handling
 lifecycle. Network and external storage are replaced with deterministic in-memory boundaries so GitHub-hosted runners
 measure SDK work instead of I/O variance.
 
+Reported time and allocation are normalized to one representative operation:
+
+- outbound dispatch: one event within a 32-event batch;
+- local command handling: one command through the public gateway and default local handler stack;
+- tracking handling: one message within a 32-message batch;
+- aggregate lifecycle: one load that replays 50 events, applies three new events, and commits them.
+
 Build and run the scenarios locally with:
 
 ```shell

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,12 +14,10 @@ Reported time and allocation are normalized to one representative operation:
 - local command handling: one command through the public gateway and default local handler stack;
 - local self handling: one query whose payload contains a no-argument `@HandleQuery` method;
 - local standalone handling: one query routed to a multi-method local query handler;
-- self-tracked command handling: one concrete command handled by an `@HandleCommand` method on its `@TrackSelf`
-  interface, within a 32-command batch;
-- standalone tracked command handling: one command routed to a multi-method handler within a 32-command batch;
-- standalone tracked event handling: one event routed to a multi-method, multi-parameter handler that injects either
-  `Entity<T>` or `T`, within a 32-event batch;
-- mixed tracking handling: one message handled by standalone and `@Stateful` handlers within a 32-message batch;
+- tracked handling routes: one message across four 32-message batches: a self-tracked command whose `@TrackSelf`
+  interface carries `@HandleCommand`; a standalone command routed to a multi-method handler; a standalone event routed
+  to a multi-method, multi-parameter handler that injects either `Entity<T>` or `T`; and the original mixed standalone
+  plus `@Stateful` event-handler scenario;
 - aggregate lifecycle: one load that replays 50 events, applies three new events, and commits them.
 
 Build and run the scenarios locally with:

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.fluxzero</groupId>
+        <artifactId>fluxzero-sdk-java</artifactId>
+        <version>0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>benchmarks</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>CI performance scenarios for the Fluxzero Java SDK.</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.fluxzero</groupId>
+            <artifactId>sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>fluxzero-benchmarks</finalName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -111,6 +112,7 @@ public class ApplicationHotPathBenchmark {
      * monitoring, and the low-level client boundary. The sink deliberately performs no transport I/O.
      */
     @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
     public long outboundDispatch() {
         eventGateway.publish(Guarantee.NONE, dispatchEvents).join();
         return sink.checksum();
@@ -121,6 +123,7 @@ public class ApplicationHotPathBenchmark {
      * and already-completed asynchronous handler results are represented.
      */
     @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
     public long localCommandHandling() {
         long result = 0L;
         for (Object command : localCommands) {

--- a/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.benchmark;
+
+import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.Registration;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.configuration.DefaultFluxzero;
+import io.fluxzero.sdk.configuration.client.Client;
+import io.fluxzero.sdk.configuration.client.ClientDispatchMonitor;
+import io.fluxzero.sdk.configuration.client.LocalClient;
+import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
+import io.fluxzero.sdk.persisting.keyvalue.client.KeyValueClient;
+import io.fluxzero.sdk.persisting.search.client.SearchClient;
+import io.fluxzero.sdk.publishing.CommandGateway;
+import io.fluxzero.sdk.publishing.EventGateway;
+import io.fluxzero.sdk.publishing.client.GatewayClient;
+import io.fluxzero.sdk.publishing.routing.RoutingKey;
+import io.fluxzero.sdk.scheduling.client.SchedulingClient;
+import io.fluxzero.sdk.tracking.client.TrackingClient;
+import io.fluxzero.sdk.tracking.handling.HandleCommand;
+import io.fluxzero.sdk.tracking.handling.LocalHandler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/** Application-shaped dispatch and local command scenarios used by the pull-request performance gate. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
+public class ApplicationHotPathBenchmark {
+    private static final int BATCH_SIZE = 32;
+
+    private final Object[] dispatchEvents = createDispatchEvents();
+    private final Object[] localCommands = createLocalCommands();
+
+    private SinkGatewayClient sink;
+    private Fluxzero dispatchFluxzero;
+    private Fluxzero localFluxzero;
+    private EventGateway eventGateway;
+    private CommandGateway commandGateway;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        sink = new SinkGatewayClient();
+        dispatchFluxzero = DefaultFluxzero.builder()
+                .disableAutomaticTracking()
+                .disableShutdownHook()
+                .build(new SinkClient(LocalClient.newInstance(Duration.ofMinutes(5)), sink));
+        eventGateway = dispatchFluxzero.eventGateway();
+
+        localFluxzero = DefaultFluxzero.builder()
+                .disableAutomaticTracking()
+                .disableShutdownHook()
+                .build(LocalClient.newInstance(Duration.ofMinutes(5)));
+        commandGateway = localFluxzero.commandGateway();
+        commandGateway.registerHandler(new MixedCommandHandler());
+
+        long checksumBefore = sink.checksum();
+        outboundDispatch();
+        if (sink.checksum() <= checksumBefore || sink.lastBatchSize() != BATCH_SIZE) {
+            throw new IllegalStateException("Outbound dispatch did not reach the serialized-message sink");
+        }
+        long commandResult = localCommandHandling();
+        if (commandResult != 640L) {
+            throw new IllegalStateException("Unexpected local command result: " + commandResult);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        localFluxzero.close();
+        dispatchFluxzero.close();
+    }
+
+    /**
+     * Dispatches a mixed event batch through message construction, dispatch interceptors, routing, serialization,
+     * monitoring, and the low-level client boundary. The sink deliberately performs no transport I/O.
+     */
+    @Benchmark
+    public long outboundDispatch() {
+        eventGateway.publish(Guarantee.NONE, dispatchEvents).join();
+        return sink.checksum();
+    }
+
+    /**
+     * Handles a mixed command batch through the public local gateway and its default interceptor stack. Both regular
+     * and already-completed asynchronous handler results are represented.
+     */
+    @Benchmark
+    public long localCommandHandling() {
+        long result = 0L;
+        for (Object command : localCommands) {
+            CommandResult commandResult = commandGateway.sendAndWait(command);
+            result += commandResult.value();
+        }
+        return result;
+    }
+
+    private static Object[] createDispatchEvents() {
+        Object[] result = new Object[BATCH_SIZE];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = switch (i & 3) {
+                case 0 -> new OrderAccepted("order-" + (i & 7), i, "accepted");
+                case 1 -> new PaymentCaptured("payment-" + (i & 7), i * 10L);
+                case 2 -> new StockReserved("stock-" + (i & 7), "item-" + i, i + 1);
+                default -> new CustomerNotified("customer-" + (i & 7), "message-" + i);
+            };
+        }
+        return result;
+    }
+
+    private static Object[] createLocalCommands() {
+        Object[] result = new Object[BATCH_SIZE];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = switch (i & 7) {
+                case 0 -> new CreateOrder(i);
+                case 1 -> new AmendOrder(i);
+                case 2 -> new ApproveOrder(i);
+                case 3 -> new RejectOrder(i);
+                case 4 -> new CapturePayment(i);
+                case 5 -> new RefundPayment(i);
+                case 6 -> new ReserveStock(i);
+                default -> new ReleaseStock(i);
+            };
+        }
+        return result;
+    }
+
+    record OrderAccepted(@RoutingKey String orderId, int lineCount, String status) {
+    }
+
+    record PaymentCaptured(@RoutingKey String paymentId, long amount) {
+    }
+
+    record StockReserved(@RoutingKey String reservationId, String itemId, int quantity) {
+    }
+
+    record CustomerNotified(@RoutingKey String customerId, String text) {
+    }
+
+    record CreateOrder(int value) {
+    }
+
+    record AmendOrder(int value) {
+    }
+
+    record ApproveOrder(int value) {
+    }
+
+    record RejectOrder(int value) {
+    }
+
+    record CapturePayment(int value) {
+    }
+
+    record RefundPayment(int value) {
+    }
+
+    record ReserveStock(int value) {
+    }
+
+    record ReleaseStock(int value) {
+    }
+
+    record CommandResult(long value) {
+    }
+
+    @LocalHandler
+    static class MixedCommandHandler {
+        @HandleCommand
+        CommandResult handle(CreateOrder command) {
+            return new CommandResult(command.value() + 1L);
+        }
+
+        @HandleCommand
+        CommandResult handle(AmendOrder command) {
+            return new CommandResult(command.value() + 2L);
+        }
+
+        @HandleCommand
+        CompletionStage<CommandResult> handle(ApproveOrder command) {
+            return CompletableFuture.completedFuture(new CommandResult(command.value() + 3L));
+        }
+
+        @HandleCommand
+        CommandResult handle(RejectOrder command) {
+            return new CommandResult(command.value() + 4L);
+        }
+
+        @HandleCommand
+        CommandResult handle(CapturePayment command) {
+            return new CommandResult(command.value() + 5L);
+        }
+
+        @HandleCommand
+        CompletionStage<CommandResult> handle(RefundPayment command) {
+            return CompletableFuture.completedFuture(new CommandResult(command.value() + 6L));
+        }
+
+        @HandleCommand
+        CommandResult handle(ReserveStock command) {
+            return new CommandResult(command.value() + 7L);
+        }
+
+        @HandleCommand
+        CommandResult handle(ReleaseStock command) {
+            return new CommandResult(command.value() + 8L);
+        }
+    }
+
+    private static class SinkGatewayClient implements GatewayClient {
+        private static final CompletableFuture<Void> COMPLETED = CompletableFuture.completedFuture(null);
+        private volatile long checksum;
+        private volatile int lastBatchSize;
+
+        @Override
+        public CompletableFuture<Void> append(Guarantee guarantee, SerializedMessage... messages) {
+            long updated = checksum;
+            for (SerializedMessage message : messages) {
+                updated += message.getBytes();
+                updated += message.getSegment() == null ? 0 : message.getSegment();
+                updated += message.getMetadata().getEntries().size();
+            }
+            checksum = updated;
+            lastBatchSize = messages.length;
+            return COMPLETED;
+        }
+
+        long checksum() {
+            return checksum;
+        }
+
+        int lastBatchSize() {
+            return lastBatchSize;
+        }
+
+        @Override
+        public Registration registerMonitor(Consumer<List<SerializedMessage>> monitor) {
+            return Registration.noOp();
+        }
+
+        @Override
+        public CompletableFuture<Void> setRetentionTime(Duration duration, Guarantee guarantee) {
+            return COMPLETED;
+        }
+
+        @Override
+        public CompletableFuture<Void> truncate(Guarantee guarantee) {
+            return COMPLETED;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /** Uses the real in-memory SDK subsystems but replaces gateway transport with a non-buffering sink. */
+    private record SinkClient(LocalClient delegate, SinkGatewayClient sink) implements Client {
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public String id() {
+            return delegate.id();
+        }
+
+        @Override
+        public String applicationId() {
+            return delegate.applicationId();
+        }
+
+        @Override
+        public String namespace() {
+            return delegate.namespace();
+        }
+
+        @Override
+        public Client forNamespace(String namespace) {
+            return this;
+        }
+
+        @Override
+        public GatewayClient getGatewayClient(MessageType messageType, String topic) {
+            return sink;
+        }
+
+        @Override
+        public Registration monitorDispatch(ClientDispatchMonitor monitor, MessageType... messageTypes) {
+            return Registration.noOp();
+        }
+
+        @Override
+        public TrackingClient getTrackingClient(MessageType messageType, String topic) {
+            return delegate.getTrackingClient(messageType, topic);
+        }
+
+        @Override
+        public EventStoreClient getEventStoreClient() {
+            return delegate.getEventStoreClient();
+        }
+
+        @Override
+        public SchedulingClient getSchedulingClient() {
+            return delegate.getSchedulingClient();
+        }
+
+        @Override
+        public KeyValueClient getKeyValueClient() {
+            return delegate.getKeyValueClient();
+        }
+
+        @Override
+        public SearchClient getSearchClient() {
+            return delegate.getSearchClient();
+        }
+
+        @Override
+        public void shutDown() {
+            sink.close();
+            delegate.shutDown();
+        }
+
+        @Override
+        public Registration beforeShutdown(Runnable task) {
+            return delegate.beforeShutdown(task);
+        }
+    }
+}

--- a/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/benchmark/ApplicationHotPathBenchmark.java
@@ -28,11 +28,13 @@ import io.fluxzero.sdk.persisting.keyvalue.client.KeyValueClient;
 import io.fluxzero.sdk.persisting.search.client.SearchClient;
 import io.fluxzero.sdk.publishing.CommandGateway;
 import io.fluxzero.sdk.publishing.EventGateway;
+import io.fluxzero.sdk.publishing.QueryGateway;
 import io.fluxzero.sdk.publishing.client.GatewayClient;
 import io.fluxzero.sdk.publishing.routing.RoutingKey;
 import io.fluxzero.sdk.scheduling.client.SchedulingClient;
 import io.fluxzero.sdk.tracking.client.TrackingClient;
 import io.fluxzero.sdk.tracking.handling.HandleCommand;
+import io.fluxzero.sdk.tracking.handling.HandleQuery;
 import io.fluxzero.sdk.tracking.handling.LocalHandler;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -55,7 +57,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-/** Application-shaped dispatch and local command scenarios used by the pull-request performance gate. */
+/** Application-shaped dispatch and local handling scenarios used by the pull-request performance gate. */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -67,12 +69,15 @@ public class ApplicationHotPathBenchmark {
 
     private final Object[] dispatchEvents = createDispatchEvents();
     private final Object[] localCommands = createLocalCommands();
+    private final SelfHandlingQuery[] selfHandlingQueries = createSelfHandlingQueries();
+    private final Object[] standaloneQueries = createStandaloneQueries();
 
     private SinkGatewayClient sink;
     private Fluxzero dispatchFluxzero;
     private Fluxzero localFluxzero;
     private EventGateway eventGateway;
     private CommandGateway commandGateway;
+    private QueryGateway queryGateway;
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -80,15 +85,19 @@ public class ApplicationHotPathBenchmark {
         dispatchFluxzero = DefaultFluxzero.builder()
                 .disableAutomaticTracking()
                 .disableShutdownHook()
+                .disableKeepalive()
                 .build(new SinkClient(LocalClient.newInstance(Duration.ofMinutes(5)), sink));
         eventGateway = dispatchFluxzero.eventGateway();
 
         localFluxzero = DefaultFluxzero.builder()
                 .disableAutomaticTracking()
                 .disableShutdownHook()
+                .disableKeepalive()
                 .build(LocalClient.newInstance(Duration.ofMinutes(5)));
         commandGateway = localFluxzero.commandGateway();
         commandGateway.registerHandler(new MixedCommandHandler());
+        queryGateway = localFluxzero.queryGateway();
+        queryGateway.registerHandler(new StandaloneQueryHandler());
 
         long checksumBefore = sink.checksum();
         outboundDispatch();
@@ -98,6 +107,14 @@ public class ApplicationHotPathBenchmark {
         long commandResult = localCommandHandling();
         if (commandResult != 640L) {
             throw new IllegalStateException("Unexpected local command result: " + commandResult);
+        }
+        long selfQueryResult = localSelfHandlingQueries();
+        if (selfQueryResult != 496L) {
+            throw new IllegalStateException("Unexpected self-handling query result: " + selfQueryResult);
+        }
+        long standaloneQueryResult = localStandaloneQueryHandling();
+        if (standaloneQueryResult != 576L) {
+            throw new IllegalStateException("Unexpected standalone query result: " + standaloneQueryResult);
         }
     }
 
@@ -133,6 +150,30 @@ public class ApplicationHotPathBenchmark {
         return result;
     }
 
+    /** Handles queries whose payload carries a conventional no-argument {@link HandleQuery} method. */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long localSelfHandlingQueries() {
+        long result = 0L;
+        for (SelfHandlingQuery query : selfHandlingQueries) {
+            QueryResult queryResult = queryGateway.sendAndWait(query);
+            result += queryResult.value();
+        }
+        return result;
+    }
+
+    /** Handles mixed query payloads through one registered local handler with several {@link HandleQuery} methods. */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long localStandaloneQueryHandling() {
+        long result = 0L;
+        for (Object query : standaloneQueries) {
+            QueryResult queryResult = queryGateway.sendAndWait(query);
+            result += queryResult.value();
+        }
+        return result;
+    }
+
     private static Object[] createDispatchEvents() {
         Object[] result = new Object[BATCH_SIZE];
         for (int i = 0; i < result.length; i++) {
@@ -158,6 +199,27 @@ public class ApplicationHotPathBenchmark {
                 case 5 -> new RefundPayment(i);
                 case 6 -> new ReserveStock(i);
                 default -> new ReleaseStock(i);
+            };
+        }
+        return result;
+    }
+
+    private static SelfHandlingQuery[] createSelfHandlingQueries() {
+        SelfHandlingQuery[] result = new SelfHandlingQuery[BATCH_SIZE];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = new SelfHandlingQuery(new QueryResult(i));
+        }
+        return result;
+    }
+
+    private static Object[] createStandaloneQueries() {
+        Object[] result = new Object[BATCH_SIZE];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = switch (i & 3) {
+                case 0 -> new FindOrder(i);
+                case 1 -> new FindPayment(i);
+                case 2 -> new FindStock(i);
+                default -> new FindCustomer(i);
             };
         }
         return result;
@@ -202,6 +264,28 @@ public class ApplicationHotPathBenchmark {
     record CommandResult(long value) {
     }
 
+    record QueryResult(long value) {
+    }
+
+    record SelfHandlingQuery(QueryResult result) {
+        @HandleQuery
+        QueryResult handle() {
+            return result;
+        }
+    }
+
+    record FindOrder(int value) {
+    }
+
+    record FindPayment(int value) {
+    }
+
+    record FindStock(int value) {
+    }
+
+    record FindCustomer(int value) {
+    }
+
     @LocalHandler
     static class MixedCommandHandler {
         @HandleCommand
@@ -242,6 +326,29 @@ public class ApplicationHotPathBenchmark {
         @HandleCommand
         CommandResult handle(ReleaseStock command) {
             return new CommandResult(command.value() + 8L);
+        }
+    }
+
+    @LocalHandler
+    static class StandaloneQueryHandler {
+        @HandleQuery
+        QueryResult handle(FindOrder query) {
+            return new QueryResult(query.value() + 1L);
+        }
+
+        @HandleQuery
+        QueryResult handle(FindPayment query) {
+            return new QueryResult(query.value() + 2L);
+        }
+
+        @HandleQuery
+        QueryResult handle(FindStock query) {
+            return new QueryResult(query.value() + 3L);
+        }
+
+        @HandleQuery
+        QueryResult handle(FindCustomer query) {
+            return new QueryResult(query.value() + 4L);
         }
     }
 

--- a/benchmarks/src/main/java/io/fluxzero/sdk/modeling/AggregateHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/modeling/AggregateHotPathBenchmark.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.modeling;
+
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.handling.ParameterResolver;
+import io.fluxzero.sdk.common.Message;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
+import io.fluxzero.sdk.persisting.eventsourcing.Apply;
+import io.fluxzero.sdk.publishing.routing.MessageRoutingInterceptor;
+import io.fluxzero.sdk.publishing.routing.RoutingKey;
+import io.fluxzero.sdk.tracking.handling.Invocation;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/** A deterministic load, replay, nested apply, event staging, and commit aggregate lifecycle. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
+public class AggregateHotPathBenchmark {
+    private static final String AGGREGATE_ID = "aggregate-1";
+    private static final String BRANCH_ID = "branch-7";
+    private static final String LEAF_ID = "leaf-7-7";
+    private static final int HISTORICAL_EVENT_COUNT = 50;
+
+    private JacksonSerializer serializer;
+    private DefaultEntityHelper entityHelper;
+    private List<DeserializingMessage> historicalEvents;
+    private long commitChecksum;
+    private boolean verifyCommit;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        serializer = new JacksonSerializer();
+        List<ParameterResolver<? super DeserializingMessage>> parameterResolvers =
+                List.of(new EntityParameterResolver());
+        entityHelper = new DefaultEntityHelper(parameterResolvers, false);
+        historicalEvents = createHistoricalEvents();
+
+        verifyCommit = true;
+        aggregateLifecycle();
+        verifyCommit = false;
+    }
+
+    /**
+     * Reconstructs a nested aggregate from 50 events, applies three new events to root/branch/leaf targets, serializes
+     * and stages them, and commits through an immediately completed storage boundary.
+     */
+    @Benchmark
+    public long aggregateLifecycle() {
+        Entity<BenchmarkAggregate> aggregate = ModifiableAggregateRoot.load(
+                AGGREGATE_ID, this::replayAggregate, AggregateCommitPolicy.SYNC_AFTER_HANDLER,
+                EventPublication.ALWAYS, EventPublicationStrategy.STORE_AND_PUBLISH,
+                AggregateEventRouting.MESSAGE_ROUTING_KEY, true, entityHelper, serializer,
+                new MessageRoutingInterceptor(), this::commit);
+
+        Invocation.performInvocation(() -> {
+            aggregate.apply(new RootUpdated(AGGREGATE_ID, 101));
+            aggregate.apply(new BranchUpdated(BRANCH_ID, 102));
+            aggregate.apply(new LeafUpdated(LEAF_ID, "current"));
+            return null;
+        });
+        return commitChecksum + aggregate.get().version();
+    }
+
+    private Entity<BenchmarkAggregate> replayAggregate() {
+        Entity<BenchmarkAggregate> model = ImmutableAggregateRoot.<BenchmarkAggregate>builder()
+                .id(AGGREGATE_ID)
+                .idProperty("id")
+                .type(BenchmarkAggregate.class)
+                .value(createAggregate())
+                .entityHelper(entityHelper)
+                .serializer(serializer)
+                .sequenceNumber(0L)
+                .build();
+
+        boolean wasLoading = Entity.isLoading();
+        Map<?, String> previousRouteCache = new LinkedHashMap<>(ImmutableEntity.snapshotLoadingRouteCache());
+        Map<?, ?> previousEntityCache = new LinkedHashMap<>(AnnotatedEntityHolder.snapshotLoadingEntityCache());
+        Map<?, ?> previousRouteValuesCache =
+                new LinkedHashMap<>(AnnotatedEntityHolder.snapshotLoadingRouteValuesCache());
+        try {
+            Entity.loading.set(true);
+            ImmutableEntity.clearLoadingRouteCache();
+            AnnotatedEntityHolder.clearLoadingEntityCache();
+            AnnotatedEntityHolder.clearLoadingRouteValuesCache();
+            for (DeserializingMessage event : historicalEvents) {
+                model = model.apply(event);
+            }
+            return model;
+        } finally {
+            AnnotatedEntityHolder.restoreLoadingRouteValuesCache(previousRouteValuesCache);
+            AnnotatedEntityHolder.restoreLoadingEntityCache(previousEntityCache);
+            ImmutableEntity.restoreLoadingRouteCache(previousRouteCache);
+            Entity.loading.set(wasLoading);
+        }
+    }
+
+    private CompletableFuture<Void> commit(
+            Entity<?> model, List<AppliedEvent> unpublished, Entity<?> beforeUpdate) {
+        if (verifyCommit) {
+            verifyCommittedModel(model, unpublished);
+        }
+        long updated = commitChecksum + model.sequenceNumber();
+        for (AppliedEvent event : unpublished) {
+            updated += event.getEvent().getSerializedObject().getBytes();
+            updated += event.getPublicationStrategy().ordinal();
+        }
+        commitChecksum = updated;
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private static void verifyCommittedModel(Entity<?> model, List<AppliedEvent> unpublished) {
+        BenchmarkAggregate aggregate = (BenchmarkAggregate) model.get();
+        BenchmarkBranch branch = aggregate.branches().stream()
+                .filter(candidate -> BRANCH_ID.equals(candidate.branchId())).findFirst().orElseThrow();
+        BenchmarkLeaf leaf = branch.leaves().stream()
+                .filter(candidate -> LEAF_ID.equals(candidate.leafId())).findFirst().orElseThrow();
+        if (unpublished.size() != 3 || aggregate.version() != 101 || branch.version() != 102
+            || !"current".equals(leaf.value())) {
+            throw new IllegalStateException("Aggregate scenario did not replay, apply, stage, and commit as expected");
+        }
+    }
+
+    private List<DeserializingMessage> createHistoricalEvents() {
+        List<DeserializingMessage> result = new ArrayList<>(HISTORICAL_EVENT_COUNT);
+        for (int i = 0; i < HISTORICAL_EVENT_COUNT; i++) {
+            Object event = switch (i % 3) {
+                case 0 -> new RootUpdated(AGGREGATE_ID, i);
+                case 1 -> new BranchUpdated(BRANCH_ID, i);
+                default -> new LeafUpdated(LEAF_ID, "historical-" + i);
+            };
+            result.add(new DeserializingMessage(new Message(event), MessageType.EVENT, serializer));
+        }
+        return List.copyOf(result);
+    }
+
+    private static BenchmarkAggregate createAggregate() {
+        List<BenchmarkBranch> branches = new ArrayList<>(8);
+        for (int branch = 0; branch < 8; branch++) {
+            List<BenchmarkLeaf> leaves = new ArrayList<>(8);
+            for (int leaf = 0; leaf < 8; leaf++) {
+                leaves.add(new BenchmarkLeaf("leaf-" + branch + "-" + leaf, "value-" + leaf));
+            }
+            branches.add(new BenchmarkBranch("branch-" + branch, List.copyOf(leaves), 0));
+        }
+        return new BenchmarkAggregate(AGGREGATE_ID, List.copyOf(branches), 0);
+    }
+
+    @Aggregate(cached = false)
+    record BenchmarkAggregate(@EntityId String id, @Member List<BenchmarkBranch> branches, int version) {
+    }
+
+    record BenchmarkBranch(@EntityId String branchId, @Member List<BenchmarkLeaf> leaves, int version) {
+    }
+
+    record BenchmarkLeaf(@EntityId String leafId, String value) {
+    }
+
+    record RootUpdated(@RoutingKey String aggregateId, int version) {
+        @Apply
+        BenchmarkAggregate apply(BenchmarkAggregate aggregate) {
+            return new BenchmarkAggregate(aggregate.id(), aggregate.branches(), version);
+        }
+    }
+
+    record BranchUpdated(@RoutingKey String branchId, int version) {
+        @Apply
+        BenchmarkBranch apply(BenchmarkBranch branch) {
+            return new BenchmarkBranch(branch.branchId(), branch.leaves(), version);
+        }
+    }
+
+    record LeafUpdated(@RoutingKey String leafId, String value) {
+        @Apply
+        BenchmarkLeaf apply(BenchmarkLeaf leaf) {
+            return new BenchmarkLeaf(leaf.leafId(), value);
+        }
+    }
+}

--- a/benchmarks/src/main/java/io/fluxzero/sdk/modeling/AggregateHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/modeling/AggregateHotPathBenchmark.java
@@ -46,8 +46,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
 public class AggregateHotPathBenchmark {
     private static final String AGGREGATE_ID = "aggregate-1";

--- a/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
@@ -14,23 +14,39 @@
 
 package io.fluxzero.sdk.tracking;
 
+import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
+import io.fluxzero.common.Registration;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.handling.Handler;
 import io.fluxzero.common.handling.HandlerFilter;
 import io.fluxzero.common.handling.MethodInvocationValidator;
 import io.fluxzero.common.handling.ParameterResolver;
+import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.Entry;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
+import io.fluxzero.sdk.configuration.DefaultFluxzero;
+import io.fluxzero.sdk.configuration.client.Client;
+import io.fluxzero.sdk.configuration.client.ClientDispatchMonitor;
+import io.fluxzero.sdk.configuration.client.LocalClient;
+import io.fluxzero.sdk.modeling.Aggregate;
+import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.EntityParameterResolver;
 import io.fluxzero.sdk.modeling.HandlerRepository;
+import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
+import io.fluxzero.sdk.persisting.keyvalue.client.KeyValueClient;
+import io.fluxzero.sdk.persisting.search.client.SearchClient;
+import io.fluxzero.sdk.publishing.client.GatewayClient;
 import io.fluxzero.sdk.publishing.dataprotection.DataProtectionInterceptor;
 import io.fluxzero.sdk.publishing.dataprotection.MissingProtectedDataPolicy;
+import io.fluxzero.sdk.scheduling.client.SchedulingClient;
+import io.fluxzero.sdk.tracking.client.TrackingClient;
 import io.fluxzero.sdk.tracking.handling.Association;
 import io.fluxzero.sdk.tracking.handling.DefaultHandlerFactory;
+import io.fluxzero.sdk.tracking.handling.HandleCommand;
 import io.fluxzero.sdk.tracking.handling.HandleEvent;
 import io.fluxzero.sdk.tracking.handling.HandlerDecorator;
 import io.fluxzero.sdk.tracking.handling.JsonPayloadParameterResolver;
@@ -58,6 +74,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -66,8 +83,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
 
-/** A received-event batch flowing through deserialization, tracking contexts, and mixed handler types. */
+/** Application-shaped tracked handling scenarios used by the pull-request performance gate. */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -76,22 +95,207 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
 public class TrackingHotPathBenchmark {
     private static final int BATCH_SIZE = 32;
+    private static final int AGGREGATE_COUNT = 8;
 
     private JacksonSerializer serializer;
-    private DefaultTracking tracking;
-    private ConsumerConfiguration configuration;
-    private List<SerializedMessage> serializedMessages;
-    private List<Handler<DeserializingMessage>> handlers;
+    private Fluxzero fluxzero;
+    private MetricsSinkGatewayClient metricsSink;
+    private DefaultTracking eventTracking;
+    private DefaultTracking commandTracking;
+
+    private ConsumerConfiguration statefulEventConfiguration;
+    private ConsumerConfiguration selfTrackedCommandConfiguration;
+    private ConsumerConfiguration standaloneCommandConfiguration;
+    private ConsumerConfiguration standaloneEventConfiguration;
+
+    private Tracker statefulEventTracker;
+    private Tracker selfTrackedCommandTracker;
+    private Tracker standaloneCommandTracker;
+    private Tracker standaloneEventTracker;
+
+    private List<SerializedMessage> statefulEventMessages;
+    private List<SerializedMessage> selfTrackedCommandMessages;
+    private List<SerializedMessage> standaloneCommandMessages;
+    private List<SerializedMessage> standaloneEventMessages;
+
+    private List<Handler<DeserializingMessage>> statefulEventHandlers;
+    private List<Handler<DeserializingMessage>> selfTrackedCommandHandlers;
+    private List<Handler<DeserializingMessage>> standaloneCommandHandlers;
+    private List<Handler<DeserializingMessage>> standaloneEventHandlers;
+
     private StatelessEventHandler statelessHandler;
     private StatefulProcessRepository statefulRepository;
+    private StandaloneCommandHandler standaloneCommandHandler;
+    private StandaloneEventHandler standaloneEventHandler;
 
     @Setup(Level.Trial)
     public void setUp() {
         serializer = new JacksonSerializer();
+        metricsSink = new MetricsSinkGatewayClient();
+        // Entity injection uses the default repository cache; its asynchronous cache-sync tracker is out of scope.
+        fluxzero = DefaultFluxzero.builder()
+                .disableAutomaticTracking()
+                .disableAutomaticAggregateCaching()
+                .disableShutdownHook()
+                .disableKeepalive()
+                .build(new MetricsSinkClient(LocalClient.newInstance(Duration.ofMinutes(5)), metricsSink));
+        seedAggregates();
+
         statefulRepository = new StatefulProcessRepository(
                 new PaymentProcess("handler-1", "process-1", 0L));
         statelessHandler = new StatelessEventHandler();
+        standaloneCommandHandler = new StandaloneCommandHandler();
+        standaloneEventHandler = new StandaloneEventHandler();
+        SelfTrackedProbe.reset();
 
+        DefaultHandlerFactory eventHandlerFactory = createHandlerFactory(MessageType.EVENT);
+        DefaultHandlerFactory commandHandlerFactory = createHandlerFactory(MessageType.COMMAND);
+
+        statefulEventHandlers = List.of(
+                createHandler(eventHandlerFactory, statelessHandler),
+                createHandler(eventHandlerFactory, PaymentProcess.class));
+        selfTrackedCommandHandlers = List.of(createHandler(commandHandlerFactory, SelfTrackedCommand.class));
+        standaloneCommandHandlers = List.of(createHandler(commandHandlerFactory, standaloneCommandHandler));
+        standaloneEventHandlers = List.of(createHandler(eventHandlerFactory, standaloneEventHandler));
+
+        eventTracking = new DefaultTracking(
+                MessageType.EVENT, null, List.of(), List.of(), serializer, eventHandlerFactory);
+        commandTracking = new DefaultTracking(
+                MessageType.COMMAND, null, List.of(), List.of(), serializer, commandHandlerFactory);
+
+        statefulEventConfiguration = configuration("benchmark-stateful-events");
+        selfTrackedCommandConfiguration = configuration("benchmark-self-tracked-commands");
+        standaloneCommandConfiguration = configuration("benchmark-standalone-commands");
+        standaloneEventConfiguration = configuration("benchmark-standalone-events");
+        statefulEventTracker = tracker(MessageType.EVENT, statefulEventConfiguration);
+        selfTrackedCommandTracker = tracker(MessageType.COMMAND, selfTrackedCommandConfiguration);
+        standaloneCommandTracker = tracker(MessageType.COMMAND, standaloneCommandConfiguration);
+        standaloneEventTracker = tracker(MessageType.EVENT, standaloneEventConfiguration);
+
+        statefulEventMessages = createStatefulEventMessages();
+        selfTrackedCommandMessages = createMessages("self-command", i -> switch (i & 3) {
+            case 0 -> new CreateSelfTrackedOrder(i);
+            case 1 -> new AmendSelfTrackedOrder(i);
+            case 2 -> new ApproveSelfTrackedOrder(i);
+            default -> new CancelSelfTrackedOrder(i);
+        }, false);
+        standaloneCommandMessages = createMessages("standalone-command", i -> switch (i & 3) {
+            case 0 -> new CreateTrackedOrder(i);
+            case 1 -> new AmendTrackedOrder(i);
+            case 2 -> new ApproveTrackedOrder(i);
+            default -> new CancelTrackedOrder(i);
+        }, false);
+        standaloneEventMessages = createMessages("standalone-event", i -> switch (i & 3) {
+            case 0 -> new OrderShipped(i);
+            case 1 -> new PaymentSettled(i);
+            case 2 -> new StockAdjusted(i);
+            default -> new CustomerNotified(i);
+        }, true);
+
+        verifyScenarios();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        commandTracking.close();
+        eventTracking.close();
+        fluxzero.close(true);
+    }
+
+    /**
+     * Preserves the original mixed tracked-event scenario: a multi-method standalone handler plus a
+     * {@link Stateful} handler repository, with synchronous and already-completed asynchronous results.
+     */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long statefulAndStandaloneTrackedEventHandling() {
+        handleBatch(eventTracking, statefulEventMessages, statefulEventHandlers,
+                    statefulEventConfiguration, statefulEventTracker);
+        return statelessHandler.invocations + statefulRepository.total();
+    }
+
+    /** Handles concrete tracked commands through a {@link TrackSelf} interface carrying the handler method. */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long selfTrackedCommandHandling() {
+        handleBatch(commandTracking, selfTrackedCommandMessages, selfTrackedCommandHandlers,
+                    selfTrackedCommandConfiguration, selfTrackedCommandTracker);
+        return SelfTrackedProbe.checksum;
+    }
+
+    /** Handles mixed tracked commands through one standalone handler with several {@link HandleCommand} methods. */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long standaloneTrackedCommandHandling() {
+        handleBatch(commandTracking, standaloneCommandMessages, standaloneCommandHandlers,
+                    standaloneCommandConfiguration, standaloneCommandTracker);
+        return standaloneCommandHandler.checksum;
+    }
+
+    /**
+     * Handles mixed tracked events through a multi-method standalone handler. Each method resolves several context
+     * parameters and injects either {@code Entity<TrackedAccount>} or {@code TrackedAccount}.
+     */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public long standaloneTrackedEventHandling() {
+        handleBatch(eventTracking, standaloneEventMessages, standaloneEventHandlers,
+                    standaloneEventConfiguration, standaloneEventTracker);
+        return standaloneEventHandler.checksum;
+    }
+
+    private void handleBatch(DefaultTracking tracking, List<SerializedMessage> serializedMessages,
+                             List<Handler<DeserializingMessage>> handlers, ConsumerConfiguration configuration,
+                             Tracker tracker) {
+        fluxzero.apply(ignored -> {
+            Tracker previous = Tracker.current.get();
+            Tracker.current.set(tracker);
+            try {
+                List<DeserializingMessage> messages = tracking.deserializeMessageList(
+                        serializedMessages, null, null, new ConcurrentHashMap<>(), BATCH_SIZE);
+                tracking.handleBatch(messages, handlers, configuration, false);
+            } finally {
+                if (previous == null) {
+                    Tracker.current.remove();
+                } else {
+                    Tracker.current.set(previous);
+                }
+            }
+            return null;
+        });
+    }
+
+    private void verifyScenarios() {
+        long statelessBefore = statelessHandler.invocations;
+        long statefulBefore = statefulRepository.total();
+        statefulAndStandaloneTrackedEventHandling();
+        if (statelessHandler.invocations <= statelessBefore || statefulRepository.total() <= statefulBefore) {
+            throw new IllegalStateException("Stateful tracking scenario did not invoke both handler types");
+        }
+
+        long selfTrackedBefore = SelfTrackedProbe.checksum;
+        selfTrackedCommandHandling();
+        if (SelfTrackedProbe.checksum <= selfTrackedBefore) {
+            throw new IllegalStateException("Self-tracked command scenario did not invoke the interface handler");
+        }
+
+        long standaloneCommandBefore = standaloneCommandHandler.checksum;
+        standaloneTrackedCommandHandling();
+        if (standaloneCommandHandler.checksum <= standaloneCommandBefore) {
+            throw new IllegalStateException("Standalone tracked command scenario did not invoke its handler");
+        }
+
+        long standaloneEventBefore = standaloneEventHandler.checksum;
+        long metricsBefore = metricsSink.checksum();
+        standaloneTrackedEventHandling();
+        if (standaloneEventHandler.checksum <= standaloneEventBefore
+            || standaloneEventHandler.entityInvocations != BATCH_SIZE || metricsSink.checksum() <= metricsBefore) {
+            throw new IllegalStateException(
+                    "Standalone tracked event scenario did not inject every entity and publish handler metrics");
+        }
+    }
+
+    private DefaultHandlerFactory createHandlerFactory(MessageType messageType) {
         List<ParameterResolver<? super DeserializingMessage>> parameterResolvers = List.of(
                 new TriggerParameterResolver(null, null), new MessageParameterResolver(),
                 new MetadataParameterResolver(), new TimestampParameterResolver(), new PayloadParameterResolver(),
@@ -101,60 +305,59 @@ public class TrackingHotPathBenchmark {
                 .andThen(new DataProtectionInterceptor(
                         null, serializer, MissingProtectedDataPolicy.HANDLE, true))
                 .andThen(new ContentFilterInterceptor(serializer));
-        DefaultHandlerFactory handlerFactory = new DefaultHandlerFactory(
-                MessageType.EVENT, handlerStack, parameterResolvers, MethodInvocationValidator.noOp(),
+        return new DefaultHandlerFactory(
+                messageType, handlerStack, parameterResolvers, MethodInvocationValidator.noOp(),
                 ignored -> statefulRepository, new InMemoryRepositoryProvider(), true, serializer);
+    }
 
-        handlers = List.of(
-                handlerFactory.createHandler(statelessHandler, HandlerFilter.ALWAYS_HANDLE, List.of()).orElseThrow(),
-                handlerFactory.createHandler(PaymentProcess.class, HandlerFilter.ALWAYS_HANDLE, List.of())
-                        .orElseThrow());
-        tracking = new DefaultTracking(
-                MessageType.EVENT, null, List.of(), List.of(), serializer, handlerFactory);
-        configuration = ConsumerConfiguration.builder()
-                .name("benchmark-tracking")
+    private static Handler<DeserializingMessage> createHandler(DefaultHandlerFactory factory, Object target) {
+        return factory.createHandler(target, HandlerFilter.ALWAYS_HANDLE, List.of()).orElseThrow();
+    }
+
+    private static ConsumerConfiguration configuration(String name) {
+        return ConsumerConfiguration.builder()
+                .name(name)
                 .handlingMode(ConsumerHandlingMode.SYNC)
                 .awaitAsyncResults(true)
                 .build();
-        serializedMessages = createMessages();
-
-        long statelessBefore = statelessHandler.invocations;
-        long statefulBefore = statefulRepository.total();
-        trackingHandling();
-        if (statelessHandler.invocations <= statelessBefore || statefulRepository.total() <= statefulBefore) {
-            throw new IllegalStateException("Tracking scenario did not invoke both stateless and stateful handlers");
-        }
     }
 
-    @TearDown(Level.Trial)
-    public void tearDown() {
-        tracking.close();
+    private static Tracker tracker(MessageType messageType, ConsumerConfiguration configuration) {
+        return new Tracker(configuration.getName(), messageType, null, configuration, null);
     }
 
-    /**
-     * Deserializes and handles one batch containing synchronous, completed-asynchronous, and stateful event handlers.
-     * Result publication and external position storage are disabled; both would measure an I/O boundary instead.
-     */
-    @Benchmark
-    @OperationsPerInvocation(BATCH_SIZE)
-    public long trackingHandling() {
-        List<DeserializingMessage> messages = tracking.deserializeMessageList(
-                serializedMessages, null, null, new ConcurrentHashMap<>(), BATCH_SIZE);
-        tracking.handleBatch(messages, handlers, configuration, false);
-        return statelessHandler.invocations + statefulRepository.total();
+    private void seedAggregates() {
+        fluxzero.apply(fc -> {
+            for (int i = 0; i < AGGREGATE_COUNT; i++) {
+                String id = "account-" + i;
+                long balance = 1_000L + i;
+                fc.aggregateRepository().load(id, TrackedAccount.class)
+                        .update(ignored -> new TrackedAccount(id, balance)).commit();
+            }
+            return null;
+        });
     }
 
-    private List<SerializedMessage> createMessages() {
+    private List<SerializedMessage> createStatefulEventMessages() {
+        return createMessages("stateful-event", i -> switch (i & 3) {
+            case 0 -> new OrderObserved("order-" + (i & 7), i);
+            case 1 -> new AsyncProjectionUpdated("projection-" + (i & 7), i);
+            case 2 -> new PaymentObserved("process-1", i * 10L);
+            default -> new CustomerObserved("customer-" + (i & 7), "name-" + i);
+        }, false);
+    }
+
+    private List<SerializedMessage> createMessages(String prefix, IntFunction<Object> payloadSupplier,
+                                                    boolean includeAggregateMetadata) {
         return java.util.stream.IntStream.range(0, BATCH_SIZE).mapToObj(i -> {
-            Object payload = switch (i & 3) {
-                case 0 -> new OrderObserved("order-" + (i & 7), i);
-                case 1 -> new AsyncProjectionUpdated("projection-" + (i & 7), i);
-                case 2 -> new PaymentObserved("process-1", i * 10L);
-                default -> new CustomerObserved("customer-" + (i & 7), "name-" + i);
-            };
+            Metadata metadata = includeAggregateMetadata
+                    ? Metadata.of("benchmark", "true",
+                                  Entity.AGGREGATE_ID_METADATA_KEY, "account-" + (i & 7),
+                                  Entity.AGGREGATE_TYPE_METADATA_KEY, TrackedAccount.class.getName())
+                    : Metadata.of("benchmark", "true");
             SerializedMessage message = new SerializedMessage(
-                    serializer.serialize(payload), Metadata.of("benchmark", "true"),
-                    "tracking-message-" + i, 1_700_000_000_000L + i);
+                    serializer.serialize(payloadSupplier.apply(i)), metadata,
+                    prefix + "-" + i, 1_700_000_000_000L + i);
             message.setIndex((long) i);
             message.setSegment(i & 3);
             return message;
@@ -199,6 +402,124 @@ public class TrackingHotPathBenchmark {
         PaymentProcess handle(PaymentObserved event) {
             return new PaymentProcess(id, processId, total + event.amount());
         }
+    }
+
+    @TrackSelf
+    interface SelfTrackedCommand {
+        int value();
+
+        @HandleCommand
+        default void handle(Metadata metadata) {
+            SelfTrackedProbe.checksum += value() + metadata.getEntries().size()
+                                         + Tracker.current().orElseThrow().getName().length();
+        }
+    }
+
+    record CreateSelfTrackedOrder(int value) implements SelfTrackedCommand {
+    }
+
+    record AmendSelfTrackedOrder(int value) implements SelfTrackedCommand {
+    }
+
+    record ApproveSelfTrackedOrder(int value) implements SelfTrackedCommand {
+    }
+
+    record CancelSelfTrackedOrder(int value) implements SelfTrackedCommand {
+    }
+
+    static class SelfTrackedProbe {
+        private static long checksum;
+
+        private static void reset() {
+            checksum = 0L;
+        }
+    }
+
+    record CreateTrackedOrder(int value) {
+    }
+
+    record AmendTrackedOrder(int value) {
+    }
+
+    record ApproveTrackedOrder(int value) {
+    }
+
+    record CancelTrackedOrder(int value) {
+    }
+
+    static class StandaloneCommandHandler {
+        private long checksum;
+
+        @HandleCommand
+        void handle(CreateTrackedOrder command) {
+            checksum += command.value() + 1L;
+        }
+
+        @HandleCommand
+        void handle(AmendTrackedOrder command, Metadata metadata) {
+            checksum += command.value() + metadata.getEntries().size();
+        }
+
+        @HandleCommand
+        void handle(ApproveTrackedOrder command, DeserializingMessage message) {
+            checksum += command.value() + message.getMessageId().length();
+        }
+
+        @HandleCommand
+        void handle(CancelTrackedOrder command, Instant timestamp) {
+            checksum += command.value() + timestamp.getEpochSecond();
+        }
+    }
+
+    record OrderShipped(int value) {
+    }
+
+    record PaymentSettled(int value) {
+    }
+
+    record StockAdjusted(int value) {
+    }
+
+    record CustomerNotified(int value) {
+    }
+
+    static class StandaloneEventHandler {
+        private long checksum;
+        private long entityInvocations;
+
+        @HandleEvent
+        void handle(OrderShipped event, Entity<TrackedAccount> entity, Metadata metadata,
+                    DeserializingMessage message) {
+            checksum += event.value() + entity.get().balance() + metadata.getEntries().size()
+                        + message.getMessageId().length();
+            entityInvocations++;
+        }
+
+        @HandleEvent
+        void handle(PaymentSettled event, TrackedAccount account, Metadata metadata, Instant timestamp) {
+            checksum += event.value() + account.balance() + metadata.getEntries().size() + timestamp.getEpochSecond();
+            entityInvocations++;
+        }
+
+        @HandleEvent
+        void handle(StockAdjusted event, Entity<TrackedAccount> entity, Instant timestamp,
+                    DeserializingMessage message) {
+            checksum += event.value() + entity.get().balance() + timestamp.getEpochSecond()
+                        + message.getMessageId().length();
+            entityInvocations++;
+        }
+
+        @HandleEvent
+        void handle(CustomerNotified event, TrackedAccount account, Metadata metadata,
+                    DeserializingMessage message) {
+            checksum += event.value() + account.balance() + metadata.getEntries().size()
+                        + message.getMessageId().length();
+            entityInvocations++;
+        }
+    }
+
+    @Aggregate(eventSourced = false, searchable = true)
+    record TrackedAccount(@EntityId String id, long balance) {
     }
 
     private record ProcessEntry(String id, Object value) implements Entry<Object> {
@@ -254,7 +575,121 @@ public class TrackingHotPathBenchmark {
         @Override
         @SuppressWarnings("unchecked")
         public <T> Map<Object, T> getRepository(Class<T> repositoryClass) {
-            return (Map<Object, T>) repositories.computeIfAbsent(repositoryClass, ignored -> new ConcurrentHashMap<>());
+            return (Map<Object, T>) repositories.computeIfAbsent(repositoryClass,
+                                                                  ignored -> new ConcurrentHashMap<>());
+        }
+    }
+
+    private static class MetricsSinkGatewayClient implements GatewayClient {
+        private static final CompletableFuture<Void> COMPLETED = CompletableFuture.completedFuture(null);
+        private volatile long checksum;
+
+        @Override
+        public CompletableFuture<Void> append(Guarantee guarantee, SerializedMessage... messages) {
+            long updated = checksum;
+            for (SerializedMessage message : messages) {
+                updated += message.getBytes();
+                updated += message.getMetadata().getEntries().size();
+            }
+            checksum = updated;
+            return COMPLETED;
+        }
+
+        long checksum() {
+            return checksum;
+        }
+
+        @Override
+        public Registration registerMonitor(Consumer<List<SerializedMessage>> monitor) {
+            return Registration.noOp();
+        }
+
+        @Override
+        public CompletableFuture<Void> setRetentionTime(Duration duration, Guarantee guarantee) {
+            return COMPLETED;
+        }
+
+        @Override
+        public CompletableFuture<Void> truncate(Guarantee guarantee) {
+            return COMPLETED;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /** Delegates SDK storage to the local client while preventing benchmark metrics from accumulating in memory. */
+    private record MetricsSinkClient(LocalClient delegate, MetricsSinkGatewayClient metricsSink) implements Client {
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public String id() {
+            return delegate.id();
+        }
+
+        @Override
+        public String applicationId() {
+            return delegate.applicationId();
+        }
+
+        @Override
+        public String namespace() {
+            return delegate.namespace();
+        }
+
+        @Override
+        public Client forNamespace(String namespace) {
+            return new MetricsSinkClient((LocalClient) delegate.forNamespace(namespace), metricsSink);
+        }
+
+        @Override
+        public GatewayClient getGatewayClient(MessageType messageType, String topic) {
+            return messageType == MessageType.METRICS ? metricsSink : delegate.getGatewayClient(messageType, topic);
+        }
+
+        @Override
+        public Registration monitorDispatch(ClientDispatchMonitor monitor, MessageType... messageTypes) {
+            return delegate.monitorDispatch(monitor, messageTypes);
+        }
+
+        @Override
+        public TrackingClient getTrackingClient(MessageType messageType, String topic) {
+            return delegate.getTrackingClient(messageType, topic);
+        }
+
+        @Override
+        public EventStoreClient getEventStoreClient() {
+            return delegate.getEventStoreClient();
+        }
+
+        @Override
+        public SchedulingClient getSchedulingClient() {
+            return delegate.getSchedulingClient();
+        }
+
+        @Override
+        public KeyValueClient getKeyValueClient() {
+            return delegate.getKeyValueClient();
+        }
+
+        @Override
+        public SearchClient getSearchClient() {
+            return delegate.getSearchClient();
+        }
+
+        @Override
+        public void shutDown() {
+            metricsSink.close();
+            delegate.shutDown();
+        }
+
+        @Override
+        public Registration beforeShutdown(Runnable task) {
+            return delegate.beforeShutdown(task);
         }
     }
 }

--- a/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
@@ -95,6 +95,7 @@ import java.util.function.IntFunction;
 @Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
 public class TrackingHotPathBenchmark {
     private static final int BATCH_SIZE = 32;
+    private static final int TRACKED_ROUTE_COUNT = 4;
     private static final int AGGREGATE_COUNT = 8;
 
     private JacksonSerializer serializer;
@@ -203,30 +204,32 @@ public class TrackingHotPathBenchmark {
     }
 
     /**
-     * Preserves the original mixed tracked-event scenario: a multi-method standalone handler plus a
-     * {@link Stateful} handler repository, with synchronous and already-completed asynchronous results.
+     * Exercises the representative tracked handling routes as one application-shaped acceptance scenario. Combining
+     * the routes makes the regression signal less sensitive to short-lived GitHub runner noise while retaining every
+     * route-specific setup assertion.
      */
     @Benchmark
-    @OperationsPerInvocation(BATCH_SIZE)
-    public long statefulAndStandaloneTrackedEventHandling() {
-        handleBatch(eventTracking, statefulEventMessages, statefulEventHandlers,
-                    statefulEventConfiguration, statefulEventTracker);
-        return statelessHandler.invocations + statefulRepository.total();
+    @OperationsPerInvocation(BATCH_SIZE * TRACKED_ROUTE_COUNT)
+    @Warmup(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+    @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    public long trackedHandlingRoutes() {
+        selfTrackedCommandHandling();
+        standaloneTrackedCommandHandling();
+        standaloneTrackedEventHandling();
+        statefulAndStandaloneTrackedEventHandling();
+        return SelfTrackedProbe.checksum + standaloneCommandHandler.checksum + standaloneEventHandler.checksum
+               + statelessHandler.invocations + statefulRepository.total() + metricsSink.checksum();
     }
 
     /** Handles concrete tracked commands through a {@link TrackSelf} interface carrying the handler method. */
-    @Benchmark
-    @OperationsPerInvocation(BATCH_SIZE)
-    public long selfTrackedCommandHandling() {
+    private long selfTrackedCommandHandling() {
         handleBatch(commandTracking, selfTrackedCommandMessages, selfTrackedCommandHandlers,
                     selfTrackedCommandConfiguration, selfTrackedCommandTracker);
         return SelfTrackedProbe.checksum;
     }
 
     /** Handles mixed tracked commands through one standalone handler with several {@link HandleCommand} methods. */
-    @Benchmark
-    @OperationsPerInvocation(BATCH_SIZE)
-    public long standaloneTrackedCommandHandling() {
+    private long standaloneTrackedCommandHandling() {
         handleBatch(commandTracking, standaloneCommandMessages, standaloneCommandHandlers,
                     standaloneCommandConfiguration, standaloneCommandTracker);
         return standaloneCommandHandler.checksum;
@@ -236,12 +239,20 @@ public class TrackingHotPathBenchmark {
      * Handles mixed tracked events through a multi-method standalone handler. Each method resolves several context
      * parameters and injects either {@code Entity<TrackedAccount>} or {@code TrackedAccount}.
      */
-    @Benchmark
-    @OperationsPerInvocation(BATCH_SIZE)
-    public long standaloneTrackedEventHandling() {
+    private long standaloneTrackedEventHandling() {
         handleBatch(eventTracking, standaloneEventMessages, standaloneEventHandlers,
                     standaloneEventConfiguration, standaloneEventTracker);
         return standaloneEventHandler.checksum;
+    }
+
+    /**
+     * Preserves the original mixed tracked-event scenario: a multi-method standalone handler plus a
+     * {@link Stateful} handler repository, with synchronous and already-completed asynchronous results.
+     */
+    private long statefulAndStandaloneTrackedEventHandling() {
+        handleBatch(eventTracking, statefulEventMessages, statefulEventHandlers,
+                    statefulEventConfiguration, statefulEventTracker);
+        return statelessHandler.invocations + statefulRepository.total();
     }
 
     private void handleBatch(DefaultTracking tracking, List<SerializedMessage> serializedMessages,

--- a/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
@@ -50,6 +50,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -135,6 +136,7 @@ public class TrackingHotPathBenchmark {
      * Result publication and external position storage are disabled; both would measure an I/O boundary instead.
      */
     @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
     public long trackingHandling() {
         List<DeserializingMessage> messages = tracking.deserializeMessageList(
                 serializedMessages, null, null, new ConcurrentHashMap<>(), BATCH_SIZE);

--- a/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
+++ b/benchmarks/src/main/java/io/fluxzero/sdk/tracking/TrackingHotPathBenchmark.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.tracking;
+
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.common.handling.Handler;
+import io.fluxzero.common.handling.HandlerFilter;
+import io.fluxzero.common.handling.MethodInvocationValidator;
+import io.fluxzero.common.handling.ParameterResolver;
+import io.fluxzero.sdk.common.Entry;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
+import io.fluxzero.sdk.modeling.EntityId;
+import io.fluxzero.sdk.modeling.EntityParameterResolver;
+import io.fluxzero.sdk.modeling.HandlerRepository;
+import io.fluxzero.sdk.publishing.dataprotection.DataProtectionInterceptor;
+import io.fluxzero.sdk.publishing.dataprotection.MissingProtectedDataPolicy;
+import io.fluxzero.sdk.tracking.handling.Association;
+import io.fluxzero.sdk.tracking.handling.DefaultHandlerFactory;
+import io.fluxzero.sdk.tracking.handling.HandleEvent;
+import io.fluxzero.sdk.tracking.handling.HandlerDecorator;
+import io.fluxzero.sdk.tracking.handling.JsonPayloadParameterResolver;
+import io.fluxzero.sdk.tracking.handling.MessageParameterResolver;
+import io.fluxzero.sdk.tracking.handling.MetadataParameterResolver;
+import io.fluxzero.sdk.tracking.handling.PayloadParameterResolver;
+import io.fluxzero.sdk.tracking.handling.RepositoryProvider;
+import io.fluxzero.sdk.tracking.handling.Stateful;
+import io.fluxzero.sdk.tracking.handling.TimestampParameterResolver;
+import io.fluxzero.sdk.tracking.handling.TriggerParameterResolver;
+import io.fluxzero.sdk.tracking.handling.contentfiltering.ContentFilterInterceptor;
+import io.fluxzero.sdk.tracking.handling.errorreporting.ErrorReportingInterceptor;
+import io.fluxzero.sdk.tracking.metrics.HandlerMonitor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/** A received-event batch flowing through deserialization, tracking contexts, and mixed handler types. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 700, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms384m", "-Xmx384m", "-XX:+AlwaysPreTouch"})
+public class TrackingHotPathBenchmark {
+    private static final int BATCH_SIZE = 32;
+
+    private JacksonSerializer serializer;
+    private DefaultTracking tracking;
+    private ConsumerConfiguration configuration;
+    private List<SerializedMessage> serializedMessages;
+    private List<Handler<DeserializingMessage>> handlers;
+    private StatelessEventHandler statelessHandler;
+    private StatefulProcessRepository statefulRepository;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        serializer = new JacksonSerializer();
+        statefulRepository = new StatefulProcessRepository(
+                new PaymentProcess("handler-1", "process-1", 0L));
+        statelessHandler = new StatelessEventHandler();
+
+        List<ParameterResolver<? super DeserializingMessage>> parameterResolvers = List.of(
+                new TriggerParameterResolver(null, null), new MessageParameterResolver(),
+                new MetadataParameterResolver(), new TimestampParameterResolver(), new PayloadParameterResolver(),
+                new JsonPayloadParameterResolver(), new EntityParameterResolver());
+        HandlerDecorator handlerStack = new ErrorReportingInterceptor(null)
+                .andThen(new HandlerMonitor())
+                .andThen(new DataProtectionInterceptor(
+                        null, serializer, MissingProtectedDataPolicy.HANDLE, true))
+                .andThen(new ContentFilterInterceptor(serializer));
+        DefaultHandlerFactory handlerFactory = new DefaultHandlerFactory(
+                MessageType.EVENT, handlerStack, parameterResolvers, MethodInvocationValidator.noOp(),
+                ignored -> statefulRepository, new InMemoryRepositoryProvider(), true, serializer);
+
+        handlers = List.of(
+                handlerFactory.createHandler(statelessHandler, HandlerFilter.ALWAYS_HANDLE, List.of()).orElseThrow(),
+                handlerFactory.createHandler(PaymentProcess.class, HandlerFilter.ALWAYS_HANDLE, List.of())
+                        .orElseThrow());
+        tracking = new DefaultTracking(
+                MessageType.EVENT, null, List.of(), List.of(), serializer, handlerFactory);
+        configuration = ConsumerConfiguration.builder()
+                .name("benchmark-tracking")
+                .handlingMode(ConsumerHandlingMode.SYNC)
+                .awaitAsyncResults(true)
+                .build();
+        serializedMessages = createMessages();
+
+        long statelessBefore = statelessHandler.invocations;
+        long statefulBefore = statefulRepository.total();
+        trackingHandling();
+        if (statelessHandler.invocations <= statelessBefore || statefulRepository.total() <= statefulBefore) {
+            throw new IllegalStateException("Tracking scenario did not invoke both stateless and stateful handlers");
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        tracking.close();
+    }
+
+    /**
+     * Deserializes and handles one batch containing synchronous, completed-asynchronous, and stateful event handlers.
+     * Result publication and external position storage are disabled; both would measure an I/O boundary instead.
+     */
+    @Benchmark
+    public long trackingHandling() {
+        List<DeserializingMessage> messages = tracking.deserializeMessageList(
+                serializedMessages, null, null, new ConcurrentHashMap<>(), BATCH_SIZE);
+        tracking.handleBatch(messages, handlers, configuration, false);
+        return statelessHandler.invocations + statefulRepository.total();
+    }
+
+    private List<SerializedMessage> createMessages() {
+        return java.util.stream.IntStream.range(0, BATCH_SIZE).mapToObj(i -> {
+            Object payload = switch (i & 3) {
+                case 0 -> new OrderObserved("order-" + (i & 7), i);
+                case 1 -> new AsyncProjectionUpdated("projection-" + (i & 7), i);
+                case 2 -> new PaymentObserved("process-1", i * 10L);
+                default -> new CustomerObserved("customer-" + (i & 7), "name-" + i);
+            };
+            SerializedMessage message = new SerializedMessage(
+                    serializer.serialize(payload), Metadata.of("benchmark", "true"),
+                    "tracking-message-" + i, 1_700_000_000_000L + i);
+            message.setIndex((long) i);
+            message.setSegment(i & 3);
+            return message;
+        }).toList();
+    }
+
+    record OrderObserved(String orderId, int line) {
+    }
+
+    record AsyncProjectionUpdated(String projectionId, int version) {
+    }
+
+    record PaymentObserved(String processId, long amount) {
+    }
+
+    record CustomerObserved(String customerId, String name) {
+    }
+
+    static class StatelessEventHandler {
+        private long invocations;
+
+        @HandleEvent
+        void handle(OrderObserved event, Metadata metadata) {
+            invocations += event.line() + metadata.getEntries().size();
+        }
+
+        @HandleEvent
+        CompletionStage<Void> handle(AsyncProjectionUpdated event) {
+            invocations += event.version();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @HandleEvent
+        void handle(CustomerObserved event, Instant timestamp) {
+            invocations += event.name().length() + timestamp.getEpochSecond();
+        }
+    }
+
+    @Stateful
+    record PaymentProcess(@EntityId String id, @Association String processId, long total) {
+        @HandleEvent
+        PaymentProcess handle(PaymentObserved event) {
+            return new PaymentProcess(id, processId, total + event.amount());
+        }
+    }
+
+    private record ProcessEntry(String id, Object value) implements Entry<Object> {
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+    }
+
+    private static class StatefulProcessRepository implements HandlerRepository {
+        private volatile PaymentProcess process;
+
+        private StatefulProcessRepository(PaymentProcess process) {
+            this.process = process;
+        }
+
+        @Override
+        public Collection<? extends Entry<?>> findByAssociation(Map<Object, String> associations) {
+            boolean matches = associations.entrySet().stream().anyMatch(
+                    entry -> "processId".equals(entry.getValue()) && process.processId().equals(entry.getKey()));
+            return matches ? List.of(new ProcessEntry(process.id(), process)) : List.of();
+        }
+
+        @Override
+        public Collection<? extends Entry<?>> getAll() {
+            return List.of(new ProcessEntry(process.id(), process));
+        }
+
+        @Override
+        public CompletableFuture<?> put(Object id, Object value) {
+            process = (PaymentProcess) value;
+            return CompletableFuture.completedFuture(value);
+        }
+
+        @Override
+        public CompletableFuture<?> delete(Object id) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        long total() {
+            return process.total();
+        }
+    }
+
+    private static class InMemoryRepositoryProvider implements RepositoryProvider {
+        private final Map<Class<?>, Map<Object, ?>> repositories = new ConcurrentHashMap<>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> Map<Object, T> getRepository(Class<T> repositoryClass) {
+            return (Map<Object, T>) repositories.computeIfAbsent(repositoryClass, ignored -> new ConcurrentHashMap<>());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <kotlin.version>2.4.0</kotlin.version>
         <json.doclet.version>0.0.10</json.doclet.version>
+        <jmh.version>1.37</jmh.version>
         <junit.parallelism>2</junit.parallelism>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
@@ -447,6 +448,12 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>benchmarks</id>
+            <modules>
+                <module>benchmarks</module>
+            </modules>
+        </profile>
         <profile>
             <id>deploy</id>
             <build>


### PR DESCRIPTION
## Summary

- add six broad JMH performance scenarios for outbound dispatch, local command handling, local self-handled queries, multi-method local query handling, tracked handling routes, and aggregate load/apply
- cover self-tracked commands, multi-method standalone command and event handlers, multi-parameter event handling, `Entity<T>`/`T` injection, and the original standalone plus `@Stateful` tracked flow inside the tracked handling scenario
- compare the pull-request base and proposed SDK from the same benchmark sources in ABBA order
- block the existing required `build-pr` check on material runtime or allocation regressions
- publish a compact result table and expandable measurement details in the GitHub job summary

## Why

These SDK paths are present in the hot path of typical applications. The benchmarks intentionally behave as broad performance acceptance tests: they detect that representative application work became slower or more allocation-heavy without trying to diagnose an individual unit.

The tracked routes are measured together as one longer-sampled application scenario. All route-specific setup assertions remain, while the combined signal is substantially less sensitive to short-lived per-route noise on GitHub-hosted runners.

## Regression policy

The gate fails above 15% for average time, or above 15% normalized allocation when the absolute increase is at least 256 B/op. Both revisions run twice on the same runner in ABBA order to reduce ordering and machine noise.

## Validation

- benchmark module package build
- eight comparator unit tests
- two independent focused tracking runs: 3.191 and 3.125 us/message
- full local ABBA comparison against the pull-request base: all six scenarios passed
- GitHub Maven build: 2m02s
- GitHub performance gate: 3m36s; all scenarios passed
- final required `build-pr` check passed
- GitHub tracking result: +7.2% time and -0.6% allocation, within the unchanged 15% regression limit
