### PR TITLE
fix(websocket): close failed sessions and replace stale predecessors

### DIFF
--- a/common/src/main/java/io/fluxzero/common/websocket/WebSocketCapabilities.java
+++ b/common/src/main/java/io/fluxzero/common/websocket/WebSocketCapabilities.java
@@ -39,6 +39,7 @@ public final class WebSocketCapabilities {
     public static final String SELECTED_TRANSPORT_FORMAT_HEADER =
             "Fluxzero-Selected-Transport-Format";
     public static final String CLIENT_SESSION_ID_HEADER = "Fluxzero-Client-Session-Id";
+    public static final String REPLACES_SESSION_ID_HEADER = "Fluxzero-Replaces-Session-Id";
     public static final String CLIENT_SDK_VERSION_HEADER = "Fluxzero-Client-Sdk-Version";
     public static final String RUNTIME_SESSION_ID_HEADER = "Fluxzero-Runtime-Session-Id";
     public static final String RUNTIME_VERSION_HEADER = "Fluxzero-Runtime-Version";
@@ -143,6 +144,10 @@ public final class WebSocketCapabilities {
 
     public static Optional<String> getClientSessionId(Map<String, List<String>> headers) {
         return getHeaderValue(headers, CLIENT_SESSION_ID_HEADER);
+    }
+
+    public static Optional<String> getReplacedSessionId(Map<String, List<String>> headers) {
+        return getHeaderValue(headers, REPLACES_SESSION_ID_HEADER);
     }
 
     public static Optional<String> getClientSdkVersion(Map<String, List<String>> headers) {

--- a/common/src/test/java/io/fluxzero/common/websocket/WebSocketCapabilitiesTest.java
+++ b/common/src/test/java/io/fluxzero/common/websocket/WebSocketCapabilitiesTest.java
@@ -60,4 +60,12 @@ class WebSocketCapabilitiesTest {
 
         assertEquals(JSON, WebSocketCapabilities.getSelectedTransportFormat(headers).orElseThrow());
     }
+
+    @Test
+    void replacedSessionIdIsParsedCaseInsensitivelyByHeaderName() {
+        Map<String, List<String>> headers = Map.of(
+                WebSocketCapabilities.REPLACES_SESSION_ID_HEADER.toLowerCase(), List.of("old-client_old-runtime"));
+
+        assertEquals("old-client_old-runtime", WebSocketCapabilities.getReplacedSessionId(headers).orElseThrow());
+    }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
@@ -132,6 +132,7 @@ import static java.util.Optional.ofNullable;
  * @see ResultBatch
  */
 public abstract class AbstractWebsocketClient implements WebsocketEndpoint, AutoCloseable {
+    private static final Duration CLOSE_HANDSHAKE_TIMEOUT = Duration.ofSeconds(1);
     protected static final Duration CONNECTION_TIMEOUT_FAILSAFE_GRACE = Duration.ofSeconds(5);
     protected static final int CONNECTION_RETRY_LOG_INTERVAL = 10;
     protected static final String CLIENT_HANDSHAKE_CONFIGURATOR_USER_PROPERTY =
@@ -651,8 +652,32 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     @SneakyThrows
     protected void abort(WebsocketSession session, String reason) {
         WebsocketCloseReason closeReason = new WebsocketCloseReason(WebsocketCloseReason.UNEXPECTED_CONDITION, reason);
-        log().warn("Aborting session {} due to {}", getNegotiatedSessionId(session), reason);
-        session.abort(closeReason);
+        log().warn("Closing session {} due to {}", getNegotiatedSessionId(session), reason);
+        CompletableFuture<Void> closeFuture;
+        try {
+            closeFuture = session.closeAsync(closeReason);
+        } catch (Throwable e) {
+            log().warn("Failed to start an orderly close for session {}. Aborting transport.",
+                       getNegotiatedSessionId(session), e);
+            session.abort(closeReason);
+            return;
+        }
+        if (closeFuture == null) {
+            session.abort(closeReason);
+            return;
+        }
+        closeFuture.orTimeout(getCloseHandshakeTimeout().toMillis(), TimeUnit.MILLISECONDS)
+                .whenComplete((ignored, error) -> {
+                    if (error != null) {
+                        log().warn("Orderly close did not complete for session {}. Aborting transport.",
+                                   getNegotiatedSessionId(session), error);
+                        session.abort(closeReason);
+                    }
+                });
+    }
+
+    protected Duration getCloseHandshakeTimeout() {
+        return CLOSE_HANDSHAKE_TIMEOUT;
     }
 
     @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
@@ -237,8 +237,8 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
                                                                                  Math.max(1, numberOfSessions)));
         this.resultExecutor = newWorkerPool(this + "-onMessage", 8);
         this.reconnectExecutor = newWorkerPool(this + "-reconnect", Math.max(1, numberOfSessions));
-        this.sessionPool = new SessionPool(numberOfSessions, () -> retryOnFailure(
-                () -> connectToServer(connector, endpointUri),
+        this.sessionPool = new SessionPool(numberOfSessions, previousSession -> retryOnFailure(
+                () -> connectToServer(connector, endpointUri, previousSession),
                 createConnectionRetryConfiguration(endpointUri, reconnectDelay)));
     }
 
@@ -275,7 +275,20 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected WebsocketSession connectToServer(WebsocketConnector connector, URI endpointUri) throws Exception {
-        ConnectionSetup connectionSetup = createConnectionSetup(clientConfig);
+        return connectToServer(connector, endpointUri, null);
+    }
+
+    protected WebsocketSession connectToServer(WebsocketConnector connector, URI endpointUri,
+                                               WebsocketSession previousSession) throws Exception {
+        String replacedSessionId = null;
+        if (previousSession != null) {
+            try {
+                replacedSessionId = getNegotiatedSessionId(previousSession);
+            } catch (RuntimeException e) {
+                log().debug("Could not determine the replaced websocket session id", e);
+            }
+        }
+        ConnectionSetup connectionSetup = createConnectionSetup(clientConfig, replacedSessionId);
         return TimingUtils.callAndWait(
                 () -> connector.connect(this, connectionSetup.options(), endpointUri),
                 clientConfig.getConnectionTimeout().plus(getConnectionTimeoutFailsafeGrace()));
@@ -869,8 +882,12 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected static ConnectionSetup createConnectionSetup(ClientConfig clientConfig) {
+        return createConnectionSetup(clientConfig, null);
+    }
+
+    protected static ConnectionSetup createConnectionSetup(ClientConfig clientConfig, String replacedSessionId) {
         ClientHandshakeConfigurator configurator = new ClientHandshakeConfigurator(
-                WebSocketCapabilities.newShortSessionId(), clientConfig);
+                WebSocketCapabilities.newShortSessionId(), clientConfig, replacedSessionId);
         Map<String, List<String>> headers = new java.util.LinkedHashMap<>();
         configurator.beforeRequest(headers);
         Map<String, Object> userProperties = Map.of(CLIENT_HANDSHAKE_CONFIGURATOR_USER_PROPERTY, configurator);
@@ -926,6 +943,7 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
         @Getter
         private final String clientSessionId;
         private final ClientConfig clientConfig;
+        private final String replacedSessionId;
         @Getter
         private volatile String runtimeSessionId;
         @Getter
@@ -937,6 +955,10 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
 
         public void beforeRequest(Map<String, List<String>> headers) {
             headers.put(WebSocketCapabilities.CLIENT_SESSION_ID_HEADER, new ArrayList<>(List.of(clientSessionId)));
+            if (replacedSessionId != null && !replacedSessionId.isBlank()) {
+                headers.put(WebSocketCapabilities.REPLACES_SESSION_ID_HEADER,
+                            new ArrayList<>(List.of(replacedSessionId)));
+            }
             SdkVersion.version().ifPresent(sdkVersion ->
                                                    headers.put(WebSocketCapabilities.CLIENT_SDK_VERSION_HEADER,
                                                                new ArrayList<>(List.of(sdkVersion))));

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
@@ -47,6 +47,8 @@ class JdkWebSocketSession implements WebsocketSession {
     private final CompletableFuture<Void> openFuture = new CompletableFuture<>();
     private final AtomicBoolean open = new AtomicBoolean();
     private final AtomicBoolean closeNotified = new AtomicBoolean();
+    private final CompletableFuture<Void> closeHandshakeFuture = new CompletableFuture<>();
+    private final Object closeInitiationLock = new Object();
     private final Object binaryMessageLock = new Object();
     /*
      * Keep calls into java.net.http.WebSocket ordered, but do not hold this monitor while waiting for the returned
@@ -54,6 +56,7 @@ class JdkWebSocketSession implements WebsocketSession {
      */
     private final Object sendInitiationLock = new Object();
     private CompletableFuture<Void> sendTail = CompletableFuture.completedFuture(null);
+    private volatile CompletableFuture<Void> closeSendFuture;
     private volatile ByteArrayOutputStream binaryMessage = new ByteArrayOutputStream();
     private volatile WebSocket webSocket;
 
@@ -147,18 +150,17 @@ class JdkWebSocketSession implements WebsocketSession {
 
     @Override
     public void close(WebsocketCloseReason closeReason) throws IOException {
-        WebSocket webSocket = this.webSocket;
-        if (!closeNotified.compareAndSet(false, true)) {
-            return;
-        }
-        open.set(false);
+        await(initiateClose(closeReason), 0);
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync(WebsocketCloseReason closeReason) {
         try {
-            if (webSocket != null && !webSocket.isOutputClosed()) {
-                await(sendClose(webSocket, closeReason), 0);
-            }
-        } finally {
-            connector.removeOpenSession(this);
-            endpoint.onClose(this, closeReason);
+            initiateClose(closeReason);
+            return closeHandshakeFuture;
+        } catch (Throwable e) {
+            closeHandshakeFuture.completeExceptionally(e);
+            return closeHandshakeFuture;
         }
     }
 
@@ -168,6 +170,7 @@ class JdkWebSocketSession implements WebsocketSession {
         if (webSocket != null) {
             webSocket.abort();
         }
+        closeHandshakeFuture.completeExceptionally(new ClosedChannelException());
         notifyClose(closeReason);
     }
 
@@ -180,6 +183,41 @@ class JdkWebSocketSession implements WebsocketSession {
         }
         connector.removeOpenSession(this);
         openFuture.completeExceptionally(new ClosedChannelException());
+        closeHandshakeFuture.completeExceptionally(new ClosedChannelException());
+    }
+
+    private CompletableFuture<Void> initiateClose(WebsocketCloseReason closeReason) {
+        CompletableFuture<Void> result;
+        boolean notifyEndpoint;
+        WebSocket currentWebSocket;
+        synchronized (closeInitiationLock) {
+            if (closeSendFuture != null) {
+                return closeSendFuture;
+            }
+            if (closeHandshakeFuture.isDone()) {
+                closeSendFuture = CompletableFuture.completedFuture(null);
+                return closeSendFuture;
+            }
+            open.set(false);
+            connector.removeOpenSession(this);
+            currentWebSocket = webSocket;
+            result = currentWebSocket == null || currentWebSocket.isOutputClosed()
+                    ? CompletableFuture.completedFuture(null)
+                    : sendClose(currentWebSocket, closeReason).thenApply(ignored -> null);
+            closeSendFuture = result;
+            notifyEndpoint = closeNotified.compareAndSet(false, true);
+        }
+        result.whenComplete((ignored, error) -> {
+            if (error != null) {
+                closeHandshakeFuture.completeExceptionally(error);
+            } else if (currentWebSocket == null || currentWebSocket.isInputClosed()) {
+                closeHandshakeFuture.complete(null);
+            }
+        });
+        if (notifyEndpoint) {
+            endpoint.onClose(this, closeReason);
+        }
+        return result;
     }
 
     private CompletableFuture<WebSocket> sendClose(WebSocket webSocket, WebsocketCloseReason closeReason) {
@@ -273,6 +311,7 @@ class JdkWebSocketSession implements WebsocketSession {
 
     private void notifyClose(WebsocketCloseReason closeReason) {
         open.set(false);
+        closeHandshakeFuture.complete(null);
         if (closeNotified.compareAndSet(false, true)) {
             connector.removeOpenSession(this);
             endpoint.onClose(this, closeReason);

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SessionPool.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SessionPool.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -28,8 +29,9 @@ import java.util.stream.IntStream;
  * A thread-safe pool of reusable {@link WebsocketSession} objects, supporting concurrent access and routing.
  * <p>
  * This class provides a mechanism to manage multiple active WebSocket sessions, either round-robin or keyed by a
- * {@code routingKey}. It lazily initializes sessions on demand using a configurable {@link Supplier}, ensuring that
- * each session slot is kept active unless the pool is shutting down or explicitly closed.
+ * {@code routingKey}. It lazily initializes sessions on demand using a configurable factory, ensuring that each
+ * session slot is kept active unless the pool is shutting down or explicitly closed. A replacement-aware factory
+ * receives the previous closed session so a new handshake can identify which server-side session it supersedes.
  * <p>
  * The session pool is particularly useful in high-throughput scenarios, where multiple sessions are used to distribute
  * load, improve parallelism, or isolate message streams.
@@ -57,10 +59,20 @@ public class SessionPool implements AutoCloseable {
     private final Object[] sessionLocks;
     private final int size;
     private final AtomicInteger counter = new AtomicInteger();
-    private final Supplier<WebsocketSession> sessionFactory;
+    private final Function<WebsocketSession, WebsocketSession> sessionFactory;
     private final AtomicBoolean shuttingDown = new AtomicBoolean();
 
     public SessionPool(int size, Supplier<WebsocketSession> sessionFactory) {
+        this(size, previousSession -> sessionFactory.get());
+    }
+
+    /**
+     * Creates a session pool whose factory receives the previous closed session when replacing a slot.
+     *
+     * @param size number of independently routed session slots
+     * @param sessionFactory factory receiving {@code null} initially and the previous session on replacement
+     */
+    public SessionPool(int size, Function<WebsocketSession, WebsocketSession> sessionFactory) {
         if (size < 1) {
             throw new IllegalArgumentException("Session pool size must be at least 1");
         }
@@ -92,7 +104,7 @@ public class SessionPool implements AutoCloseable {
                 if (shuttingDown.get()) {
                     throw new ClientClosedException();
                 }
-                s = sessionFactory.get();
+                s = sessionFactory.apply(s);
             }
             sessionMap.put(index, s);
             return s;

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SessionPool.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SessionPool.java
@@ -72,7 +72,7 @@ public class SessionPool implements AutoCloseable {
      * @param size number of independently routed session slots
      * @param sessionFactory factory receiving {@code null} initially and the previous session on replacement
      */
-    public SessionPool(int size, Function<WebsocketSession, WebsocketSession> sessionFactory) {
+    SessionPool(int size, Function<WebsocketSession, WebsocketSession> sessionFactory) {
         if (size < 1) {
             throw new IllegalArgumentException("Session pool size must be at least 1");
         }

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketSession.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketSession.java
@@ -130,6 +130,29 @@ public interface WebsocketSession {
     void close(WebsocketCloseReason closeReason) throws IOException;
 
     /**
+     * Starts an orderly close without blocking the caller.
+     *
+     * <p>The returned future completes when the peer has acknowledged the close, or exceptionally when the close
+     * handshake fails. The default dispatches {@link #close(WebsocketCloseReason)} on a virtual thread and completes
+     * after that method returns; implementations that can observe peer acknowledgement should override it.</p>
+     *
+     * @param closeReason close status and reason to send
+     * @return completion of the orderly close handshake
+     */
+    default CompletableFuture<Void> closeAsync(WebsocketCloseReason closeReason) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Thread.startVirtualThread(() -> {
+            try {
+                close(closeReason);
+                result.complete(null);
+            } catch (Throwable e) {
+                result.completeExceptionally(e);
+            }
+        });
+        return result;
+    }
+
+    /**
      * Immediately aborts the underlying transport and reports the given close reason to the endpoint.
      *
      * @param closeReason synthetic close status and reason to report

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
@@ -170,6 +170,20 @@ class AbstractWebsocketClientTest {
     }
 
     @Test
+    void replacementConnectionIdentifiesThePreviousNegotiatedSession() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+
+        AbstractWebsocketClient.ConnectionSetup connectionSetup =
+                AbstractWebsocketClient.createConnectionSetup(clientConfig, "old-client_old-runtime");
+
+        assertEquals("old-client_old-runtime", WebSocketCapabilities.getReplacedSessionId(
+                connectionSetup.options().headers()).orElseThrow());
+    }
+
+    @Test
     void connectionOptionsPublishConfiguredJdkConnectionTimeout() {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
@@ -73,6 +73,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -278,7 +280,7 @@ class AbstractWebsocketClientTest {
     }
 
     @Test
-    void sendBatchAbortsSessionWhenTransportSendFails() throws Exception {
+    void sendBatchClosesSessionWhenTransportSendFails() throws Exception {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
                 .name("test-client")
@@ -301,14 +303,14 @@ class AbstractWebsocketClientTest {
             List<Request> requests = List.of(new Append(MessageType.EVENT, List.<SerializedMessage>of(), Guarantee.NONE));
             assertDoesNotThrow(() -> sendBatch.invoke(client, requests, session));
 
-            verify(session).abort(any());
+            verify(session).closeAsync(any());
         } finally {
             client.close();
         }
     }
 
     @Test
-    void sendBatchAbortsSessionWhenTransportSendTimesOut() throws Exception {
+    void sendBatchClosesSessionWhenTransportSendTimesOut() throws Exception {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
                 .name("test-client")
@@ -331,7 +333,51 @@ class AbstractWebsocketClientTest {
             List<Request> requests = List.of(new Append(MessageType.EVENT, List.<SerializedMessage>of(), Guarantee.NONE));
             assertTimeout(Duration.ofSeconds(2), () -> assertDoesNotThrow(() -> sendBatch.invoke(client, requests, session)));
 
-            verify(session).abort(any());
+            verify(session).closeAsync(any());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void abortStartsOrderlyCloseAndDoesNotAbortAfterPeerAcknowledgement() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        CloseObservingClient client = new CloseObservingClient(mock(WebsocketConnector.class), clientConfig);
+        WebsocketSession session = mockSession("client123_runtime456");
+        CompletableFuture<Void> closeHandshake = new CompletableFuture<>();
+        when(session.closeAsync(any())).thenReturn(closeHandshake);
+
+        try {
+            client.abortForTest(session, "Ping failed");
+
+            verify(session).closeAsync(any());
+            verify(session, never()).abort(any());
+            closeHandshake.complete(null);
+            Thread.sleep(150);
+            verify(session, never()).abort(any());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void abortFallsBackToTransportAbortWhenPeerDoesNotAcknowledgeClose() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        CloseObservingClient client = new CloseObservingClient(mock(WebsocketConnector.class), clientConfig);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.closeAsync(any())).thenReturn(new CompletableFuture<>());
+
+        try {
+            client.abortForTest(session, "Ping failed");
+
+            verify(session).closeAsync(any());
+            verify(session, timeout(1000)).abort(any());
         } finally {
             client.close();
         }
@@ -731,6 +777,21 @@ class AbstractWebsocketClientTest {
 
         void publishTestMetric(Append append) {
             tryPublishMetrics(append, Metadata.empty());
+        }
+    }
+
+    private static class CloseObservingClient extends TestClient {
+        CloseObservingClient(WebsocketConnector container, WebSocketClient.ClientConfig clientConfig) {
+            super(container, clientConfig);
+        }
+
+        void abortForTest(WebsocketSession session, String reason) {
+            abort(session, reason);
+        }
+
+        @Override
+        protected Duration getCloseHandshakeTimeout() {
+            return Duration.ofMillis(100);
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
@@ -436,6 +436,30 @@ class JdkWebsocketConnectorTest {
     }
 
     @Test
+    void asynchronousCloseWaitsForPeerAfterLogicallyClosingSession() throws Exception {
+        try (TestWebSocketServer server = TestWebSocketServer.start()) {
+            JdkWebsocketConnector connector = new JdkWebsocketConnector();
+            RecordingEndpoint endpoint = new RecordingEndpoint();
+            WebsocketSession session = connector.connect(endpoint, null, server.uri());
+            WebsocketCloseReason closeReason =
+                    new WebsocketCloseReason(WebsocketCloseReason.UNEXPECTED_CONDITION, "Ping failed");
+
+            CompletableFuture<Void> closeHandshake = session.closeAsync(closeReason);
+
+            assertFalse(session.isOpen());
+            assertTrue(session.getOpenSessions().isEmpty());
+            assertTrue(endpoint.awaitClose());
+            assertFalse(closeHandshake.isDone());
+            assertFrame(new Frame(0x8, closePayload(closeReason.code(), closeReason.reason())), server.readFrame());
+
+            server.sendFrame(true, 0x8, closePayload(closeReason.code(), closeReason.reason()));
+
+            closeHandshake.get(5, TimeUnit.SECONDS);
+            assertEquals(1, endpoint.closeCount.get());
+        }
+    }
+
+    @Test
     void abortRemovesOpenSessionAndNotifiesEndpointOnce() throws Exception {
         try (TestWebSocketServer server = TestWebSocketServer.start()) {
             JdkWebsocketConnector connector = new JdkWebsocketConnector();

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/SessionPoolTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/SessionPoolTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -93,6 +94,25 @@ class SessionPoolTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    void replacementFactoryReceivesTheClosedSession() {
+        WebsocketSession first = mock(WebsocketSession.class);
+        when(first.isOpen()).thenReturn(true, false, false);
+        WebsocketSession replacement = openSession();
+        AtomicReference<WebsocketSession> replacedSession = new AtomicReference<>();
+        SessionPool sessionPool = new SessionPool(1, previousSession -> {
+            if (previousSession == null) {
+                return first;
+            }
+            replacedSession.set(previousSession);
+            return replacement;
+        });
+
+        assertSame(first, sessionPool.get());
+        assertSame(replacement, sessionPool.get());
+        assertSame(first, replacedSession.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- companion runtime change: https://github.com/fluxzero-io/fluxzero-runtime/pull/337
- mark an unhealthy websocket session logically closed immediately
- enqueue an orderly close frame without blocking the caller and retain a bounded transport-abort fallback
- pass the previous negotiated session id in a replacement handshake
- keep the replacement-aware session-pool factory internal so the existing public constructor remains source-compatible

## Why

An immediate transport abort can prevent the peer from observing a close frame. A reconnect may then overlap with a stale server-side session until separate liveness cleanup occurs. The SDK now attempts an orderly close first while remaining non-blocking and bounded, and a supporting runtime can remove the exact predecessor only after the replacement is active.

Older runtimes safely ignore the new handshake header.

## Verification

- `./mvnw -B install`: all 9 reactor modules passed
- focused websocket suite: 59 tests passed
- manual transport-state, reconnect-race, API-compatibility, and privacy review completed
- `git diff --check` passed
