### PR TITLE
feat(web): support multi-value WebRequest cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2428,6 +2428,41 @@ disabling the runtime endpoint or model. Use `@ApiDocInfo.security` for top-leve
 `@ApiDocComponent` through `@ApiDocInfo.components` for shared OpenAPI components such as reusable responses or
 security schemes when automatic inference is not enough.
 
+#### Request Cookies
+
+[HTTP/2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.3) and
+[HTTP/3](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2.1) can split one logical `Cookie` field over multiple
+field lines for compression. `WebRequest` parses all received `Cookie` values in logical wire order, whether the HTTP
+layer preserves those field lines or combines them with `; `. Commas are cookie-value data, not cookie-pair separators.
+
+```java
+List<HttpCookie> allCookies = request.getCookies();
+List<HttpCookie> sessions = request.getCookies("session");
+Optional<HttpCookie> firstSession = request.getCookie("session");
+```
+
+`getCookies()` returns every cookie without collapsing duplicate names. `getCookies(name)` uses an exact,
+case-sensitive name match. HTTP header names remain case-insensitive, so `Cookie` and `cookie` identify the same header;
+cookie names such as `Session` and `session` remain distinct.
+
+`getCookie(name)` retains its existing first-match behavior and uses `CookieValueConflictPolicy.DEFAULT`, which is
+`ALLOW_CONFLICTING_VALUES` in this release. It now also finds a first match in a later cookie field. Callers that need
+every value should use `getCookies(name)` instead of splitting raw headers.
+
+For security-sensitive cookies, reject conflicting values explicitly:
+
+```java
+HttpCookie session = request
+        .getCookie("session", CookieValueConflictPolicy.REJECT_CONFLICTING_VALUES)
+        .orElseThrow();
+```
+
+`REJECT_CONFLICTING_VALUES` accepts repeated cookies when their parsed values are exactly equal and throws a redacted
+`CookieConflictException` when any value differs. The exception contains no cookie name or value. Use this policy for
+session, authentication, authorization, flow-binding, and CSRF cookies so different processing layers cannot select
+different values from the same request. Cookie headers and values are excluded from `WebRequest` and builder
+`toString()` output.
+
 #### Other Parameter Annotations
 
 In addition to `@PathParam`, you can extract other values from the request using:

--- a/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
@@ -238,6 +238,28 @@ class ProxyServerTest {
         }
 
         @Test
+        void http2CookieCrumbsReachWebRequestInOrder() {
+            testFixture.registerHandlers(new Object() {
+                        @HandleGet("/cookie-headers")
+                        String cookies(WebRequest request) {
+                            return request.getCookies().stream()
+                                    .map(cookie -> cookie.getName() + "=" + cookie.getValue())
+                                    .collect(java.util.stream.Collectors.joining(","));
+                        }
+                    })
+                    .whenApplying(fc -> httpClient.send(
+                            newBuilder(URI.create(format("http://localhost:%s/cookie-headers", proxyPort)))
+                                    .version(HttpClient.Version.HTTP_2)
+                                    .header("Cookie", "first=one; shared=same")
+                                    .header("Cookie", "second=two; shared=same")
+                                    .GET().build(), BodyHandlers.ofString()))
+                    .verifyResult(response -> {
+                        assertEquals(HttpClient.Version.HTTP_2, response.version());
+                        assertEquals("first=one,shared=same,second=two,shared=same", response.body());
+                    });
+        }
+
+        @Test
         @ResourceLock(ProxyRequestHandler.SEGMENT_HEADER_PROPERTY)
         void requestSegmentCanBeSelectedFromConfiguredHeader() throws Exception {
             String previousValue = System.getProperty(ProxyRequestHandler.SEGMENT_HEADER_PROPERTY);

--- a/sdk/src/main/java/io/fluxzero/sdk/web/CookieConflictException.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/CookieConflictException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.web;
+
+import io.fluxzero.sdk.tracking.handling.validation.ValidationException;
+
+import java.util.Set;
+
+/**
+ * Indicates that a request contains distinct values for a cookie that was required to be conflict-free.
+ * <p>
+ * The exception deliberately excludes the cookie name and values from its message and serialized state.
+ */
+public class CookieConflictException extends ValidationException {
+
+    /**
+     * Creates a conflict that intentionally carries no cookie-specific data.
+     */
+    public CookieConflictException() {
+        super("Request contains conflicting cookie values", Set.of());
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/web/CookieValueConflictPolicy.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/CookieValueConflictPolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.web;
+
+/**
+ * Determines how {@link WebRequest#getCookie(String, CookieValueConflictPolicy)} handles multiple cookies with the
+ * same case-sensitive name.
+ */
+public enum CookieValueConflictPolicy {
+
+    /** Uses the SDK default, which is {@link #ALLOW_CONFLICTING_VALUES} in this release. */
+    DEFAULT,
+
+    /** Returns the first matching cookie, including when later values differ. */
+    ALLOW_CONFLICTING_VALUES,
+
+    /** Rejects the lookup when matching cookies contain different values. */
+    REJECT_CONFLICTING_VALUES
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestContext.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestContext.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -108,8 +107,7 @@ public class DefaultWebRequestContext implements WebRequestContext {
                 .map(scheme -> scheme + "://" + uri.getHost() + Optional.of(uri.getPort())
                         .filter(p -> p >= 0).map(p -> ":" + p).orElse("")).orElse(null);
         queryParameters = parseParameters(uri.getRawQuery());
-        cookieMap = WebRequest.getHeaders(metadata).getOrDefault("Cookie", Collections.emptyList())
-                .stream().findFirst().map(WebUtils::parseRequestCookieHeader).orElseGet(Collections::emptyList)
+        cookieMap = WebRequest.parseCookieHeaders(WebRequest.getHeaders(metadata).getOrDefault("Cookie", List.of()))
                 .stream().collect(toMap(HttpCookie::getName, HttpCookie::getValue, (first, ignored) -> first,
                                         LinkedHashMap::new));
         remoteAddress = Stream.of("X-Forwarded-For", "Forwarded", "X-Real-IP")

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
@@ -141,12 +141,16 @@ public class WebRequest extends Message {
     Map<String, List<String>> headers;
 
     /**
-     * Lazily parsed list of HTTP cookies, derived from the "Cookie" header.
+     * Returns all request cookies from every {@code Cookie} header value in logical wire order.
+     * <p>
+     * Each header value is parsed as a semicolon-separated sequence. Cookies with the same name are not collapsed.
+     * Header names are case-insensitive, while cookie names remain case-sensitive.
+     *
+     * @return all request cookies, or an empty list when none are present
      */
     @Getter(lazy = true)
     @JsonIgnore
-    List<HttpCookie> cookies = Optional.ofNullable(getHeader("Cookie"))
-            .map(WebUtils::parseRequestCookieHeader).orElse(Collections.emptyList());
+    List<HttpCookie> cookies = parseCookieHeaders(getHeaders("Cookie"));
 
     private WebRequest(Builder builder) {
         super(builder.payload(), builder.metadata.with(urlKey, builder.url(), methodKey, builder.method(),
@@ -271,13 +275,59 @@ public class WebRequest extends Message {
     }
 
     /**
-     * Finds a cookie by name.
+     * Finds the first cookie with the given name in logical wire order.
+     * <p>
+     * This method retains its first-match behavior and is equivalent to calling
+     * {@link #getCookie(String, CookieValueConflictPolicy)} with {@link CookieValueConflictPolicy#DEFAULT}. Cookies in
+     * later {@code Cookie} header values are now included in the lookup.
      *
-     * @param name the cookie name
-     * @return optional cookie
+     * @param name the case-sensitive cookie name
+     * @return the first matching cookie, or empty if it is absent
      */
     public Optional<HttpCookie> getCookie(String name) {
-        return getCookies().stream().filter(c -> Objects.equals(name, c.getName())).findFirst();
+        return getCookie(name, CookieValueConflictPolicy.DEFAULT);
+    }
+
+    /**
+     * Finds a cookie with the given name using the requested conflict policy.
+     * <p>
+     * Identical repeated values are accepted by both policies. {@link CookieValueConflictPolicy#REJECT_CONFLICTING_VALUES}
+     * throws a redacted {@link CookieConflictException} when at least one matching value differs.
+     *
+     * @param name           the case-sensitive cookie name
+     * @param conflictPolicy the policy for matching cookies with different values
+     * @return the first matching cookie, or empty if it is absent
+     * @throws CookieConflictException if conflicting values are present and rejection is requested
+     */
+    public Optional<HttpCookie> getCookie(String name, CookieValueConflictPolicy conflictPolicy) {
+        CookieValueConflictPolicy requestedPolicy = Objects.requireNonNull(conflictPolicy, "conflictPolicy");
+        CookieValueConflictPolicy resolvedPolicy = requestedPolicy == CookieValueConflictPolicy.DEFAULT
+                ? CookieValueConflictPolicy.ALLOW_CONFLICTING_VALUES : requestedPolicy;
+        HttpCookie first = null;
+        for (HttpCookie cookie : getCookies()) {
+            if (!Objects.equals(name, cookie.getName())) {
+                continue;
+            }
+            if (first == null) {
+                first = cookie;
+                if (resolvedPolicy == CookieValueConflictPolicy.ALLOW_CONFLICTING_VALUES) {
+                    return Optional.of(cookie);
+                }
+            } else if (!Objects.equals(first.getValue(), cookie.getValue())) {
+                throw new CookieConflictException();
+            }
+        }
+        return Optional.ofNullable(first);
+    }
+
+    /**
+     * Returns all cookies with the given name in logical wire order, without collapsing duplicates.
+     *
+     * @param name the case-sensitive cookie name
+     * @return all matching cookies, possibly empty
+     */
+    public List<HttpCookie> getCookies(String name) {
+        return getCookies().stream().filter(c -> Objects.equals(name, c.getName())).toList();
     }
 
     /**
@@ -351,9 +401,17 @@ public class WebRequest extends Message {
      * Retrieves the first cookie with the given name from the provided Metadata object.
      */
     public static Optional<HttpCookie> getCookie(Metadata metadata, String name) {
-        return getHeaders(metadata).getOrDefault("Cookie", Collections.emptyList())
-                .stream().findFirst().map(WebUtils::parseRequestCookieHeader).orElseGet(Collections::emptyList)
+        return parseCookieHeaders(getHeaders(metadata).getOrDefault("Cookie", Collections.emptyList()))
                 .stream().filter(c -> Objects.equals(c.getName(), name)).findFirst();
+    }
+
+    private static List<HttpCookie> parseCookieHeaders(List<String> cookieHeaders) {
+        return switch (cookieHeaders.size()) {
+            case 0 -> List.of();
+            case 1 -> WebUtils.parseRequestCookieHeader(cookieHeaders.getFirst());
+            default -> cookieHeaders.stream()
+                    .flatMap(header -> WebUtils.parseRequestCookieHeader(header).stream()).toList();
+        };
     }
 
     /**
@@ -375,6 +433,7 @@ public class WebRequest extends Message {
      * Fluent builder for {@link WebRequest}. Use {@link #builder()} to start building.
      */
     @Data
+    @ToString(exclude = {"headers", "cookies", "metadata"})
     @NoArgsConstructor
     @Accessors(fluent = true, chain = true)
     @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -396,9 +455,6 @@ public class WebRequest extends Message {
             url(WebRequest.getUrl(metadata));
             WebRequest.getHeaders(metadata).forEach((k, v) -> headers.put(k, new ArrayList<>(v)));
             headers(WebRequest.getHeaders(metadata));
-            cookies.addAll(WebUtils.parseRequestCookieHeader(
-                    Optional.ofNullable(headers.remove("Cookie")).orElseGet(List::of)
-                            .stream().findFirst().orElse(null)));
         }
 
         protected Builder(WebRequest request) {
@@ -406,9 +462,6 @@ public class WebRequest extends Message {
             url(request.getPath());
             payload(request.getPayload());
             headers(request.getHeaders());
-            cookies.addAll(WebUtils.parseRequestCookieHeader(
-                    Optional.ofNullable(headers.remove("Cookie")).orElseGet(List::of)
-                            .stream().findFirst().orElse(null)));
             metadata = request.getMetadata();
         }
 
@@ -443,8 +496,16 @@ public class WebRequest extends Message {
         }
 
         public Builder cookie(HttpCookie cookie) {
-            cookies.add(cookie);
+            cookies().add(cookie);
             return this;
+        }
+
+        public List<HttpCookie> cookies() {
+            List<String> cookieHeaders = headers.remove("Cookie");
+            if (cookieHeaders != null) {
+                cookies.addAll(parseCookieHeaders(cookieHeaders));
+            }
+            return cookies;
         }
 
         public Builder contentType(String contentType) {

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
@@ -405,7 +405,7 @@ public class WebRequest extends Message {
                 .stream().filter(c -> Objects.equals(c.getName(), name)).findFirst();
     }
 
-    private static List<HttpCookie> parseCookieHeaders(List<String> cookieHeaders) {
+    static List<HttpCookie> parseCookieHeaders(List<String> cookieHeaders) {
         return switch (cookieHeaders.size()) {
             case 0 -> List.of();
             case 1 -> WebUtils.parseRequestCookieHeader(cookieHeaders.getFirst());
@@ -453,7 +453,6 @@ public class WebRequest extends Message {
         protected Builder(Metadata metadata) {
             method(WebRequest.getMethod(metadata));
             url(WebRequest.getUrl(metadata));
-            WebRequest.getHeaders(metadata).forEach((k, v) -> headers.put(k, new ArrayList<>(v)));
             headers(WebRequest.getHeaders(metadata));
         }
 
@@ -486,7 +485,7 @@ public class WebRequest extends Message {
         }
 
         public Builder headers(Map<String, List<String>> headers) {
-            this.headers.putAll(headers);
+            headers.forEach((key, values) -> this.headers.put(key, new ArrayList<>(values)));
             return this;
         }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
@@ -296,7 +296,7 @@ public class WebRequest extends Message {
     }
 
     /**
-     * The HTTP headers as a case-sensitive map. Header values are lists to support repeated headers.
+     * The HTTP headers as a case-insensitive map. Header values are lists to support repeated headers.
      */
     public @NonNull Map<String, List<String>> getHeaders() {
         return headers;

--- a/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
@@ -2525,6 +2525,18 @@ public class HandleWebTest {
         }
 
         @Test
+        void testWithRepeatedCookieHeaders() {
+            TestFixture.create(new Object() {
+                        @HandleGet("/checkCookies")
+                        List<String> check(WebRequest request) {
+                            return request.getCookies().stream()
+                                    .map(cookie -> cookie.getName() + "=" + cookie.getValue()).toList();
+                        }
+                    }).withHeader("Cookie", "first=one", "second=two")
+                    .whenGet("/checkCookies").expectResult(List.of("first=one", "second=two"));
+        }
+
+        @Test
         void returnedCookieIsUsed() {
             TestFixture.create(new Object() {
                 @HandlePost("/signIn")

--- a/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
@@ -2537,6 +2537,17 @@ public class HandleWebTest {
         }
 
         @Test
+        void cookieParamFindsCookieInLaterHeader() {
+            TestFixture.create(new Object() {
+                        @HandleGet("/checkCookieParam")
+                        String check(@CookieParam("second") String second) {
+                            return second;
+                        }
+                    }).withHeader("Cookie", "first=one", "second=two")
+                    .whenGet("/checkCookieParam").expectResult("two");
+        }
+
+        @Test
         void returnedCookieIsUsed() {
             TestFixture.create(new Object() {
                 @HandlePost("/signIn")

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebMessageTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebMessageTest.java
@@ -14,12 +14,19 @@
 
 package io.fluxzero.sdk.web;
 
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpCookie;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
+import static io.fluxzero.common.MessageType.WEBREQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class WebMessageTest {
 
@@ -49,5 +56,65 @@ class WebMessageTest {
         assertEquals((Object) input.getPayload(), converted.getPayload());
         assertEquals(input.getMetadata(), converted.getMetadata());
         assertFalse(input.getHeaders("Cookie").isEmpty());
+    }
+
+    @Test
+    void existingCookieContractIsCaseSensitiveAndFirstMatch() {
+        WebRequest request = WebRequest.get("/test")
+                .header("cOoKiE", "Session=upper; session=first; session=second")
+                .build();
+
+        assertEquals(List.of("Session=upper", "session=first", "session=second"),
+                     request.getCookies().stream().map(c -> c.getName() + "=" + c.getValue()).toList());
+        assertEquals("upper", request.getCookie("Session").orElseThrow().getValue());
+        assertEquals("first", request.getCookie("session").orElseThrow().getValue());
+        assertEquals(List.of("Session=upper; session=first; session=second"), request.getHeaders("COOKIE"));
+    }
+
+    @Test
+    void repeatedCookieHeaderValuesSurviveMetadataSerialization() {
+        WebRequest input = WebRequest.get("/test")
+                .header("Cookie", "first=one")
+                .header("Cookie", "second=two")
+                .payload(Map.of("body", "value"))
+                .build();
+
+        assertEquals(List.of("first=one", "second=two"), input.getHeaders("cookie"));
+        assertEquals(input.getHeaders("Cookie"), WebRequest.getHeaders(input.getMetadata()).get("COOKIE"));
+
+        JacksonSerializer serializer = new JacksonSerializer();
+        WebRequest copy = (WebRequest) serializer.deserializeMessage(input.serialize(serializer), WEBREQUEST)
+                .toMessage();
+        assertEquals(input.getHeaders("Cookie"), copy.getHeaders("cookie"));
+    }
+
+    @Test
+    void rawHeaderMapRetainsCaseInsensitiveReplacementSemantics() {
+        Map<String, List<String>> rawHeaders = new LinkedHashMap<>();
+        rawHeaders.put("cookie", List.of("first=one"));
+        rawHeaders.put("COOKIE", List.of("second=two"));
+        rawHeaders.put("X-Test", List.of("old"));
+        rawHeaders.put("x-test", List.of("new"));
+        Metadata metadata = Metadata.empty().with(
+                WebRequest.urlKey, "/test", WebRequest.methodKey, HttpRequestMethod.GET,
+                WebRequest.headersKey, rawHeaders);
+
+        assertEquals(List.of("second=two"), WebRequest.getHeaders(metadata).get("Cookie"));
+        assertEquals(List.of("new"), WebRequest.getHeaders(metadata).get("X-Test"));
+    }
+
+    @Test
+    void builderCookieListRetainsMutableContract() {
+        WebRequest.Builder builder = WebRequest.get("/test").cookie(new HttpCookie("first", "one"));
+        List<HttpCookie> cookies = builder.cookies();
+        assertSame(cookies, builder.cookies());
+
+        cookies.add(new HttpCookie("second", "two"));
+        cookies.getFirst().setValue("updated");
+
+        WebRequest request = builder.build();
+        assertEquals(List.of("first=updated; second=two"), request.getHeaders("Cookie"));
+        assertEquals(List.of("updated", "two"),
+                     request.getCookies().stream().map(HttpCookie::getValue).toList());
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestCookieTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestCookieTest.java
@@ -136,6 +136,37 @@ class WebRequestCookieTest {
         assertFalse(request.toBuilder().toString().contains("secret-cookie-value"));
     }
 
+    @Test
+    void builderCopyHasIndependentCookieHeaderValues() {
+        WebRequest original = WebRequest.get("/test")
+                .header("Cookie", "first=one")
+                .build();
+        assertEquals(List.of("first=one"), describe(original.getCookies()));
+
+        WebRequest copy = original.toBuilder()
+                .header("Cookie", "second=two")
+                .build();
+
+        assertEquals(List.of("first=one"), original.getHeaders("Cookie"));
+        assertEquals(List.of("first=one"), describe(original.getCookies()));
+        assertEquals(List.of("first=one", "second=two"), copy.getHeaders("Cookie"));
+        assertEquals(List.of("first=one", "second=two"), describe(copy.getCookies()));
+    }
+
+    @Test
+    void builderCopiesProvidedImmutableHeaderValues() {
+        WebRequest original = WebRequest.get("/test")
+                .headers(Map.of("Cookie", List.of("first=one")))
+                .build();
+
+        WebRequest copy = original.toBuilder()
+                .header("Cookie", "second=two")
+                .build();
+
+        assertEquals(List.of("first=one"), original.getHeaders("Cookie"));
+        assertEquals(List.of("first=one", "second=two"), copy.getHeaders("Cookie"));
+    }
+
     private static List<String> describe(List<HttpCookie> cookies) {
         return cookies.stream().map(c -> c.getName() + "=" + c.getValue()).toList();
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestCookieTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestCookieTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.web;
+
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpCookie;
+import java.util.List;
+import java.util.Map;
+
+import static io.fluxzero.common.MessageType.WEBREQUEST;
+import static io.fluxzero.sdk.web.CookieValueConflictPolicy.ALLOW_CONFLICTING_VALUES;
+import static io.fluxzero.sdk.web.CookieValueConflictPolicy.DEFAULT;
+import static io.fluxzero.sdk.web.CookieValueConflictPolicy.REJECT_CONFLICTING_VALUES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebRequestCookieTest {
+
+    @Test
+    void returnsAllCookieHeaderValuesInLogicalWireOrder() {
+        WebRequest request = WebRequest.get("/test")
+                .header("cOoKiE", "theme=dark; session=abc")
+                .header("COOKIE", "csrf=xyz; session=abc")
+                .build();
+
+        assertEquals(List.of("theme=dark", "session=abc", "csrf=xyz", "session=abc"), describe(request.getCookies()));
+        assertEquals(List.of("session=abc", "session=abc"), describe(request.getCookies("session")));
+        assertTrue(request.getCookies("Session").isEmpty());
+        assertEquals("xyz", request.getCookie("csrf").orElseThrow().getValue());
+        assertEquals("xyz", WebRequest.getCookie(request.getMetadata(), "csrf").orElseThrow().getValue());
+    }
+
+    @Test
+    void defaultAndAllowPoliciesRetainFirstMatchBehavior() {
+        WebRequest request = WebRequest.get("/test")
+                .header("Cookie", "theme=first")
+                .header("Cookie", "theme=second")
+                .build();
+
+        assertEquals("first", request.getCookie("theme").orElseThrow().getValue());
+        assertEquals("first", request.getCookie("theme", DEFAULT).orElseThrow().getValue());
+        assertEquals("first", request.getCookie("theme", ALLOW_CONFLICTING_VALUES).orElseThrow().getValue());
+        assertTrue(request.getCookie("missing", ALLOW_CONFLICTING_VALUES).isEmpty());
+    }
+
+    @Test
+    void rejectPolicyAllowsIdenticalValues() {
+        WebRequest request = WebRequest.get("/test")
+                .header("Cookie", "session=abc")
+                .header("Cookie", "session=abc")
+                .build();
+
+        assertEquals("abc", request.getCookie("session", REJECT_CONFLICTING_VALUES).orElseThrow().getValue());
+        assertTrue(request.getCookie("missing", REJECT_CONFLICTING_VALUES).isEmpty());
+    }
+
+    @Test
+    void rejectPolicyRejectsDifferentValuesWithoutSensitiveData() {
+        WebRequest request = WebRequest.get("/test")
+                .header("Cookie", "private-session=secret-first")
+                .header("Cookie", "private-session=secret-second")
+                .build();
+
+        CookieConflictException exception = assertThrows(
+                CookieConflictException.class,
+                () -> request.getCookie("private-session", REJECT_CONFLICTING_VALUES));
+
+        assertFalse(exception.getMessage().contains("private-session"));
+        assertFalse(exception.getMessage().contains("secret-first"));
+        assertFalse(exception.getMessage().contains("secret-second"));
+    }
+
+    @Test
+    void cookieValuesAreComparedExactlyAndCommaIsNotASeparator() {
+        WebRequest conflicting = WebRequest.get("/test")
+                .header("Cookie", "session=value")
+                .header("Cookie", "session=Value")
+                .build();
+        assertThrows(CookieConflictException.class,
+                     () -> conflicting.getCookie("session", REJECT_CONFLICTING_VALUES));
+
+        WebRequest comma = WebRequest.get("/test").header("Cookie", "one=first,two=second").build();
+        assertEquals(List.of("one=first,two=second"), describe(comma.getCookies()));
+    }
+
+    @Test
+    void builderMetadataAndSerializationRoundTripsPreserveCookieHeaders() {
+        WebRequest input = WebRequest.get("/test")
+                .header("Cookie", "first=one; shared=same")
+                .header("Cookie", "shared=same; last=three")
+                .payload(Map.of("body", "value"))
+                .build();
+
+        WebRequest builderCopy = input.toBuilder().build();
+        assertEquals(input.getHeaders("Cookie"), builderCopy.getHeaders("cookie"));
+        assertEquals(describe(input.getCookies()), describe(builderCopy.getCookies()));
+
+        WebRequest.Builder mutableCopy = input.toBuilder();
+        assertEquals(describe(input.getCookies()), describe(mutableCopy.cookies()));
+        mutableCopy.cookie(new HttpCookie("added", "four"));
+        assertEquals(List.of("first=one", "shared=same", "shared=same", "last=three", "added=four"),
+                     describe(mutableCopy.build().getCookies()));
+
+        JacksonSerializer serializer = new JacksonSerializer();
+        WebRequest serializedCopy = (WebRequest) serializer.deserializeMessage(input.serialize(serializer), WEBREQUEST)
+                .toMessage();
+        assertEquals(input.getHeaders("Cookie"), serializedCopy.getHeaders("cookie"));
+        assertEquals(describe(input.getCookies()), describe(serializedCopy.getCookies()));
+    }
+
+    @Test
+    void requestAndBuilderToStringRedactCookieData() {
+        WebRequest request = WebRequest.get("/test")
+                .header("Cookie", "private-cookie=secret-cookie-value")
+                .build();
+
+        assertFalse(request.toString().contains("private-cookie"));
+        assertFalse(request.toString().contains("secret-cookie-value"));
+        assertFalse(request.toBuilder().toString().contains("private-cookie"));
+        assertFalse(request.toBuilder().toString().contains("secret-cookie-value"));
+    }
+
+    private static List<String> describe(List<HttpCookie> cookies) {
+        return cookies.stream().map(c -> c.getName() + "=" + c.getValue()).toList();
+    }
+}


### PR DESCRIPTION
## Summary

- parse every received `Cookie` field value in logical wire order
- add `getCookies(name)` for exact, case-sensitive all-value lookup
- add `CookieValueConflictPolicy` and a policy-aware `getCookie` overload
- make `DEFAULT` a real policy value that resolves to `ALLOW_CONFLICTING_VALUES` in this release
- retain the existing first-match contract of `getCookie(name)`, while also finding cookies in later fields
- preserve repeated cookie fields through metadata, serialization, `TestFixture`, proxy forwarding, and untouched builder round trips
- correct the existing `getHeaders()` case-sensitivity Javadoc

## Why

HTTP/2 and HTTP/3 permit one logical `Cookie` field to be split across multiple field lines and define their logical value by concatenating them in order with `; `. `WebRequest` previously parsed only the first value, so a cookie in a later field appeared absent.

Repeated cookies with the same name also need an explicit selection rule for security-sensitive callers. The new overload keeps compatibility as the default while allowing callers to reject distinct values deliberately.

## API and compatibility

| API | Behavior |
| --- | --- |
| `getCookies()` | all cookies from all field values, in logical wire order, without collapsing names |
| `getCookies(name)` | all exact, case-sensitive name matches |
| `getCookie(name)` | first match using `CookieValueConflictPolicy.DEFAULT` |
| `DEFAULT` | resolves to `ALLOW_CONFLICTING_VALUES` in this release |
| `ALLOW_CONFLICTING_VALUES` | first match, including when later values differ |
| `REJECT_CONFLICTING_VALUES` | accepts identical repeats and throws on the first distinct parsed value |

`getCookie(name)` remains source- and binary-compatible and keeps first-match selection. Its only behavioral correction is that the first match can now come from a later cookie field. `DEFAULT` is a real enum constant, following the SDK's other policy-enum patterns, and is resolved at the `WebRequest` lookup boundary.

Header names are case-insensitive; cookie names and parsed values are compared exactly. A comma remains cookie-value data and is not treated as a cookie-pair separator.

Untouched builders preserve the original repeated header values. The existing mutable `cookies()` builder extension point materializes raw cookie headers only when used; the removed header itself is the one-time state marker, so no parallel initialization flag is required.

## Security and scope

- `REJECT_CONFLICTING_VALUES` is documented for session, authentication, authorization, flow-binding, and CSRF cookies.
- `CookieConflictException` contains no cookie name or value.
- Cookie headers and values are excluded from request and builder `toString()` output.
- `@CookieParam` binding, parser grammar, size limits, general header-map normalization, and application-wide configuration defaults are unchanged.

## Commit structure

1. lock down the pre-existing cookie and builder contracts
2. correct the inaccurate header-case Javadoc
3. add the multi-value API, conflict policy, implementation, and focused integration tests
4. document the public API and security guidance

## Verification

- `./mvnw -T1 -B clean install`: all 9 reactor modules passed, including proxy/test-server, annotation processors, and Java/Kotlin downstream projects
- `./mvnw -T1 -B site -Pjavadoc`: passed; no new Javadoc diagnostics
- focused WebRequest tests: 13 passed
- full `HandleWebTest`: 155 passed, including the repeated-header `TestFixture` path
- full `ProxyServerTest`: 83 passed, including the HTTP/2 repeated-cookie path
- builder, metadata, and serialization round trips preserve repeated header values
- public bytecode review confirmed only additive API surface and no Lombok runtime references on the supported Java 25 toolchain
- parser hot-path review retains the no-extra-copy path for zero or one `Cookie` field and streams only multiple fields
- `git diff --check` passed
