### PR TITLE
fix(websocket): isolate liveness with bounded parallel dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5598,7 +5598,7 @@ To configure and instantiate a WebSocket-backed client:
 ```java
 WebSocketClient client = WebSocketClient.newInstance(
         WebSocketClient.ClientConfig.builder()
-                .serviceBaseUrl("wss://my.flux.host")
+                .runtimeBaseUrl("wss://my.flux.host")
                 .name("my-service")
                 .build());
 
@@ -5606,7 +5606,7 @@ Fluxzero flux = Fluxzero.builder().build(client);
 ```
 
 This is the most common setup for production and shared environments. It connects to a remote Fluxzero Runtime via the
-service base URL, which must point to the desired deployment.
+runtime base URL, which must point to the desired deployment.
 
 ---
 
@@ -5617,16 +5617,19 @@ and can be created or extended using the `toBuilder()` pattern.
 
 Key options include:
 
-| Setting                     | Description                                                  | Default                          |
-|-----------------------------|--------------------------------------------------------------|----------------------------------|
-| `serviceBaseUrl`            | Base URL for all subsystems <br/>(e.g. `wss://my.flux.host`) | `FLUX_BASE_URL` property         |
-| `name`                      | Name of the application                                      | `FLUX_APPLICATION_NAME` property |
-| `applicationId`             | Optional app ID                                              | `FLUX_APPLICATION_ID` property   |
-| `id`                        | Unique client instance ID                                    | `FLUX_TASK_ID` property or UUID  |
-| `compression`               | Compression algorithm                                        | `LZ4`                            |
-| `pingDelay` / `pingTimeout` | Heartbeat intervals for WebSocket health                     | 10s / 5s                         |
-| `disableMetrics`            | Whether to suppress all outgoing metrics                     | `false`                          |
-| `typeFilter`                | Optional message type restriction                            | `null`                           |
+| Setting | Description | Default |
+|---|---|---|
+| `runtimeBaseUrl` | Base URL for all subsystems, e.g. `wss://my.flux.host` | `FLUXZERO_BASE_URL` or `FLUX_BASE_URL` |
+| `name` | Name of the application | `FLUXZERO_APPLICATION_NAME` or `FLUX_APPLICATION_NAME` |
+| `applicationId` | Optional application ID | `FLUXZERO_APPLICATION_ID` or `FLUX_APPLICATION_ID` |
+| `id` | Unique client instance ID | `FLUXZERO_TASK_ID`, `FLUX_TASK_ID`, or UUID |
+| `supportedCompressionAlgorithms` | Preferred and fallback compression algorithms | ZSTD, then LZ4 |
+| `pingDelay` / `pingTimeout` | Heartbeat intervals for WebSocket health | 10s / 15s |
+| `maxConcurrentRuntimeWebSocketMessages` | Complete runtime messages processed concurrently per session | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_CONCURRENCY` or `3` |
+| `maxRetainedRuntimeWebSocketMessages` | Total assembling, pending, submitted, and active runtime messages per session | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_MESSAGES` or `19` |
+| `maxRetainedRuntimeWebSocketBytes` | Total compressed runtime-message wire bytes retained per session | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_BYTES` or 16 MiB |
+| `disableMetrics` | Whether to suppress all outgoing metrics | `false` |
+| `typeFilter` | Optional message type restriction | `null` |
 
 ---
 
@@ -5639,17 +5642,37 @@ not occupy the default callback executor that acknowledges an already delivered 
 can again complete in parallel. Applications must not rely on WebSocket arrival order or single-threaded result
 completion; request/result correlation remains based on request IDs.
 
-The dispatcher retains at most 19 runtime messages or 16 MiB per session: up to three executor-submitted messages and
-up to 16 pending or being assembled. Submitted, running, and pending messages remain in that accounting until their
-processing fully completes. A single larger message may proceed when it is the only retained message, but no later
-message is accepted alongside it. WebSocket demand remains open at the bound so a subsequent pong can still reach the
-protocol handler. If the next frame starts another data message instead, the SDK fails that session with a
-runtime-ingress overflow before copying its payload; reconnect then occurs rather than buffering beyond the bound.
-Fragment reassembly reserves one of the retained message slots and its accumulated compressed bytes count toward the
-same bound.
-As with a complete message, a single fragmented message may exceed 16 MiB only while it is the sole retained message.
-The byte bound applies to compressed wire payloads and does not cap the size of decompressed object graphs; up to three
-runtime-message decodes may be active per session.
+By default, the dispatcher retains at most 19 runtime messages or 16 MiB per session: up to three executor-submitted
+messages and up to 16 pending or being assembled. Pending capacity is always derived as
+`maxRetainedRuntimeWebSocketMessages - maxConcurrentRuntimeWebSocketMessages`; it is not a separate setting.
+Submitted, running, and pending messages remain in that accounting until their processing fully completes. A single
+larger message may proceed when it is the only retained message, but no later message is accepted alongside it.
+WebSocket demand remains open at the bound so a subsequent pong can still reach the protocol handler. If the next
+frame starts another data message instead, the SDK fails that session with a runtime-ingress overflow before copying
+its payload; reconnect then occurs rather than buffering beyond the bound. Fragment reassembly reserves one retained
+message slot and its accumulated compressed bytes count toward the same bound. The byte bound applies to compressed
+wire payloads and does not cap the size of decompressed object graphs.
+
+The limits can be tuned without disabling protocol isolation:
+
+```java
+WebSocketClient.ClientConfig.builder()
+        .maxConcurrentRuntimeWebSocketMessages(3)
+        .maxRetainedRuntimeWebSocketMessages(19)
+        .maxRetainedRuntimeWebSocketBytes(16L * 1024 * 1024)
+        .build();
+```
+
+An explicit builder value takes precedence over the corresponding environment variable or system/application
+property, which in turn takes precedence over the SDK default. Concurrency must be at least one, retained messages
+must be at least concurrency, and retained bytes must be positive; invalid combinations are rejected when the
+`WebSocketClient` is constructed. There is no disable or unbounded mode. Set concurrency to one for serial runtime
+message callbacks while retaining the liveness isolation.
+
+Increase retained messages for bursts of small responses and retained bytes for larger compressed responses. Increase
+concurrency only when decode or handling is the bottleneck and the process has CPU and heap headroom. These limits are
+per physical WebSocket session, so account for the configured number of subsystem sessions. For tracking workloads,
+consider lowering fetch size or byte limits before substantially increasing the WebSocket retention envelope.
 
 The default `JdkWebsocketConnector` owns a separate shared runtime-data executor. Connectors constructed with an
 explicit `HttpClient` or executor retain their original executor affinity for compatibility; an explicitly supplied

--- a/README.md
+++ b/README.md
@@ -5078,7 +5078,7 @@ fluxzero.defaults.version=2026.05.21
 This enables both the per-handler consumer default and the newer periodic initial-delay default. To choose one behavior
 explicitly without changing the defaults version, set the dedicated property directly. Existing applications that omit
 `fluxzero.defaults.version` keep compatibility behavior: unconfigured handlers share the application default consumer,
-and implicit `@Periodic(initialDelay = -1)` is treated as an immediate first run.
+implicit `@Periodic(initialDelay = -1)` is treated as an immediate first run.
 
 ### Encrypted Values
 
@@ -5627,6 +5627,43 @@ Key options include:
 | `pingDelay` / `pingTimeout` | Heartbeat intervals for WebSocket health                     | 10s / 5s                         |
 | `disableMetrics`            | Whether to suppress all outgoing metrics                     | `false`                          |
 | `typeFilter`                | Optional message type restriction                            | `null`                           |
+
+---
+
+### Runtime Data Dispatch Isolation
+
+SDK clients route complete runtime messages through a bounded dispatcher. With the default `JdkWebsocketConnector`, its
+executor is separate from the JDK WebSocket protocol callback workers. Protocol ingress remains ordered, while up to
+three complete messages from one session may be processed concurrently. Slow decode or result handling therefore does
+not occupy the default callback executor that acknowledges an already delivered pong, and independent runtime results
+can again complete in parallel. Applications must not rely on WebSocket arrival order or single-threaded result
+completion; request/result correlation remains based on request IDs.
+
+The dispatcher retains at most 19 runtime messages or 16 MiB per session: up to three executor-submitted messages and
+up to 16 pending or being assembled. Submitted, running, and pending messages remain in that accounting until their
+processing fully completes. A single larger message may proceed when it is the only retained message, but no later
+message is accepted alongside it. WebSocket demand remains open at the bound so a subsequent pong can still reach the
+protocol handler. If the next frame starts another data message instead, the SDK fails that session with a
+runtime-ingress overflow before copying its payload; reconnect then occurs rather than buffering beyond the bound.
+Fragment reassembly reserves one of the retained message slots and its accumulated compressed bytes count toward the
+same bound.
+As with a complete message, a single fragmented message may exceed 16 MiB only while it is the sole retained message.
+The byte bound applies to compressed wire payloads and does not cap the size of decompressed object graphs; up to three
+runtime-message decodes may be active per session.
+
+The default `JdkWebsocketConnector` owns a separate shared runtime-data executor. Connectors constructed with an
+explicit `HttpClient` or executor retain their original executor affinity for compatibility; an explicitly supplied
+single-thread executor therefore does not promise the same isolation.
+
+Transport anomaly metrics remain disabled by default. Set
+`fluxzero.websocket.transportMetrics.enabled=true` to emit a metric only for ping timeout, runtime-ingress overflow, or
+runtime-data executor rejection. They contain the client type, runtime and Java versions, actual executor
+isolation/ownership and worker mode, retained, executor-submitted, active, and dispatcher-pending message/byte counts,
+the active-concurrency and retained message/byte limits, and last inbound age, but no session or ping IDs. Enabling
+this diagnostic also records the last native inbound activity using monotonic time; the default listener performs no
+corresponding clock reads. Ping-timeout close starts before best-effort metric publication is dispatched. Transport
+metrics follow
+`disableMetrics` and are suppressed on the metrics WebSocket itself to avoid recursive publication.
 
 ---
 

--- a/proxy/src/test/java/io/fluxzero/proxy/ProxyServerBenchmark.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ProxyServerBenchmark.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.fluxzero.common.ObjectUtils.supportsVirtualThreadWorkers;
 import static java.lang.Integer.getInteger;
 import static java.lang.Long.getLong;
 import static java.lang.Math.max;
@@ -78,14 +79,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  *
  * <p>Example:</p>
  * <pre>{@code
- * ./mvnw -pl proxy -am -DskipTests test-compile
+ * ./mvnw -pl proxy -am -DskipTests install
  * ./mvnw -pl proxy -DskipTests \
  *   org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
  *   -Dexec.classpathScope=test \
  *   -Dexec.mainClass=io.fluxzero.proxy.ProxyServerBenchmark \
  *   -Drequests=10000 -Dwarmup=1000 -Dconcurrency=32
  *
- * ./mvnw -pl proxy -am -DskipTests test-compile
+ * ./mvnw -pl proxy -am -DskipTests install
  * ./mvnw -pl proxy -DskipTests \
  *   org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
  *   -Dexec.classpathScope=test \
@@ -100,6 +101,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  *   -Dexec.mainClass=io.fluxzero.proxy.ProxyServerBenchmark \
  *   -Dscenarios=websocket-slow-clients -Dconcurrency=16
  * }</pre>
+ *
+ * <p>The install step is intentional: the separate exec invocation must resolve the current reactor snapshots rather
+ * than older snapshots from the local Maven repository.</p>
+ *
+ * <p>Use {@code -Druntime=test-server} to include the SDK WebSocket result path. The default local runtime measures the
+ * Proxy and local SDK path only.</p>
  *
  * <p>Run this same class on the Undertow baseline commit and the Jetty commit to compare transport overhead.</p>
  */
@@ -118,6 +125,8 @@ public class ProxyServerBenchmark {
 
     @SneakyThrows
     void run(BenchmarkConfig config) {
+        System.out.printf("Proxy benchmark runtime: java=%s, feature=%d%n",
+                          Runtime.version(), Runtime.version().feature());
         byte[] responsePayload = payload(config.responseBytes(), (byte) 'r', PayloadPattern.REPEATED);
         byte[] requestPayload = payload(config.requestBytes(), (byte) 'q', config.payloadPattern());
         String websocketPayload = "w".repeat(config.websocketBytes());
@@ -148,6 +157,10 @@ public class ProxyServerBenchmark {
                     System.out.printf("Proxy benchmark config: %s, runtimeBaseUrl=%s, proxyPort=%d%s%n",
                                       config, runtime.runtimeBaseUrl(), proxyServer.getPort(),
                                       proxyDetails(proxyServer));
+                    boolean exercisesSdkWebsocket = runtime.runtimeBaseUrl() != null;
+                    System.out.println(exercisesSdkWebsocket
+                                               ? "SDK runtime data dispatch: always-on bounded parallel"
+                                               : "SDK runtime data dispatch: not exercised (local client)");
 
                     if (config.scenarios().contains(Scenario.HEALTH)) {
                         ObservedVersions observedVersions = new ObservedVersions();
@@ -221,6 +234,9 @@ public class ProxyServerBenchmark {
                     if (config.scenarios().contains(Scenario.WEBSOCKET_SLOW_CLIENTS)) {
                         benchmarkSlowWebsocketClients("websocket-slow-clients", config, handlers,
                                                       websocketBaseUri.resolve("/benchmark/ws-slow"));
+                    }
+                    if (exercisesSdkWebsocket) {
+                        System.out.println(sdkWebsocketWorkerDetails());
                     }
                 } finally {
                     proxyServer.cancel();
@@ -593,6 +609,21 @@ public class ProxyServerBenchmark {
             details.append(", proxyThreads=").append(minThreads).append("..").append(maxThreads);
         }
         return details.toString();
+    }
+
+    private static String sdkWebsocketWorkerDetails() {
+        long jdkWorkers = countLiveThreads("fluxzero-websocket-jdk-");
+        long runtimeDataWorkers = countLiveThreads("fluxzero-websocket-runtime-data-");
+        String workerMode = supportsVirtualThreadWorkers() ? "virtual-per-task" : "fixed-platform";
+        return "SDK websocket workers: mode=%s, retainedJdk=%d, retainedRuntimeData=%d"
+                .formatted(workerMode, jdkWorkers, runtimeDataWorkers);
+    }
+
+    private static long countLiveThreads(String prefix) {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(Thread::isAlive)
+                .filter(thread -> thread.getName().startsWith(prefix))
+                .count();
     }
 
     private static Object invokeNoArg(Object target, String methodName) {

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
@@ -1050,6 +1050,12 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
         Map<String, Object> userProperties = new java.util.LinkedHashMap<>();
         userProperties.put(CLIENT_HANDSHAKE_CONFIGURATOR_USER_PROPERTY, configurator);
         userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true);
+        userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY,
+                           clientConfig.getMaxConcurrentRuntimeWebSocketMessages());
+        userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY,
+                           clientConfig.getMaxRetainedRuntimeWebSocketMessages());
+        userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY,
+                           clientConfig.getMaxRetainedRuntimeWebSocketBytes());
         if (transportMetricsEnabled) {
             userProperties.put(JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true);
         }

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClient.java
@@ -34,6 +34,7 @@ import io.fluxzero.common.api.RequestBatch;
 import io.fluxzero.common.api.RequestResult;
 import io.fluxzero.common.api.ResultBatch;
 import io.fluxzero.common.application.DefaultPropertySource;
+import io.fluxzero.common.application.PropertySource;
 import io.fluxzero.common.serialization.compression.CompressionAlgorithm;
 import io.fluxzero.common.websocket.WebSocketCapabilities;
 import io.fluxzero.common.websocket.WebSocketTransportCodec;
@@ -82,6 +83,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static io.fluxzero.common.Guarantee.NONE;
 import static io.fluxzero.common.Guarantee.STORED;
 import static io.fluxzero.common.MessageType.METRICS;
 import static io.fluxzero.common.ObjectUtils.newWorkerPool;
@@ -132,6 +134,8 @@ import static java.util.Optional.ofNullable;
  * @see ResultBatch
  */
 public abstract class AbstractWebsocketClient implements WebsocketEndpoint, AutoCloseable {
+    static final String TRANSPORT_METRICS_ENABLED_PROPERTY =
+            "fluxzero.websocket.transportMetrics.enabled";
     private static final Duration CLOSE_HANDSHAKE_TIMEOUT = Duration.ofSeconds(1);
     protected static final Duration CONNECTION_TIMEOUT_FAILSAFE_GRACE = Duration.ofSeconds(5);
     protected static final int CONNECTION_RETRY_LOG_INTERVAL = 10;
@@ -177,7 +181,9 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     private final ExecutorService reconnectExecutor;
     private final Semaphore inFlightWebSocketBytes;
     private final boolean allowMetrics;
+    private final boolean transportMetricsEnabled;
     private final WebsocketResultDiagnostics resultDiagnostics;
+    private final SdkRuntimeWebsocketEndpoint sdkRuntimeEndpoint = new SdkRuntimeWebsocketEndpoint(this);
 
     @Getter(value = AccessLevel.PROTECTED, lazy = true)
     private final Serializer fallbackSerializer = new JacksonSerializer();
@@ -226,20 +232,34 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     public AbstractWebsocketClient(WebsocketConnector connector, URI endpointUri, WebSocketClient client,
                                    boolean allowMetrics, Duration reconnectDelay, ObjectMapper objectMapper,
                                    int numberOfSessions) {
+        this(connector, endpointUri, client, allowMetrics, reconnectDelay, objectMapper, numberOfSessions,
+             DefaultPropertySource.getInstance(), AbstractWebsocketClient::createPingScheduler);
+    }
+
+    AbstractWebsocketClient(WebsocketConnector connector, URI endpointUri, WebSocketClient client,
+                            boolean allowMetrics, Duration reconnectDelay, ObjectMapper objectMapper,
+                            int numberOfSessions, PropertySource propertySource,
+                            PingSchedulerFactory pingSchedulerFactory) {
         this.client = client;
         this.clientConfig = client.getClientConfig();
         this.objectMapper = objectMapper;
         this.allowMetrics = allowMetrics;
-        this.resultDiagnostics = WebsocketResultDiagnostics.from(DefaultPropertySource.getInstance());
+        this.resultDiagnostics = WebsocketResultDiagnostics.from(propertySource);
+        this.transportMetricsEnabled = allowMetrics && !clientConfig.isDisableMetrics()
+                                       && transportMetricsEnabled(propertySource);
         this.inFlightWebSocketBytes = new Semaphore(Math.max(1, clientConfig.getMaxInFlightWebSocketBytes()));
-        this.pingScheduler = new InMemoryTaskScheduler(this + "-pingScheduler",
-                                                       ObjectUtils.newWorkerPool(this + "-ping",
-                                                                                 Math.max(1, numberOfSessions)));
+        this.pingScheduler = pingSchedulerFactory.create(this, numberOfSessions);
         this.resultExecutor = newWorkerPool(this + "-onMessage", 8);
         this.reconnectExecutor = newWorkerPool(this + "-reconnect", Math.max(1, numberOfSessions));
         this.sessionPool = new SessionPool(numberOfSessions, previousSession -> retryOnFailure(
                 () -> connectToServer(connector, endpointUri, previousSession),
                 createConnectionRetryConfiguration(endpointUri, reconnectDelay)));
+    }
+
+    private static TaskScheduler createPingScheduler(AbstractWebsocketClient client, int numberOfSessions) {
+        return new InMemoryTaskScheduler(client + "-pingScheduler",
+                                         ObjectUtils.newWorkerPool(client + "-ping",
+                                                                   Math.max(1, numberOfSessions)));
     }
 
     protected RetryConfiguration createConnectionRetryConfiguration(URI endpointUri, Duration reconnectDelay) {
@@ -288,9 +308,10 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
                 log().debug("Could not determine the replaced websocket session id", e);
             }
         }
-        ConnectionSetup connectionSetup = createConnectionSetup(clientConfig, replacedSessionId);
+        ConnectionSetup connectionSetup = createConnectionSetup(
+                clientConfig, replacedSessionId, transportMetricsEnabled);
         return TimingUtils.callAndWait(
-                () -> connector.connect(this, connectionSetup.options(), endpointUri),
+                () -> connector.connect(sdkRuntimeEndpoint, connectionSetup.options(), endpointUri),
                 clientConfig.getConnectionTimeout().plus(getConnectionTimeoutFailsafeGrace()));
     }
 
@@ -514,7 +535,9 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected void handleMessage(byte[] bytes, WebsocketSession session, ReceiveTiming receiveTiming) {
-        WebsocketResultDiagnostics.FrameTiming frameTiming = resultDiagnostics.frameTiming(receiveTiming);
+        WebsocketResultDiagnostics.FrameTiming frameTiming =
+                resultDiagnostics.frameTiming(receiveTiming, sdkRuntimeEndpoint.currentDispatchTiming());
+        long decodeStartedNanos = resultDiagnostics.monotonicTimestamp();
         JsonType value;
         try {
             value = transportCodec(session).decode(getCompressionAlgorithm(session).decompress(bytes));
@@ -524,6 +547,8 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
             return;
         }
         long decodedTimestamp = resultDiagnostics.timestamp();
+        long decodeDuration = decodeStartedNanos == 0L ? 0L : TimeUnit.NANOSECONDS.toMillis(
+                Math.max(0L, resultDiagnostics.monotonicTimestamp() - decodeStartedNanos));
         String sessionId = getNegotiatedSessionId(session);
         if (value instanceof ResultBatch) {
             String batchId = Fluxzero.generateId();
@@ -532,7 +557,7 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
                 executeResultCallback("result", () -> handleResult(
                         r, batchId, sessionId,
                         resultDiagnostics.resultTiming(
-                                frameTiming, decodedTimestamp, callbackQueuedTimestamp,
+                                frameTiming, decodedTimestamp, decodeDuration, callbackQueuedTimestamp,
                                 resultDiagnostics.timestamp())));
             });
         } else {
@@ -544,7 +569,7 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
             long callbackQueuedTimestamp = resultDiagnostics.timestamp();
             handleResult((RequestResult) value, null, sessionId,
                          resultDiagnostics.resultTiming(
-                                 frameTiming, decodedTimestamp, callbackQueuedTimestamp,
+                                 frameTiming, decodedTimestamp, decodeDuration, callbackQueuedTimestamp,
                                  resultDiagnostics.timestamp()));
         }
     }
@@ -613,53 +638,89 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
             if (v != null) {
                 v.cancel();
             }
-            return !closed.get() ? new PingRegistration(
-                    pingScheduler.schedule(clientConfig.getPingDelay(), () -> sendPing(session))) : null;
+            return newScheduledPing(session);
         });
+    }
+
+    private PingRegistration newScheduledPing(WebsocketSession session) {
+        return !closed.get() && session.isOpen() ? new PingRegistration(
+                pingScheduler.schedule(clientConfig.getPingDelay(), () -> sendPing(session))) : null;
     }
 
     @SneakyThrows
     protected void sendPing(WebsocketSession session) {
         if (!closed.get()) {
             if (session.isOpen()) {
-                var registration = pingDeadlines.compute(getNegotiatedSessionId(session), (k, v) -> {
+                String sessionId = getNegotiatedSessionId(session);
+                var registration = pingDeadlines.compute(sessionId, (k, v) -> {
                     if (v != null) {
                         v.cancel();
                     }
-                    return new PingRegistration(pingScheduler.schedule(clientConfig.getPingTimeout(), () -> {
-                        log().warn("Failed to get a ping response in time for session {}. Resetting connection",
-                                   getNegotiatedSessionId(session));
-                        abort(session, "Ping failed");
-                    }));
+                    if (closed.get() || !session.isOpen()) {
+                        return null;
+                    }
+                    String pingId = Fluxzero.generateId();
+                    return new PingRegistration(pingId, pingScheduler.schedule(
+                            clientConfig.getPingTimeout(), () -> handlePingTimeout(session, sessionId, pingId)));
                 });
-                try {
-                    session.sendPing(ByteBuffer.wrap(registration.getId().getBytes()));
-                } catch (Exception e) {
-                    log().warn("Failed to send ping message", e);
+                if (registration != null) {
+                    try {
+                        session.sendPing(ByteBuffer.wrap(registration.getId().getBytes()));
+                    } catch (Exception e) {
+                        log().warn("Failed to send ping message", e);
+                    }
                 }
             }
         }
     }
 
+    private void handlePingTimeout(WebsocketSession session, String sessionId, String pingId) {
+        PingRegistration current = pingDeadlines.get(sessionId);
+        if (current != null && current.getId().equals(pingId) && pingDeadlines.remove(sessionId, current)) {
+            JdkWebSocketSession.RuntimeDataState metricState = shouldEmitTransportMetrics()
+                    ? transportMetricState(session, null) : null;
+            log().warn("Failed to get a ping response in time for session {}. Resetting connection", sessionId);
+            abort(session, "Ping failed");
+            emitTransportMetricAsync(WebsocketTransportMetric.Event.PING_TIMEOUT, session, metricState);
+        }
+    }
+
     public void onPong(ByteBuffer message, WebsocketSession session) {
+        acknowledgePong(session);
         executeResultCallback("pong", () -> handlePong(session));
     }
 
-    protected void handlePong(WebsocketSession session) {
-        pingDeadlines.compute(getNegotiatedSessionId(session), (k, v) -> {
-            if (v == null) {
+    private void acknowledgePong(WebsocketSession session) {
+        pingDeadlines.compute(getNegotiatedSessionId(session), (key, current) -> {
+            if (current == null) {
                 return null;
             }
-            v.cancel();
-            return schedulePing(session);
+            current.cancel();
+            return newScheduledPing(session);
         });
+    }
+
+    /**
+     * Invoked asynchronously after the pong deadline has been acknowledged on the protocol callback path.
+     * Subclasses may override this method for observation but should not perform liveness bookkeeping themselves.
+     */
+    protected void handlePong(WebsocketSession session) {
     }
 
     @Value
     protected static class PingRegistration implements Registration {
-        String id = Fluxzero.generateId();
+        String id;
         @Delegate
         Registration delegate;
+
+        public PingRegistration(Registration delegate) {
+            this(Fluxzero.generateId(), delegate);
+        }
+
+        PingRegistration(String id, Registration delegate) {
+            this.id = id;
+            this.delegate = delegate;
+        }
     }
 
     @SneakyThrows
@@ -755,6 +816,14 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected void handleError(WebsocketSession session, Throwable e) {
+        if (e instanceof JdkWebSocketSession.RuntimeDataDispatchException dispatchException) {
+            JdkWebSocketSession.RuntimeDataState state = dispatchException.state();
+            emitTransportMetric(
+                    dispatchException.reason() == JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW
+                            ? WebsocketTransportMetric.Event.RUNTIME_INGRESS_OVERFLOW
+                            : WebsocketTransportMetric.Event.RUNTIME_EXECUTOR_REJECTED,
+                    session, state);
+        }
         log().error("Client side error for web socket session {}, connected to endpoint {}",
                     getNegotiatedSessionId(session), session.getRequestURI(), e);
     }
@@ -838,6 +907,87 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
         }
     }
 
+    private void emitTransportMetric(WebsocketTransportMetric.Event event, WebsocketSession session,
+                                     JdkWebSocketSession.RuntimeDataState knownState) {
+        if (!shouldEmitTransportMetrics()) {
+            return;
+        }
+        emitTransportMetricSnapshot(event, session, transportMetricState(session, knownState));
+    }
+
+    private void emitTransportMetricSnapshot(WebsocketTransportMetric.Event event, WebsocketSession session,
+                                             JdkWebSocketSession.RuntimeDataState state) {
+        if (!shouldEmitTransportMetrics()) {
+            return;
+        }
+        try {
+            WebsocketTransportMetric metric = new WebsocketTransportMetric(
+                    event, getClass().getSimpleName(), getRuntimeVersion(session).orElse(null),
+                    Runtime.version().feature(), transportWorkerMode(session),
+                    state.retainedMessages(), state.retainedBytes(), state.inFlightMessages(),
+                    state.inFlightBytes(), state.activeMessages(), state.activeBytes(),
+                    state.pendingMessages(), state.pendingBytes(), state.maxConcurrency(),
+                    state.maxRetainedMessages(), state.maxRetainedBytes(),
+                    state.lastInboundAgeMillis());
+            publishTransportMetric(metric, metricsMetadata().with(
+                    "transportFormat", getTransportFormat(session),
+                    "compression", getCompressionAlgorithm(session)));
+        } catch (Exception e) {
+            if (!closed.get()) {
+                log().warn("Failed to emit websocket transport metric", e);
+            }
+        }
+    }
+
+    private void emitTransportMetricAsync(WebsocketTransportMetric.Event event, WebsocketSession session,
+                                          JdkWebSocketSession.RuntimeDataState state) {
+        if (state == null || !shouldEmitTransportMetrics()) {
+            return;
+        }
+        try {
+            resultExecutor.execute(() -> emitTransportMetricSnapshot(event, session, state));
+        } catch (RejectedExecutionException e) {
+            if (!closed.get()) {
+                log().warn("Failed to schedule websocket transport metric publication", e);
+            }
+        }
+    }
+
+    private JdkWebSocketSession.RuntimeDataState transportMetricState(
+            WebsocketSession session, JdkWebSocketSession.RuntimeDataState knownState) {
+        JdkWebSocketSession.RuntimeDataState observedState = session instanceof JdkWebSocketSession jdkSession
+                ? jdkSession.runtimeDataState() : JdkWebSocketSession.RuntimeDataState.empty();
+        return knownState == null ? observedState
+                : knownState.withLastInboundAgeMillis(observedState.lastInboundAgeMillis());
+    }
+
+    private String transportWorkerMode(WebsocketSession session) {
+        return session instanceof JdkWebSocketSession jdkSession
+                ? jdkSession.runtimeDataWorkerMode() : "custom-connector";
+    }
+
+    private boolean shouldEmitTransportMetrics() {
+        return transportMetricsEnabled && allowMetrics && !clientConfig.isDisableMetrics() && !closed.get();
+    }
+
+    void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+        try {
+            Fluxzero.getOptionally().ifPresentOrElse(
+                    f -> publishMetrics(metric, metadata),
+                    () -> client.getGatewayClient(METRICS).append(
+                            NONE, asMessage(metric).addMetadata(metadata).serialize(getFallbackSerializer())));
+        } catch (SessionPool.ClientClosedException ignored) {
+        } catch (GatewayException e) {
+            if (!closed.get() && !(e.getCause() instanceof SessionPool.ClientClosedException)) {
+                log().warn("Failed to publish websocket transport metric", e);
+            }
+        } catch (Exception e) {
+            if (!closed.get()) {
+                log().warn("Failed to publish websocket transport metric", e);
+            }
+        }
+    }
+
     protected Metadata metricsMetadata() {
         return Metadata.empty();
     }
@@ -886,13 +1036,29 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected static ConnectionSetup createConnectionSetup(ClientConfig clientConfig, String replacedSessionId) {
+        PropertySource propertySource = DefaultPropertySource.getInstance();
+        return createConnectionSetup(clientConfig, replacedSessionId,
+                                     !clientConfig.isDisableMetrics() && transportMetricsEnabled(propertySource));
+    }
+
+    static ConnectionSetup createConnectionSetup(ClientConfig clientConfig, String replacedSessionId,
+                                                  boolean transportMetricsEnabled) {
         ClientHandshakeConfigurator configurator = new ClientHandshakeConfigurator(
                 WebSocketCapabilities.newShortSessionId(), clientConfig, replacedSessionId);
         Map<String, List<String>> headers = new java.util.LinkedHashMap<>();
         configurator.beforeRequest(headers);
-        Map<String, Object> userProperties = Map.of(CLIENT_HANDSHAKE_CONFIGURATOR_USER_PROPERTY, configurator);
+        Map<String, Object> userProperties = new java.util.LinkedHashMap<>();
+        userProperties.put(CLIENT_HANDSHAKE_CONFIGURATOR_USER_PROPERTY, configurator);
+        userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true);
+        if (transportMetricsEnabled) {
+            userProperties.put(JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true);
+        }
         return new ConnectionSetup(new WebsocketConnectionOptions(
                 headers, userProperties, clientConfig.getConnectionTimeout(), List.of()), configurator);
+    }
+
+    static boolean transportMetricsEnabled(PropertySource propertySource) {
+        return propertySource.getBoolean(TRANSPORT_METRICS_ENABLED_PROPERTY);
     }
 
     protected String getNegotiatedSessionId(WebsocketSession session) {
@@ -936,6 +1102,11 @@ public abstract class AbstractWebsocketClient implements WebsocketEndpoint, Auto
     }
 
     protected record ConnectionSetup(WebsocketConnectionOptions options, ClientHandshakeConfigurator configurator) {
+    }
+
+    @FunctionalInterface
+    interface PingSchedulerFactory {
+        TaskScheduler create(AbstractWebsocketClient client, int numberOfSessions);
     }
 
     @RequiredArgsConstructor

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
@@ -42,14 +42,17 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 class JdkWebSocketSession implements WebsocketSession {
     static final String SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY =
             JdkWebSocketSession.class.getName() + ".sdkRuntimeDataDispatch";
+    static final String SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY =
+            JdkWebSocketSession.class.getName() + ".sdkRuntimeDataMaxConcurrency";
+    static final String SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY =
+            JdkWebSocketSession.class.getName() + ".sdkRuntimeDataMaxRetainedMessages";
+    static final String SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY =
+            JdkWebSocketSession.class.getName() + ".sdkRuntimeDataMaxRetainedBytes";
     static final String SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY =
             JdkWebSocketSession.class.getName() + ".sdkTransportMetricsEnabled";
-    static final int MAX_CONCURRENT_RUNTIME_MESSAGES = 3;
-    // The production dispatcher retains these in addition to its three submitted messages.
-    static final int MAX_PENDING_RUNTIME_MESSAGES = 16;
-    static final int MAX_RETAINED_RUNTIME_MESSAGES =
-            MAX_CONCURRENT_RUNTIME_MESSAGES + MAX_PENDING_RUNTIME_MESSAGES;
-    static final long MAX_RETAINED_RUNTIME_BYTES = 16L * 1024 * 1024;
+    static final int DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES = 3;
+    static final int DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES = 19;
+    static final long DEFAULT_MAX_RETAINED_RUNTIME_BYTES = 16L * 1024 * 1024;
 
     private final JdkWebsocketConnector connector;
     private final WebsocketEndpoint endpoint;
@@ -91,27 +94,67 @@ class JdkWebSocketSession implements WebsocketSession {
                         JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
                         Executor callbackExecutor, Executor runtimeDataExecutor) {
         this(connector, endpoint, options, requestUri, handshakeResponse, callbackExecutor, runtimeDataExecutor,
-             MAX_CONCURRENT_RUNTIME_MESSAGES);
+             runtimeDataMaxConcurrency(options), runtimeDataMaxRetainedMessages(options),
+             runtimeDataMaxRetainedBytes(options));
     }
 
-    JdkWebSocketSession(JdkWebsocketConnector connector, WebsocketEndpoint endpoint,
-                        WebsocketConnectionOptions options, URI requestUri,
-                        JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
-                        Executor callbackExecutor, Executor runtimeDataExecutor, int maxConcurrentRuntimeMessages) {
+    private JdkWebSocketSession(JdkWebsocketConnector connector, WebsocketEndpoint endpoint,
+                                WebsocketConnectionOptions options, URI requestUri,
+                                JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
+                                Executor callbackExecutor, Executor runtimeDataExecutor,
+                                int maxConcurrentRuntimeMessages, int maxRetainedRuntimeMessages,
+                                long maxRetainedRuntimeBytes) {
         this.connector = connector;
         this.endpoint = endpoint;
         this.handshakeResponse = handshakeResponse;
         this.callbackExecutor = callbackExecutor;
         this.requestUri = requestUri;
         this.userProperties.putAll(options.userProperties());
+        this.userProperties.remove(SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY);
+        this.userProperties.remove(SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY);
+        this.userProperties.remove(SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY);
         this.runtimeDataWorkerMode = JdkWebsocketConnector.runtimeDataWorkerMode(
                 callbackExecutor, runtimeDataExecutor);
         this.runtimeDataDispatcher = Boolean.TRUE.equals(
                 options.userProperties().get(SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY))
-                ? new RuntimeDataDispatcher(runtimeDataExecutor, maxConcurrentRuntimeMessages) : null;
+                ? new RuntimeDataDispatcher(runtimeDataExecutor, maxConcurrentRuntimeMessages,
+                                            maxRetainedRuntimeMessages, maxRetainedRuntimeBytes) : null;
         this.trackInboundActivity = Boolean.TRUE.equals(
                 options.userProperties().get(SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY));
         this.lastInboundNanos = trackInboundActivity ? System.nanoTime() : 0L;
+    }
+
+    private static int runtimeDataMaxConcurrency(WebsocketConnectionOptions options) {
+        return integerUserProperty(options, SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY,
+                                   DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
+    }
+
+    private static int runtimeDataMaxRetainedMessages(WebsocketConnectionOptions options) {
+        return integerUserProperty(options, SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY,
+                                   DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES);
+    }
+
+    private static long runtimeDataMaxRetainedBytes(WebsocketConnectionOptions options) {
+        Object value = options.userProperties().get(SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY);
+        if (value == null) {
+            return DEFAULT_MAX_RETAINED_RUNTIME_BYTES;
+        }
+        if (value instanceof Long result) {
+            return result;
+        }
+        throw new IllegalArgumentException(
+                SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY + " must be a long");
+    }
+
+    private static int integerUserProperty(WebsocketConnectionOptions options, String name, int defaultValue) {
+        Object value = options.userProperties().get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Integer result) {
+            return result;
+        }
+        throw new IllegalArgumentException(name + " must be an integer");
     }
 
     WebSocket.Listener createListener() {
@@ -611,6 +654,8 @@ class JdkWebSocketSession implements WebsocketSession {
     private class RuntimeDataDispatcher {
         private final Executor executor;
         private final int maxConcurrency;
+        private final int maxRetainedMessages;
+        private final long maxRetainedBytes;
         private final ArrayDeque<Object> pendingMessages = new ArrayDeque<>();
         private final ArrayDeque<RuntimeTask> availableTasks = new ArrayDeque<>();
         private int createdTaskCount;
@@ -627,13 +672,22 @@ class JdkWebSocketSession implements WebsocketSession {
         private boolean stopping;
         private Runnable terminalCallback;
 
-        private RuntimeDataDispatcher(Executor executor, int maxConcurrency) {
-            if (maxConcurrency < 1 || maxConcurrency > MAX_CONCURRENT_RUNTIME_MESSAGES) {
+        private RuntimeDataDispatcher(Executor executor, int maxConcurrency, int maxRetainedMessages,
+                                      long maxRetainedBytes) {
+            if (maxConcurrency < 1) {
+                throw new IllegalArgumentException("Runtime message concurrency must be at least 1");
+            }
+            if (maxRetainedMessages < maxConcurrency) {
                 throw new IllegalArgumentException(
-                        "Runtime message concurrency must be between 1 and " + MAX_CONCURRENT_RUNTIME_MESSAGES);
+                        "Retained runtime messages must be at least runtime message concurrency");
+            }
+            if (maxRetainedBytes < 1) {
+                throw new IllegalArgumentException("Retained runtime bytes must be positive");
             }
             this.executor = executor;
             this.maxConcurrency = maxConcurrency;
+            this.maxRetainedMessages = maxRetainedMessages;
+            this.maxRetainedBytes = maxRetainedBytes;
         }
 
         synchronized DispatchStatus beginMessage(int firstFrameBytes) {
@@ -660,11 +714,17 @@ class JdkWebSocketSession implements WebsocketSession {
             if (!messageAssemblyRetained) {
                 throw new IllegalStateException("No runtime message is being assembled");
             }
-            if (retainedMessages > 1 && retainedBytes + nextFragmentBytes > MAX_RETAINED_RUNTIME_BYTES) {
+            if (retainedMessages > 1 && exceedsByteCapacity(nextFragmentBytes)) {
                 return DispatchStatus.OVERFLOW;
             }
-            messageAssemblyBytes += nextFragmentBytes;
-            retainedBytes += nextFragmentBytes;
+            try {
+                long updatedMessageAssemblyBytes = Math.addExact(messageAssemblyBytes, nextFragmentBytes);
+                long updatedRetainedBytes = Math.addExact(retainedBytes, nextFragmentBytes);
+                messageAssemblyBytes = updatedMessageAssemblyBytes;
+                retainedBytes = updatedRetainedBytes;
+            } catch (ArithmeticException e) {
+                return DispatchStatus.OVERFLOW;
+            }
             return DispatchStatus.ACCEPTED;
         }
 
@@ -687,9 +747,12 @@ class JdkWebSocketSession implements WebsocketSession {
         }
 
         private boolean hasCapacity(int nextMessageBytes) {
-            return retainedMessages < MAX_RETAINED_RUNTIME_MESSAGES
-                    && (retainedMessages == 0
-                    || retainedBytes + nextMessageBytes <= MAX_RETAINED_RUNTIME_BYTES);
+            return retainedMessages < maxRetainedMessages
+                    && (retainedMessages == 0 || !exceedsByteCapacity(nextMessageBytes));
+        }
+
+        private boolean exceedsByteCapacity(int additionalBytes) {
+            return additionalBytes > maxRetainedBytes || retainedBytes > maxRetainedBytes - additionalBytes;
         }
 
         private void scheduleAvailable() {
@@ -843,7 +906,7 @@ class JdkWebSocketSession implements WebsocketSession {
             return new RuntimeDataState(
                     retainedMessages, retainedBytes, inFlightMessages, inFlightBytes, activeMessages, activeBytes,
                     pendingMessageCount, retainedBytes - inFlightBytes, maxConcurrency,
-                    MAX_RETAINED_RUNTIME_MESSAGES, MAX_RETAINED_RUNTIME_BYTES, 0L);
+                    maxRetainedMessages, maxRetainedBytes, 0L);
         }
 
         void closeAfterDrain(Runnable closeCallback) {
@@ -1019,8 +1082,8 @@ class JdkWebSocketSession implements WebsocketSession {
                             long lastInboundAgeMillis) {
         static RuntimeDataState empty() {
             return new RuntimeDataState(
-                    0, 0L, 0, 0L, 0, 0L, 0, 0L, MAX_CONCURRENT_RUNTIME_MESSAGES,
-                    MAX_RETAINED_RUNTIME_MESSAGES, MAX_RETAINED_RUNTIME_BYTES, 0L);
+                    0, 0L, 0, 0L, 0, 0L, 0, 0L, DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES,
+                    DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES, DEFAULT_MAX_RETAINED_RUNTIME_BYTES, 0L);
         }
 
         RuntimeDataState withLastInboundAgeMillis(long lastInboundAgeMillis) {

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebSocketSession.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,17 +37,33 @@ import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
 import static java.util.Optional.ofNullable;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 class JdkWebSocketSession implements WebsocketSession {
+    static final String SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY =
+            JdkWebSocketSession.class.getName() + ".sdkRuntimeDataDispatch";
+    static final String SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY =
+            JdkWebSocketSession.class.getName() + ".sdkTransportMetricsEnabled";
+    static final int MAX_CONCURRENT_RUNTIME_MESSAGES = 3;
+    // The production dispatcher retains these in addition to its three submitted messages.
+    static final int MAX_PENDING_RUNTIME_MESSAGES = 16;
+    static final int MAX_RETAINED_RUNTIME_MESSAGES =
+            MAX_CONCURRENT_RUNTIME_MESSAGES + MAX_PENDING_RUNTIME_MESSAGES;
+    static final long MAX_RETAINED_RUNTIME_BYTES = 16L * 1024 * 1024;
+
     private final JdkWebsocketConnector connector;
     private final WebsocketEndpoint endpoint;
     private final JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse;
     private final Executor callbackExecutor;
+    private final RuntimeDataDispatcher runtimeDataDispatcher;
+    private final String runtimeDataWorkerMode;
+    private final boolean trackInboundActivity;
     private final URI requestUri;
     private final Map<String, Object> userProperties = new ConcurrentHashMap<>();
     private final CompletableFuture<Void> openFuture = new CompletableFuture<>();
     private final AtomicBoolean open = new AtomicBoolean();
     private final AtomicBoolean closeNotified = new AtomicBoolean();
+    private final AtomicBoolean runtimeDataFailureNotified = new AtomicBoolean();
     private final CompletableFuture<Void> closeHandshakeFuture = new CompletableFuture<>();
     private final Object closeInitiationLock = new Object();
     private final Object binaryMessageLock = new Object();
@@ -58,22 +75,47 @@ class JdkWebSocketSession implements WebsocketSession {
     private CompletableFuture<Void> sendTail = CompletableFuture.completedFuture(null);
     private volatile CompletableFuture<Void> closeSendFuture;
     private volatile ByteArrayOutputStream binaryMessage = new ByteArrayOutputStream();
+    private boolean binaryMessageFragmented;
     private volatile WebSocket webSocket;
+    private volatile long lastInboundNanos;
 
     JdkWebSocketSession(JdkWebsocketConnector connector, WebsocketEndpoint endpoint,
                         WebsocketConnectionOptions options, URI requestUri,
                         JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
                         Executor callbackExecutor) {
+        this(connector, endpoint, options, requestUri, handshakeResponse, callbackExecutor, callbackExecutor);
+    }
+
+    JdkWebSocketSession(JdkWebsocketConnector connector, WebsocketEndpoint endpoint,
+                        WebsocketConnectionOptions options, URI requestUri,
+                        JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
+                        Executor callbackExecutor, Executor runtimeDataExecutor) {
+        this(connector, endpoint, options, requestUri, handshakeResponse, callbackExecutor, runtimeDataExecutor,
+             MAX_CONCURRENT_RUNTIME_MESSAGES);
+    }
+
+    JdkWebSocketSession(JdkWebsocketConnector connector, WebsocketEndpoint endpoint,
+                        WebsocketConnectionOptions options, URI requestUri,
+                        JdkWebsocketConnector.CapturedHandshakeResponse handshakeResponse,
+                        Executor callbackExecutor, Executor runtimeDataExecutor, int maxConcurrentRuntimeMessages) {
         this.connector = connector;
         this.endpoint = endpoint;
         this.handshakeResponse = handshakeResponse;
         this.callbackExecutor = callbackExecutor;
         this.requestUri = requestUri;
         this.userProperties.putAll(options.userProperties());
+        this.runtimeDataWorkerMode = JdkWebsocketConnector.runtimeDataWorkerMode(
+                callbackExecutor, runtimeDataExecutor);
+        this.runtimeDataDispatcher = Boolean.TRUE.equals(
+                options.userProperties().get(SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY))
+                ? new RuntimeDataDispatcher(runtimeDataExecutor, maxConcurrentRuntimeMessages) : null;
+        this.trackInboundActivity = Boolean.TRUE.equals(
+                options.userProperties().get(SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY));
+        this.lastInboundNanos = trackInboundActivity ? System.nanoTime() : 0L;
     }
 
     WebSocket.Listener createListener() {
-        return new Listener();
+        return trackInboundActivity ? new ActivityTrackingListener() : new Listener();
     }
 
     void awaitOpen() throws IOException {
@@ -166,15 +208,21 @@ class JdkWebSocketSession implements WebsocketSession {
 
     @Override
     public void abort(WebsocketCloseReason closeReason) {
+        Runnable deferredClose = closeRuntimeDataDispatcher();
         WebSocket webSocket = this.webSocket;
         if (webSocket != null) {
             webSocket.abort();
         }
         closeHandshakeFuture.completeExceptionally(new ClosedChannelException());
-        notifyClose(closeReason);
+        try {
+            notifyClose(closeReason);
+        } finally {
+            runDeferredClose(deferredClose);
+        }
     }
 
     void abortConnecting() {
+        Runnable deferredClose = closeRuntimeDataDispatcher();
         closeNotified.set(true);
         open.set(false);
         WebSocket webSocket = this.webSocket;
@@ -184,11 +232,13 @@ class JdkWebSocketSession implements WebsocketSession {
         connector.removeOpenSession(this);
         openFuture.completeExceptionally(new ClosedChannelException());
         closeHandshakeFuture.completeExceptionally(new ClosedChannelException());
+        runDeferredClose(deferredClose);
     }
 
     private CompletableFuture<Void> initiateClose(WebsocketCloseReason closeReason) {
         CompletableFuture<Void> result;
         boolean notifyEndpoint;
+        Runnable deferredClose;
         WebSocket currentWebSocket;
         synchronized (closeInitiationLock) {
             if (closeSendFuture != null) {
@@ -198,6 +248,7 @@ class JdkWebSocketSession implements WebsocketSession {
                 closeSendFuture = CompletableFuture.completedFuture(null);
                 return closeSendFuture;
             }
+            deferredClose = closeRuntimeDataDispatcher();
             open.set(false);
             connector.removeOpenSession(this);
             currentWebSocket = webSocket;
@@ -216,6 +267,8 @@ class JdkWebSocketSession implements WebsocketSession {
         });
         if (notifyEndpoint) {
             endpoint.onClose(this, closeReason);
+        } else {
+            runDeferredClose(deferredClose);
         }
         return result;
     }
@@ -310,11 +363,29 @@ class JdkWebSocketSession implements WebsocketSession {
     }
 
     private void notifyClose(WebsocketCloseReason closeReason) {
+        Runnable deferredClose = closeRuntimeDataDispatcher();
         open.set(false);
         closeHandshakeFuture.complete(null);
         if (closeNotified.compareAndSet(false, true)) {
             connector.removeOpenSession(this);
             endpoint.onClose(this, closeReason);
+        } else {
+            runDeferredClose(deferredClose);
+        }
+    }
+
+    private void notifyPeerClose(WebsocketCloseReason closeReason) {
+        open.set(false);
+        closeHandshakeFuture.complete(null);
+        if (closeNotified.compareAndSet(false, true)) {
+            connector.removeOpenSession(this);
+            Runnable closeCallback = () -> endpoint.onClose(this, closeReason);
+            if (runtimeDataDispatcher == null) {
+                closeCallback.run();
+            } else {
+                discardIncompleteRuntimeMessage();
+                runtimeDataDispatcher.closeAfterDrain(closeCallback);
+            }
         }
     }
 
@@ -335,43 +406,139 @@ class JdkWebSocketSession implements WebsocketSession {
         }
     }
 
-    private void handleBinary(ByteBuffer message, boolean last) {
-        handleBinary(message, last, null);
+    private boolean handleBinary(ByteBuffer message, boolean last) {
+        return handleBinary(message, last, null);
     }
 
-    private void handleBinary(ByteBuffer message, boolean last, WebsocketEndpoint.ReceiveTiming receiveTiming) {
-        byte[] bytes = appendBinary(message, last);
-        if (bytes != null) {
-            if (receiveTiming == null) {
-                endpoint.onMessage(bytes, this);
-            } else {
-                endpoint.onMessage(bytes, this, receiveTiming);
+    private boolean handleBinary(ByteBuffer message, boolean last, WebsocketEndpoint.ReceiveTiming receiveTiming) {
+        if (runtimeDataDispatcher == null) {
+            byte[] bytes = appendBinary(message, last);
+            if (bytes == null) {
+                return true;
+            }
+            dispatchBinaryMessage(bytes, receiveTiming, null);
+            return true;
+        }
+
+        byte[] bytes;
+        RuntimeDataDispatcher.DispatchStatus status = RuntimeDataDispatcher.DispatchStatus.ACCEPTED;
+        synchronized (binaryMessageLock) {
+            status = binaryMessageFragmented
+                    ? runtimeDataDispatcher.retainMessageFragmentBytes(message.remaining())
+                    : runtimeDataDispatcher.beginMessage(message.remaining());
+            bytes = status == RuntimeDataDispatcher.DispatchStatus.ACCEPTED
+                    ? appendBinaryLocked(message, last) : null;
+        }
+        if (status == RuntimeDataDispatcher.DispatchStatus.OVERFLOW) {
+            failRuntimeDataDispatch(RuntimeDataDispatchException.overflow(runtimeDataDispatcher.state()));
+            return false;
+        }
+        if (status == RuntimeDataDispatcher.DispatchStatus.CLOSED) {
+            return false;
+        }
+        if (bytes == null) {
+            return true;
+        }
+        status = runtimeDataDispatcher.dispatchAssembledMessage(bytes, receiveTiming);
+        return status == RuntimeDataDispatcher.DispatchStatus.ACCEPTED;
+    }
+
+    private void dispatchBinaryMessage(byte[] bytes, WebsocketEndpoint.ReceiveTiming receiveTiming,
+                                       SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming runtimeDispatchTiming) {
+        if (runtimeDispatchTiming != null && endpoint instanceof SdkRuntimeWebsocketEndpoint runtimeEndpoint) {
+            runtimeEndpoint.onRuntimeMessage(bytes, this, receiveTiming, runtimeDispatchTiming);
+        } else if (receiveTiming == null) {
+            endpoint.onMessage(bytes, this);
+        } else {
+            endpoint.onMessage(bytes, this, receiveTiming);
+        }
+    }
+
+    private void failRuntimeDataDispatch(Throwable error) {
+        if (!runtimeDataFailureNotified.compareAndSet(false, true)) {
+            return;
+        }
+        Runnable deferredClose = closeRuntimeDataDispatcher();
+        WebSocket webSocket = this.webSocket;
+        try {
+            notifyError(error);
+        } finally {
+            try {
+                runDeferredClose(deferredClose);
+            } finally {
+                if (webSocket != null) {
+                    webSocket.abort();
+                }
             }
         }
+    }
+
+    private Runnable closeRuntimeDataDispatcher() {
+        if (runtimeDataDispatcher == null) {
+            return null;
+        }
+        synchronized (binaryMessageLock) {
+            binaryMessage = new ByteArrayOutputStream();
+            binaryMessageFragmented = false;
+            return runtimeDataDispatcher.close();
+        }
+    }
+
+    private static void runDeferredClose(Runnable deferredClose) {
+        if (deferredClose != null) {
+            deferredClose.run();
+        }
+    }
+
+    RuntimeDataState runtimeDataState() {
+        RuntimeDataState state = runtimeDataDispatcher == null
+                ? RuntimeDataState.empty() : runtimeDataDispatcher.state();
+        long inboundNanos = lastInboundNanos;
+        long inboundAgeMillis = inboundNanos == 0L ? 0L
+                : NANOSECONDS.toMillis(Math.max(0L, System.nanoTime() - inboundNanos));
+        return state.withLastInboundAgeMillis(inboundAgeMillis);
+    }
+
+    String runtimeDataWorkerMode() {
+        return runtimeDataWorkerMode;
     }
 
     private void handlePong(ByteBuffer message) {
         endpoint.onPong(copyBuffer(message), this);
     }
 
+    private void discardIncompleteRuntimeMessage() {
+        synchronized (binaryMessageLock) {
+            binaryMessage = new ByteArrayOutputStream();
+            binaryMessageFragmented = false;
+            runtimeDataDispatcher.discardMessageAssembly();
+        }
+    }
+
     private byte[] appendBinary(ByteBuffer message, boolean last) {
         synchronized (binaryMessageLock) {
-            if (last && binaryMessage.size() == 0) {
-                return copyBytes(message);
-            }
-            byte[] fragment = copyBytes(message);
-            try {
-                binaryMessage.write(fragment);
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to buffer websocket binary message", e);
-            }
-            if (!last) {
-                return null;
-            }
-            byte[] bytes = binaryMessage.toByteArray();
-            binaryMessage = new ByteArrayOutputStream();
-            return bytes;
+            return appendBinaryLocked(message, last);
         }
+    }
+
+    private byte[] appendBinaryLocked(ByteBuffer message, boolean last) {
+        if (last && !binaryMessageFragmented) {
+            return copyBytes(message);
+        }
+        byte[] fragment = copyBytes(message);
+        binaryMessageFragmented = true;
+        try {
+            binaryMessage.write(fragment);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to buffer websocket binary message", e);
+        }
+        if (!last) {
+            return null;
+        }
+        byte[] bytes = binaryMessage.toByteArray();
+        binaryMessage = new ByteArrayOutputStream();
+        binaryMessageFragmented = false;
+        return bytes;
     }
 
     private static ByteBuffer copyBuffer(ByteBuffer buffer) {
@@ -441,6 +608,289 @@ class JdkWebSocketSession implements WebsocketSession {
         return result;
     }
 
+    private class RuntimeDataDispatcher {
+        private final Executor executor;
+        private final int maxConcurrency;
+        private final ArrayDeque<Object> pendingMessages = new ArrayDeque<>();
+        private final ArrayDeque<RuntimeTask> availableTasks = new ArrayDeque<>();
+        private int createdTaskCount;
+        private long retainedBytes;
+        private int retainedMessages;
+        private int inFlightMessages;
+        private long inFlightBytes;
+        private int activeMessages;
+        private long activeBytes;
+        private boolean messageAssemblyRetained;
+        private long messageAssemblyBytes;
+        private boolean accepting = true;
+        private boolean discardPending;
+        private boolean stopping;
+        private Runnable terminalCallback;
+
+        private RuntimeDataDispatcher(Executor executor, int maxConcurrency) {
+            if (maxConcurrency < 1 || maxConcurrency > MAX_CONCURRENT_RUNTIME_MESSAGES) {
+                throw new IllegalArgumentException(
+                        "Runtime message concurrency must be between 1 and " + MAX_CONCURRENT_RUNTIME_MESSAGES);
+            }
+            this.executor = executor;
+            this.maxConcurrency = maxConcurrency;
+        }
+
+        synchronized DispatchStatus beginMessage(int firstFrameBytes) {
+            if (!accepting) {
+                return DispatchStatus.CLOSED;
+            }
+            if (messageAssemblyRetained) {
+                throw new IllegalStateException("A runtime message is already being assembled");
+            }
+            if (!hasCapacity(firstFrameBytes)) {
+                return DispatchStatus.OVERFLOW;
+            }
+            messageAssemblyRetained = true;
+            messageAssemblyBytes = firstFrameBytes;
+            retainedMessages++;
+            retainedBytes += firstFrameBytes;
+            return DispatchStatus.ACCEPTED;
+        }
+
+        synchronized DispatchStatus retainMessageFragmentBytes(int nextFragmentBytes) {
+            if (!accepting) {
+                return DispatchStatus.CLOSED;
+            }
+            if (!messageAssemblyRetained) {
+                throw new IllegalStateException("No runtime message is being assembled");
+            }
+            if (retainedMessages > 1 && retainedBytes + nextFragmentBytes > MAX_RETAINED_RUNTIME_BYTES) {
+                return DispatchStatus.OVERFLOW;
+            }
+            messageAssemblyBytes += nextFragmentBytes;
+            retainedBytes += nextFragmentBytes;
+            return DispatchStatus.ACCEPTED;
+        }
+
+        DispatchStatus dispatchAssembledMessage(byte[] bytes, WebsocketEndpoint.ReceiveTiming receiveTiming) {
+            Object message = receiveTiming == null ? bytes : new RuntimeMessage(
+                    bytes, receiveTiming, System.currentTimeMillis(), System.nanoTime());
+            synchronized (this) {
+                if (!accepting || !messageAssemblyRetained) {
+                    return DispatchStatus.CLOSED;
+                }
+                if (messageAssemblyBytes != bytes.length) {
+                    throw new IllegalStateException("Retained bytes do not match the assembled runtime message");
+                }
+                messageAssemblyRetained = false;
+                messageAssemblyBytes = 0L;
+                pendingMessages.add(message);
+            }
+            scheduleAvailable();
+            return DispatchStatus.ACCEPTED;
+        }
+
+        private boolean hasCapacity(int nextMessageBytes) {
+            return retainedMessages < MAX_RETAINED_RUNTIME_MESSAGES
+                    && (retainedMessages == 0
+                    || retainedBytes + nextMessageBytes <= MAX_RETAINED_RUNTIME_BYTES);
+        }
+
+        private void scheduleAvailable() {
+            Object message;
+            RuntimeTask task;
+            synchronized (this) {
+                if (discardPending || stopping || inFlightMessages >= maxConcurrency) {
+                    return;
+                }
+                message = pendingMessages.poll();
+                if (message == null) {
+                    return;
+                }
+                inFlightMessages++;
+                inFlightBytes += messageBytes(message).length;
+                task = availableTasks.poll();
+                if (task == null) {
+                    if (createdTaskCount >= maxConcurrency) {
+                        throw new IllegalStateException("Missing reusable runtime dispatch task");
+                    }
+                    task = new RuntimeTask();
+                    createdTaskCount++;
+                }
+                task.message = message;
+            }
+            try {
+                executor.execute(task);
+            } catch (RejectedExecutionException e) {
+                RuntimeDataState rejectedState = discardRejected(task, message);
+                failRuntimeDataDispatch(RuntimeDataDispatchException.executorRejected(rejectedState, e));
+            }
+        }
+
+        private void process(RuntimeTask task, Object message) {
+            Throwable failure = null;
+            boolean active = markActive(message);
+            if (active) {
+                try {
+                    RuntimeMessage timedMessage = message instanceof RuntimeMessage runtimeMessage
+                            ? runtimeMessage : null;
+                    SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming runtimeDispatchTiming = null;
+                    if (timedMessage != null) {
+                        long startedNanos = System.nanoTime();
+                        runtimeDispatchTiming = new SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming(
+                                timedMessage.queuedTimestamp(), System.currentTimeMillis(),
+                                NANOSECONDS.toMillis(Math.max(0L, startedNanos - timedMessage.queuedNanos())));
+                    }
+                    dispatchBinaryMessage(messageBytes(message),
+                                          timedMessage == null ? null : timedMessage.receiveTiming(),
+                                          runtimeDispatchTiming);
+                } catch (Throwable e) {
+                    failure = e;
+                }
+            }
+            complete(task, message, active, failure);
+        }
+
+        private synchronized boolean markActive(Object message) {
+            if (discardPending || stopping) {
+                return false;
+            }
+            activeMessages++;
+            activeBytes += messageBytes(message).length;
+            return true;
+        }
+
+        private void complete(RuntimeTask task, Object message, boolean active, Throwable failure) {
+            Runnable terminal;
+            boolean scheduleMore;
+            synchronized (this) {
+                inFlightMessages--;
+                inFlightBytes -= messageBytes(message).length;
+                if (active) {
+                    activeMessages--;
+                    activeBytes -= messageBytes(message).length;
+                }
+                retainedMessages--;
+                retainedBytes -= messageBytes(message).length;
+                task.message = null;
+                availableTasks.add(task);
+                if (failure != null) {
+                    accepting = false;
+                    stopping = true;
+                }
+                if (failure == null && !stopping && retainedMessages == 0 && terminalCallback != null) {
+                    terminal = terminalCallback;
+                    terminalCallback = null;
+                    discardPending = true;
+                } else {
+                    terminal = null;
+                }
+                scheduleMore = failure == null && !discardPending && !pendingMessages.isEmpty();
+            }
+            if (failure != null) {
+                failRuntimeDataDispatch(failure);
+            } else {
+                if (scheduleMore) {
+                    scheduleAvailable();
+                }
+                if (terminal != null) {
+                    terminal.run();
+                }
+            }
+        }
+
+        private synchronized RuntimeDataState discardRejected(RuntimeTask task, Object rejectedMessage) {
+            RuntimeDataState rejectedState = state();
+            accepting = false;
+            stopping = true;
+            inFlightMessages--;
+            inFlightBytes -= messageBytes(rejectedMessage).length;
+            retainedMessages--;
+            retainedBytes -= messageBytes(rejectedMessage).length;
+            task.message = null;
+            availableTasks.add(task);
+            return rejectedState;
+        }
+
+        synchronized Runnable close() {
+            if (discardPending) {
+                return null;
+            }
+            accepting = false;
+            discardPending = true;
+            Runnable deferredClose = terminalCallback;
+            terminalCallback = null;
+            discardMessageAssembly();
+            Object message;
+            while ((message = pendingMessages.poll()) != null) {
+                retainedMessages--;
+                retainedBytes -= messageBytes(message).length;
+            }
+            return deferredClose;
+        }
+
+        synchronized void discardMessageAssembly() {
+            if (messageAssemblyRetained) {
+                retainedMessages--;
+                retainedBytes -= messageAssemblyBytes;
+                messageAssemblyRetained = false;
+                messageAssemblyBytes = 0L;
+            }
+        }
+
+        private byte[] messageBytes(Object message) {
+            return message instanceof byte[] bytes ? bytes : ((RuntimeMessage) message).bytes();
+        }
+
+        synchronized RuntimeDataState state() {
+            int pendingMessageCount = pendingMessages.size() + (messageAssemblyRetained ? 1 : 0);
+            return new RuntimeDataState(
+                    retainedMessages, retainedBytes, inFlightMessages, inFlightBytes, activeMessages, activeBytes,
+                    pendingMessageCount, retainedBytes - inFlightBytes, maxConcurrency,
+                    MAX_RETAINED_RUNTIME_MESSAGES, MAX_RETAINED_RUNTIME_BYTES, 0L);
+        }
+
+        void closeAfterDrain(Runnable closeCallback) {
+            boolean runNow;
+            synchronized (this) {
+                if (stopping && !discardPending) {
+                    terminalCallback = closeCallback;
+                    runNow = false;
+                } else if (!accepting) {
+                    runNow = true;
+                } else {
+                    accepting = false;
+                    runNow = retainedMessages == 0;
+                    if (runNow) {
+                        discardPending = true;
+                    } else {
+                        terminalCallback = closeCallback;
+                    }
+                }
+            }
+            if (runNow) {
+                closeCallback.run();
+            }
+        }
+
+        private enum DispatchStatus {
+            ACCEPTED, CLOSED, OVERFLOW
+        }
+
+        private record RuntimeMessage(byte[] bytes, WebsocketEndpoint.ReceiveTiming receiveTiming,
+                                      long queuedTimestamp, long queuedNanos) {
+        }
+
+        private class RuntimeTask implements Runnable {
+            private Object message;
+
+            @Override
+            public void run() {
+                Object currentMessage = message;
+                if (currentMessage == null) {
+                    throw new IllegalStateException("Runtime dispatch task has no message");
+                }
+                process(this, currentMessage);
+            }
+        }
+    }
+
     private void handleOpenDispatchFailure(WebSocket webSocket, Throwable error) {
         open.set(false);
         openFuture.completeExceptionally(error);
@@ -469,22 +919,22 @@ class JdkWebSocketSession implements WebsocketSession {
                 long frameDispatchQueuedTimestamp = System.currentTimeMillis();
                 return dispatchCallback(frameDispatchStartedTimestamp -> {
                     try {
-                        handleBinary(data, last, new WebsocketEndpoint.ReceiveTiming(
-                                frameReceivedTimestamp, frameDispatchQueuedTimestamp, frameDispatchStartedTimestamp));
+                        if (handleBinary(data, last, new WebsocketEndpoint.ReceiveTiming(
+                                frameReceivedTimestamp, frameDispatchQueuedTimestamp, frameDispatchStartedTimestamp))) {
+                            requestNext(webSocket);
+                        }
                     } catch (Throwable e) {
                         notifyError(e);
-                    } finally {
-                        requestNext(webSocket);
                     }
                 });
             }
             return dispatchCallback(() -> {
                 try {
-                    handleBinary(data, last);
+                    if (handleBinary(data, last)) {
+                        requestNext(webSocket);
+                    }
                 } catch (Throwable e) {
                     notifyError(e);
-                } finally {
-                    requestNext(webSocket);
                 }
             });
         }
@@ -505,6 +955,16 @@ class JdkWebSocketSession implements WebsocketSession {
 
         @Override
         public CompletableFuture<?> onPong(WebSocket webSocket, ByteBuffer message) {
+            if (runtimeDataDispatcher != null && endpoint instanceof SdkRuntimeWebsocketEndpoint) {
+                try {
+                    handlePong(message);
+                } catch (Throwable e) {
+                    notifyError(e);
+                } finally {
+                    requestNext(webSocket);
+                }
+                return CompletableFuture.completedFuture(null);
+            }
             return dispatchCallback(() -> {
                 try {
                     handlePong(message);
@@ -518,12 +978,93 @@ class JdkWebSocketSession implements WebsocketSession {
 
         @Override
         public CompletableFuture<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-            return dispatchCallback(() -> notifyClose(new WebsocketCloseReason(statusCode, reason)));
+            return dispatchCallback(() -> notifyPeerClose(new WebsocketCloseReason(statusCode, reason)));
         }
 
         @Override
         public void onError(WebSocket webSocket, Throwable error) {
             dispatchCallback(() -> notifyError(error));
+        }
+    }
+
+    private class ActivityTrackingListener extends Listener {
+        @Override
+        public CompletableFuture<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+            lastInboundNanos = System.nanoTime();
+            return super.onBinary(webSocket, data, last);
+        }
+
+        @Override
+        public CompletableFuture<?> onPing(WebSocket webSocket, ByteBuffer message) {
+            lastInboundNanos = System.nanoTime();
+            return super.onPing(webSocket, message);
+        }
+
+        @Override
+        public CompletableFuture<?> onPong(WebSocket webSocket, ByteBuffer message) {
+            lastInboundNanos = System.nanoTime();
+            return super.onPong(webSocket, message);
+        }
+
+        @Override
+        public CompletableFuture<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            lastInboundNanos = System.nanoTime();
+            return super.onClose(webSocket, statusCode, reason);
+        }
+    }
+
+    record RuntimeDataState(int retainedMessages, long retainedBytes, int inFlightMessages, long inFlightBytes,
+                            int activeMessages, long activeBytes, int pendingMessages, long pendingBytes,
+                            int maxConcurrency, int maxRetainedMessages, long maxRetainedBytes,
+                            long lastInboundAgeMillis) {
+        static RuntimeDataState empty() {
+            return new RuntimeDataState(
+                    0, 0L, 0, 0L, 0, 0L, 0, 0L, MAX_CONCURRENT_RUNTIME_MESSAGES,
+                    MAX_RETAINED_RUNTIME_MESSAGES, MAX_RETAINED_RUNTIME_BYTES, 0L);
+        }
+
+        RuntimeDataState withLastInboundAgeMillis(long lastInboundAgeMillis) {
+            return new RuntimeDataState(
+                    retainedMessages, retainedBytes, inFlightMessages, inFlightBytes, activeMessages, activeBytes,
+                    pendingMessages, pendingBytes, maxConcurrency, maxRetainedMessages, maxRetainedBytes,
+                    lastInboundAgeMillis);
+        }
+    }
+
+    static final class RuntimeDataDispatchException extends RejectedExecutionException {
+        private final Reason reason;
+        private final RuntimeDataState state;
+
+        private RuntimeDataDispatchException(Reason reason, RuntimeDataState state, Throwable cause) {
+            super(reason == Reason.OVERFLOW
+                          ? "SDK runtime websocket ingress exceeded its retained message or byte limit; "
+                            + "reconnect is required"
+                          : "SDK runtime websocket data executor rejected dispatch");
+            this.reason = reason;
+            this.state = state;
+            if (cause != null) {
+                initCause(cause);
+            }
+        }
+
+        static RuntimeDataDispatchException overflow(RuntimeDataState state) {
+            return new RuntimeDataDispatchException(Reason.OVERFLOW, state, null);
+        }
+
+        static RuntimeDataDispatchException executorRejected(RuntimeDataState state, Throwable cause) {
+            return new RuntimeDataDispatchException(Reason.EXECUTOR_REJECTED, state, cause);
+        }
+
+        Reason reason() {
+            return reason;
+        }
+
+        RuntimeDataState state() {
+            return state;
+        }
+
+        enum Reason {
+            OVERFLOW, EXECUTOR_REJECTED
         }
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnector.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnector.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static io.fluxzero.common.ObjectUtils.newWorkerPool;
+import static io.fluxzero.common.ObjectUtils.supportsVirtualThreadWorkers;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 
 /**
@@ -53,8 +54,11 @@ import static java.net.http.HttpClient.Version.HTTP_1_1;
  */
 public class JdkWebsocketConnector implements WebsocketConnector {
     static final String DEFAULT_EXECUTOR_THREAD_PREFIX = "fluxzero-websocket-jdk-";
+    static final String SDK_RUNTIME_DATA_EXECUTOR_THREAD_PREFIX = "fluxzero-websocket-runtime-data-";
 
     private static final Executor DEFAULT_EXECUTOR = newWorkerPool(DEFAULT_EXECUTOR_THREAD_PREFIX, 8);
+    private static final Executor SDK_RUNTIME_DATA_EXECUTOR =
+            newWorkerPool(SDK_RUNTIME_DATA_EXECUTOR_THREAD_PREFIX, 8);
     private static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
     private static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
     private static final String WEBSOCKET_ACCEPT_SUFFIX = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
@@ -62,20 +66,23 @@ public class JdkWebsocketConnector implements WebsocketConnector {
     private final HttpClient httpClient;
     private final CapturingCookieHandler cookieHandler;
     private final Executor executor;
+    private final Executor runtimeDataExecutor;
     private final Set<WebsocketSession> openSessions = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates a connector backed by a default HTTP/1.1 {@link HttpClient}.
+     * SDK runtime messages use a separate shared executor from native WebSocket callbacks.
      */
     public JdkWebsocketConnector() {
-        this(HttpClient.newBuilder().version(HTTP_1_1).build());
+        this(HttpClient.newBuilder().version(HTTP_1_1).build(), DEFAULT_EXECUTOR, SDK_RUNTIME_DATA_EXECUTOR);
     }
 
     /**
      * Creates a connector backed by the supplied HTTP client.
      *
      * <p>A single internal client is derived from this client so the connector can install its handshake-header
-     * capturing cookie handler without mutating the original client.</p>
+     * capturing cookie handler without mutating the original client. Its resolved executor is retained for both native
+     * callbacks and SDK runtime messages.</p>
      *
      * @param httpClient base client whose proxy, SSL, authenticator, executor, cookie, and timeout settings are reused
      */
@@ -86,14 +93,19 @@ public class JdkWebsocketConnector implements WebsocketConnector {
     /**
      * Creates a connector backed by the supplied HTTP client and executor.
      *
-     * <p>The executor is used for the internal HTTP client derived from the supplied client and for dispatching native
-     * JDK websocket listener callbacks.</p>
+     * <p>The executor is used for the internal HTTP client derived from the supplied client, native JDK WebSocket
+     * listener callbacks, and SDK runtime messages.</p>
      *
      * @param httpClient base client whose proxy, SSL, authenticator, cookie, and timeout settings are reused
      * @param executor   executor for JDK websocket and listener callback work
      */
     public JdkWebsocketConnector(HttpClient httpClient, Executor executor) {
+        this(httpClient, executor, executor);
+    }
+
+    JdkWebsocketConnector(HttpClient httpClient, Executor executor, Executor runtimeDataExecutor) {
         this.executor = Objects.requireNonNull(executor);
+        this.runtimeDataExecutor = Objects.requireNonNull(runtimeDataExecutor);
         this.cookieHandler = new CapturingCookieHandler(
                 Objects.requireNonNull(httpClient).cookieHandler().orElse(null));
         this.httpClient = createHttpClient(httpClient, this.executor, cookieHandler);
@@ -121,7 +133,7 @@ public class JdkWebsocketConnector implements WebsocketConnector {
         applySubprotocols(builder, connectionOptions.subprotocols());
 
         JdkWebSocketSession session = new JdkWebSocketSession(this, endpoint, connectionOptions, uri,
-                                                             handshakeResponse, executor);
+                                                             handshakeResponse, executor, runtimeDataExecutor);
         HandshakeCapture handshakeCapture = new HandshakeCapture(handshakeResponse);
         CompletableFuture<WebSocket> webSocketFuture = null;
         try {
@@ -152,6 +164,20 @@ public class JdkWebsocketConnector implements WebsocketConnector {
 
     void removeOpenSession(WebsocketSession session) {
         openSessions.remove(session);
+    }
+
+    static String runtimeDataWorkerMode(Executor callbackExecutor, Executor selectedRuntimeDataExecutor) {
+        if (selectedRuntimeDataExecutor == SDK_RUNTIME_DATA_EXECUTOR) {
+            return "isolated-sdk-default-" + defaultWorkerMode();
+        }
+        if (selectedRuntimeDataExecutor == DEFAULT_EXECUTOR) {
+            return "shared-sdk-default-" + defaultWorkerMode();
+        }
+        return selectedRuntimeDataExecutor == callbackExecutor ? "shared-caller-owned" : "isolated-caller-owned";
+    }
+
+    private static String defaultWorkerMode() {
+        return supportsVirtualThreadWorkers() ? "virtual-thread-per-task" : "fixed-platform-pool";
     }
 
     private static void abortConnectingSession(JdkWebSocketSession session, CompletableFuture<WebSocket> webSocketFuture) {

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SdkRuntimeWebsocketEndpoint.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/SdkRuntimeWebsocketEndpoint.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.common.websocket;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Internal adapter that marks SDK runtime endpoints and exposes runtime-dispatch timing while delegating the public
+ * low-level endpoint contract.
+ */
+final class SdkRuntimeWebsocketEndpoint implements WebsocketEndpoint {
+    private final WebsocketEndpoint delegate;
+    private final ThreadLocal<RuntimeDispatchTiming> runtimeDispatchTiming = new ThreadLocal<>();
+
+    SdkRuntimeWebsocketEndpoint(WebsocketEndpoint delegate) {
+        this.delegate = delegate;
+    }
+
+    void onRuntimeMessage(byte[] bytes, WebsocketSession session, ReceiveTiming receiveTiming,
+                          RuntimeDispatchTiming dispatchTiming) {
+        RuntimeDispatchTiming previousTiming = runtimeDispatchTiming.get();
+        runtimeDispatchTiming.set(dispatchTiming);
+        try {
+            delegate.onMessage(bytes, session, receiveTiming);
+        } finally {
+            if (previousTiming == null) {
+                runtimeDispatchTiming.remove();
+            } else {
+                runtimeDispatchTiming.set(previousTiming);
+            }
+        }
+    }
+
+    RuntimeDispatchTiming currentDispatchTiming() {
+        return runtimeDispatchTiming.get();
+    }
+
+    @Override
+    public void onOpen(WebsocketSession session) {
+        delegate.onOpen(session);
+    }
+
+    @Override
+    public void onMessage(byte[] bytes, WebsocketSession session) {
+        delegate.onMessage(bytes, session);
+    }
+
+    @Override
+    public void onMessage(byte[] bytes, WebsocketSession session, ReceiveTiming receiveTiming) {
+        delegate.onMessage(bytes, session, receiveTiming);
+    }
+
+    @Override
+    public boolean captureReceiveTiming() {
+        return delegate.captureReceiveTiming();
+    }
+
+    @Override
+    public void onPong(ByteBuffer data, WebsocketSession session) {
+        delegate.onPong(data, session);
+    }
+
+    @Override
+    public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+        delegate.onClose(session, closeReason);
+    }
+
+    @Override
+    public void onError(WebsocketSession session, Throwable error) {
+        delegate.onError(session, error);
+    }
+
+    /**
+     * Runtime-message dispatch timestamps and monotonic queue duration in milliseconds.
+     */
+    record RuntimeDispatchTiming(long queuedTimestamp, long startedTimestamp, long queueDuration) {
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketResultDiagnostics.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketResultDiagnostics.java
@@ -62,21 +62,37 @@ enum WebsocketResultDiagnostics {
         }
 
         @Override
-        FrameTiming frameTiming(WebsocketEndpoint.ReceiveTiming timing) {
-            if (timing == null) {
-                return FrameTiming.none();
-            }
-            return new FrameTiming(timing.frameReceivedTimestamp(), timing.frameDispatchQueuedTimestamp(),
-                                   timing.frameDispatchStartedTimestamp());
+        long monotonicTimestamp() {
+            return System.nanoTime();
         }
 
         @Override
-        ResultTiming resultTiming(FrameTiming frameTiming, long decodedTimestamp, long callbackQueuedTimestamp,
-                                  long callbackStartedTimestamp) {
+        FrameTiming frameTiming(WebsocketEndpoint.ReceiveTiming timing) {
+            return frameTiming(timing, null);
+        }
+
+        @Override
+        FrameTiming frameTiming(WebsocketEndpoint.ReceiveTiming timing,
+                                SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming runtimeTiming) {
+            if (timing == null) {
+                return FrameTiming.none();
+            }
+            long runtimeQueuedTimestamp = runtimeTiming == null ? 0L : runtimeTiming.queuedTimestamp();
+            long runtimeStartedTimestamp = runtimeTiming == null ? 0L : runtimeTiming.startedTimestamp();
+            long runtimeQueueDuration = runtimeTiming == null ? 0L : runtimeTiming.queueDuration();
+            return new FrameTiming(timing.frameReceivedTimestamp(), timing.frameDispatchQueuedTimestamp(),
+                                   timing.frameDispatchStartedTimestamp(), runtimeQueuedTimestamp,
+                                   runtimeStartedTimestamp, runtimeQueueDuration);
+        }
+
+        @Override
+        ResultTiming resultTiming(FrameTiming frameTiming, long decodedTimestamp, long decodeDuration,
+                                  long callbackQueuedTimestamp, long callbackStartedTimestamp) {
             FrameTiming timing = frameTiming == null ? FrameTiming.none() : frameTiming;
             return new ResultTiming(timing.frameReceivedTimestamp(), timing.frameDispatchQueuedTimestamp(),
-                                    timing.frameDispatchStartedTimestamp(), decodedTimestamp, callbackQueuedTimestamp,
-                                    callbackStartedTimestamp);
+                                    timing.frameDispatchStartedTimestamp(), timing.runtimeDispatchQueuedTimestamp(),
+                                    timing.runtimeDispatchStartedTimestamp(), timing.runtimeQueueDuration(),
+                                    decodedTimestamp, decodeDuration, callbackQueuedTimestamp, callbackStartedTimestamp);
         }
 
         @Override
@@ -119,9 +135,24 @@ enum WebsocketResultDiagnostics {
     }
 
     /**
+     * Returns a monotonic timestamp for duration measurements, or {@code 0} when timings are disabled.
+     */
+    long monotonicTimestamp() {
+        return 0L;
+    }
+
+    /**
      * Converts endpoint receive timing into frame timing metadata input.
      */
     FrameTiming frameTiming(WebsocketEndpoint.ReceiveTiming timing) {
+        return FrameTiming.none();
+    }
+
+    /**
+     * Converts transport and runtime-dispatch timing into metadata input.
+     */
+    FrameTiming frameTiming(WebsocketEndpoint.ReceiveTiming timing,
+                            SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming runtimeTiming) {
         return FrameTiming.none();
     }
 
@@ -130,6 +161,14 @@ enum WebsocketResultDiagnostics {
      */
     ResultTiming resultTiming(FrameTiming frameTiming, long decodedTimestamp, long callbackQueuedTimestamp,
                               long callbackStartedTimestamp) {
+        return resultTiming(frameTiming, decodedTimestamp, 0L, callbackQueuedTimestamp, callbackStartedTimestamp);
+    }
+
+    /**
+     * Combines frame, runtime queue, decode, and callback timings into result metadata input.
+     */
+    ResultTiming resultTiming(FrameTiming frameTiming, long decodedTimestamp, long decodeDuration,
+                              long callbackQueuedTimestamp, long callbackStartedTimestamp) {
         return ResultTiming.none();
     }
 
@@ -163,7 +202,11 @@ enum WebsocketResultDiagnostics {
                 "clientFrameReceivedTimestamp", timing.frameReceivedTimestamp(),
                 "clientFrameDispatchQueuedTimestamp", timing.frameDispatchQueuedTimestamp(),
                 "clientFrameDispatchStartedTimestamp", timing.frameDispatchStartedTimestamp(),
+                "clientRuntimeDispatchQueuedTimestamp", timing.runtimeDispatchQueuedTimestamp(),
+                "clientRuntimeDispatchStartedTimestamp", timing.runtimeDispatchStartedTimestamp(),
+                "clientRuntimeQueueDuration", timing.runtimeQueueDuration(),
                 "clientDecodedTimestamp", timing.decodedTimestamp(),
+                "clientDecodeDuration", timing.decodeDuration(),
                 "clientCallbackQueuedTimestamp", timing.callbackQueuedTimestamp(),
                 "clientCallbackStartedTimestamp", timing.callbackStartedTimestamp());
     }
@@ -202,9 +245,12 @@ enum WebsocketResultDiagnostics {
     record FrameTiming(
             long frameReceivedTimestamp,
             long frameDispatchQueuedTimestamp,
-            long frameDispatchStartedTimestamp
+            long frameDispatchStartedTimestamp,
+            long runtimeDispatchQueuedTimestamp,
+            long runtimeDispatchStartedTimestamp,
+            long runtimeQueueDuration
     ) {
-        private static final FrameTiming NONE = new FrameTiming(0L, 0L, 0L);
+        private static final FrameTiming NONE = new FrameTiming(0L, 0L, 0L, 0L, 0L, 0L);
 
         static FrameTiming none() {
             return NONE;
@@ -218,11 +264,15 @@ enum WebsocketResultDiagnostics {
             long frameReceivedTimestamp,
             long frameDispatchQueuedTimestamp,
             long frameDispatchStartedTimestamp,
+            long runtimeDispatchQueuedTimestamp,
+            long runtimeDispatchStartedTimestamp,
+            long runtimeQueueDuration,
             long decodedTimestamp,
+            long decodeDuration,
             long callbackQueuedTimestamp,
             long callbackStartedTimestamp
     ) {
-        private static final ResultTiming NONE = new ResultTiming(0L, 0L, 0L, 0L, 0L, 0L);
+        private static final ResultTiming NONE = new ResultTiming(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
 
         static ResultTiming none() {
             return NONE;

--- a/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketTransportMetric.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/websocket/WebsocketTransportMetric.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.common.websocket;
+
+import io.fluxzero.common.api.JsonType;
+
+/**
+ * Sparse operational metric emitted only for anomalous SDK websocket transport events.
+ */
+record WebsocketTransportMetric(
+        Event event,
+        String clientType,
+        String runtimeVersion,
+        int javaFeatureVersion,
+        String workerMode,
+        int retainedMessages,
+        long retainedBytes,
+        int inFlightMessages,
+        long inFlightBytes,
+        int activeMessages,
+        long activeBytes,
+        int pendingMessages,
+        long pendingBytes,
+        int maxConcurrency,
+        int maxRetainedMessages,
+        long maxRetainedBytes,
+        long lastInboundAgeMillis
+) implements JsonType {
+
+    enum Event {
+        PING_TIMEOUT,
+        RUNTIME_INGRESS_OVERFLOW,
+        RUNTIME_EXECUTOR_REJECTED
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/client/WebSocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/client/WebSocketClient.java
@@ -37,7 +37,6 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 import java.time.Duration;
@@ -62,6 +61,7 @@ import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.searchUrl;
 import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.trackingUrl;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getFirstAvailableProperty;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getLongProperty;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -85,7 +85,6 @@ import static java.util.stream.Collectors.toMap;
  * @see Client
  * @see LocalClient for an in-memory alternative
  */
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class WebSocketClient extends AbstractClient {
 
     @Getter
@@ -93,6 +92,12 @@ public class WebSocketClient extends AbstractClient {
 
     @Getter(AccessLevel.PRIVATE)
     private final WebSocketClient applicationClient;
+
+    protected WebSocketClient(ClientConfig clientConfig, WebSocketClient applicationClient) {
+        this.clientConfig = Objects.requireNonNull(clientConfig, "clientConfig");
+        this.clientConfig.validateRuntimeWebSocketCapacity();
+        this.applicationClient = applicationClient;
+    }
 
     public static WebSocketClient newInstance(ClientConfig clientConfig) {
         return new WebSocketClient(clientConfig, null);
@@ -179,6 +184,15 @@ public class WebSocketClient extends AbstractClient {
     public static class ClientConfig {
         static final int DEFAULT_MAX_IN_FLIGHT_WEBSOCKET_BYTES = 16 * 1024 * 1024;
         static final String MAX_IN_FLIGHT_WEBSOCKET_BYTES_PROPERTY = "FLUXZERO_MAX_IN_FLIGHT_WEBSOCKET_BYTES";
+        static final int DEFAULT_MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES = 3;
+        static final int DEFAULT_MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES = 19;
+        static final long DEFAULT_MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES = 16L * 1024 * 1024;
+        static final String MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY =
+                "FLUXZERO_WEBSOCKET_RUNTIME_MAX_CONCURRENCY";
+        static final String MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY =
+                "FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_MESSAGES";
+        static final String MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES_PROPERTY =
+                "FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_BYTES";
 
         /**
          * The base URL for all Fluxzero Runtime services, typically starting with {@code wss://}. Defaults to property
@@ -233,6 +247,37 @@ public class WebSocketClient extends AbstractClient {
         @Default
         int maxInFlightWebSocketBytes = getIntegerProperty(MAX_IN_FLIGHT_WEBSOCKET_BYTES_PROPERTY,
                                                            DEFAULT_MAX_IN_FLIGHT_WEBSOCKET_BYTES);
+
+        /**
+         * Maximum number of complete SDK runtime messages decoded or handled concurrently per WebSocket session.
+         * Defaults to {@code FLUXZERO_WEBSOCKET_RUNTIME_MAX_CONCURRENCY}, or {@code 3} when unset. Use {@code 1} for
+         * serial application callbacks while retaining protocol-liveness isolation.
+         */
+        @Default
+        int maxConcurrentRuntimeWebSocketMessages = getIntegerProperty(
+                MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY,
+                DEFAULT_MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES);
+
+        /**
+         * Maximum number of SDK runtime messages retained per WebSocket session across fragment assembly, executor
+         * submission, pending work and active processing. The pending capacity is this value minus
+         * {@link #maxConcurrentRuntimeWebSocketMessages}. Defaults to
+         * {@code FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_MESSAGES}, or {@code 19} when unset.
+         */
+        @Default
+        int maxRetainedRuntimeWebSocketMessages = getIntegerProperty(
+                MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY,
+                DEFAULT_MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES);
+
+        /**
+         * Maximum compressed wire bytes retained by the SDK runtime-data dispatcher per WebSocket session. A single
+         * larger message may proceed while it is the only retained message. Defaults to
+         * {@code FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_BYTES}, or 16 MiB when unset.
+         */
+        @Default
+        long maxRetainedRuntimeWebSocketBytes = getLongProperty(
+                MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES_PROPERTY,
+                DEFAULT_MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES);
 
         /**
          * Maximum payload bytes per physical WebSocket binary frame. Larger logical Fluxzero messages are sent with
@@ -340,6 +385,19 @@ public class WebSocketClient extends AbstractClient {
             HashMap<MessageType, TrackingClientConfig> config = new HashMap<>(trackingConfigs);
             config.put(messageType, trackingConfig);
             return toBuilder().trackingConfigs(config).build();
+        }
+
+        private void validateRuntimeWebSocketCapacity() {
+            if (maxConcurrentRuntimeWebSocketMessages < 1) {
+                throw new IllegalArgumentException("maxConcurrentRuntimeWebSocketMessages must be at least 1");
+            }
+            if (maxRetainedRuntimeWebSocketMessages < maxConcurrentRuntimeWebSocketMessages) {
+                throw new IllegalArgumentException(
+                        "maxRetainedRuntimeWebSocketMessages must be at least maxConcurrentRuntimeWebSocketMessages");
+            }
+            if (maxRetainedRuntimeWebSocketBytes < 1) {
+                throw new IllegalArgumentException("maxRetainedRuntimeWebSocketBytes must be positive");
+            }
         }
 
         private static Map<MessageType, Integer> defaultGatewaySessions() {

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
@@ -16,22 +16,25 @@
 package io.fluxzero.sdk.common.websocket;
 
 import io.fluxzero.common.Backlog;
-import io.fluxzero.common.DirectExecutorService;
 import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.RetryConfiguration;
 import io.fluxzero.common.RetryStatus;
+import io.fluxzero.common.Registration;
 import io.fluxzero.common.TaskScheduler;
+import io.fluxzero.common.ThrowingRunnable;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.api.Request;
 import io.fluxzero.common.api.RequestResult;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.api.VoidResult;
 import io.fluxzero.common.api.publishing.Append;
+import io.fluxzero.common.application.SimplePropertySource;
 import io.fluxzero.common.serialization.compression.CompressionAlgorithm;
 import io.fluxzero.common.websocket.WebSocketCapabilities;
 import io.fluxzero.common.websocket.WebSocketTransportFormat;
 import io.fluxzero.sdk.common.SdkVersion;
+import io.fluxzero.sdk.configuration.ApplicationProperties;
 import io.fluxzero.sdk.configuration.client.WebSocketClient;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +44,9 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.time.Clock;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +85,54 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AbstractWebsocketClientTest {
+
+    @Test
+    void transportMetricsAreOptIn() {
+        assertFalse(AbstractWebsocketClient.transportMetricsEnabled(new SimplePropertySource(Map.of())));
+        assertFalse(AbstractWebsocketClient.transportMetricsEnabled(new SimplePropertySource(Map.of(
+                AbstractWebsocketClient.TRANSPORT_METRICS_ENABLED_PROPERTY, "false"))));
+        assertTrue(AbstractWebsocketClient.transportMetricsEnabled(new SimplePropertySource(Map.of(
+                AbstractWebsocketClient.TRANSPORT_METRICS_ENABLED_PROPERTY, "true"))));
+    }
+
+    @Test
+    void transportMetricsAreDisabledByDefault() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(clientConfig, true);
+        WebsocketSession session = mockSession("client123_runtime456");
+
+        try {
+            client.handleError(session, JdkWebSocketSession.RuntimeDataDispatchException.overflow(
+                    runtimeDataState(2, 4_096L, 2, 0)));
+
+            assertNull(client.transportMetric.get());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void connectionSetupAlwaysMarksSdkRuntimeDataDispatch() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+
+        AbstractWebsocketClient.ConnectionSetup defaults =
+                AbstractWebsocketClient.createConnectionSetup(clientConfig);
+        AbstractWebsocketClient.ConnectionSetup metricsEnabled =
+                AbstractWebsocketClient.createConnectionSetup(clientConfig, null, true);
+
+        assertEquals(true, defaults.options().userProperties().get(
+                JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY));
+        assertEquals(true, metricsEnabled.options().userProperties().get(
+                JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY));
+        assertFalse(defaults.options().userProperties().containsKey(
+                JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY));
+    }
 
     @Test
     void supportedCompressionAlgorithmsDefaultToConfiguredCompressionFirst() {
@@ -432,12 +485,17 @@ class AbstractWebsocketClientTest {
     @Test
     void clientResultTimingMetadataIncludesClientTimestamps() {
         Metadata metadata = AbstractWebsocketClient.clientResultTimingMetadata(
-                new WebsocketResultDiagnostics.ResultTiming(1_000L, 1_005L, 1_008L, 1_010L, 1_020L, 1_030L));
+                new WebsocketResultDiagnostics.ResultTiming(
+                        1_000L, 1_005L, 1_008L, 1_010L, 1_012L, 2L, 1_015L, 3L, 1_020L, 1_030L));
 
         assertEquals("1000", metadata.get("clientFrameReceivedTimestamp"));
         assertEquals("1005", metadata.get("clientFrameDispatchQueuedTimestamp"));
         assertEquals("1008", metadata.get("clientFrameDispatchStartedTimestamp"));
-        assertEquals("1010", metadata.get("clientDecodedTimestamp"));
+        assertEquals("1010", metadata.get("clientRuntimeDispatchQueuedTimestamp"));
+        assertEquals("1012", metadata.get("clientRuntimeDispatchStartedTimestamp"));
+        assertEquals("2", metadata.get("clientRuntimeQueueDuration"));
+        assertEquals("1015", metadata.get("clientDecodedTimestamp"));
+        assertEquals("3", metadata.get("clientDecodeDuration"));
         assertEquals("1020", metadata.get("clientCallbackQueuedTimestamp"));
         assertEquals("1030", metadata.get("clientCallbackStartedTimestamp"));
     }
@@ -489,16 +547,21 @@ class AbstractWebsocketClientTest {
         result.setResponseQueuedTimestamp(2_260L);
         result.setResponseSendStartTimestamp(2_275L);
         WebsocketResultDiagnostics.FrameTiming frameTiming = WebsocketResultDiagnostics.HEAVY.frameTiming(
-                new WebsocketEndpoint.ReceiveTiming(1_000L, 1_005L, 1_008L));
+                new WebsocketEndpoint.ReceiveTiming(1_000L, 1_005L, 1_008L),
+                new SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming(1_009L, 1_011L, 2L));
         WebsocketResultDiagnostics.ResultTiming resultTiming = WebsocketResultDiagnostics.HEAVY.resultTiming(
-                frameTiming, 1_010L, 1_020L, 1_030L);
+                frameTiming, 1_015L, 4L, 1_020L, 1_030L);
 
         Metadata metadata = WebsocketResultDiagnostics.HEAVY.metadata(result, resultTiming);
 
         assertEquals("2260", metadata.get("responseQueuedTimestamp"));
         assertEquals("2275", metadata.get("responseSendStartTimestamp"));
         assertEquals("1000", metadata.get("clientFrameReceivedTimestamp"));
-        assertEquals("1010", metadata.get("clientDecodedTimestamp"));
+        assertEquals("1009", metadata.get("clientRuntimeDispatchQueuedTimestamp"));
+        assertEquals("1011", metadata.get("clientRuntimeDispatchStartedTimestamp"));
+        assertEquals("2", metadata.get("clientRuntimeQueueDuration"));
+        assertEquals("1015", metadata.get("clientDecodedTimestamp"));
+        assertEquals("4", metadata.get("clientDecodeDuration"));
         assertEquals("1030", metadata.get("clientCallbackStartedTimestamp"));
     }
 
@@ -538,15 +601,26 @@ class AbstractWebsocketClientTest {
     }
 
     @Test
-    void pingSchedulerUsesDedicatedWorkerPool() throws Exception {
+    void pingTimeoutRunsOnDedicatedWorkerInsteadOfSchedulerThread() {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
                 .name("test-client")
+                .pingTimeout(Duration.ZERO)
                 .build();
         TestClient client = new TestClient(mock(WebsocketConnector.class), clientConfig, 2);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+        AtomicReference<String> closeThread = new AtomicReference<>();
+        when(session.closeAsync(any())).thenAnswer(invocation -> {
+            closeThread.set(Thread.currentThread().getName());
+            return CompletableFuture.completedFuture(null);
+        });
 
         try {
-            assertFalse(pingSchedulerWorkerPool(client) instanceof DirectExecutorService);
+            client.sendPing(session);
+
+            verify(session, org.mockito.Mockito.timeout(1_000)).closeAsync(any());
+            assertFalse(closeThread.get().contains("pingScheduler"));
         } finally {
             client.close();
         }
@@ -707,6 +781,341 @@ class AbstractWebsocketClientTest {
     }
 
     @Test
+    void pongCancelsDeadlineBeforeResultExecutorCallbackRuns() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        CallbackObservingClient client = new CallbackObservingClient(
+                mock(WebsocketConnector.class), clientConfig, taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+
+        try {
+            client.sendPing(session);
+            ThrowingRunnable staleTimeout = taskScheduler.dequeue();
+            client.onPong(ByteBuffer.allocate(0), session);
+            assertTrue(client.pongHandled.await(1, TimeUnit.SECONDS));
+            staleTimeout.run();
+
+            verify(session, never()).closeAsync(any());
+            assertEquals(1, taskScheduler.pendingTaskCount(),
+                         "Receiving a pong should replace its deadline before result callbacks can finish");
+        } finally {
+            client.allowPongToFinish.countDown();
+            client.close();
+        }
+    }
+
+    @Test
+    void pongDoesNotScheduleAnotherPingForClosedSession() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        TestClient client = new TestClient(mock(WebsocketConnector.class), clientConfig, taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true, false);
+
+        try {
+            client.sendPing(session);
+            client.onPong(ByteBuffer.allocate(0), session);
+
+            assertEquals(0, taskScheduler.pendingTaskCount());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void pingIsNotSentWhenSessionClosesBeforeDeadlineRegistration() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        TestClient client = new TestClient(mock(WebsocketConnector.class), clientConfig, taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true, false);
+
+        try {
+            assertDoesNotThrow(() -> client.sendPing(session));
+
+            verify(session, never()).sendPing(any());
+            assertEquals(0, taskScheduler.pendingTaskCount());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void stalePingTimeoutDoesNotAbortSessionAfterPongWasHandled() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        PongSchedulingClient client = new PongSchedulingClient(
+                mock(WebsocketConnector.class), clientConfig, taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+
+        try {
+            client.sendPing(session);
+            ThrowingRunnable staleTimeout = taskScheduler.dequeue();
+
+            client.onPong(ByteBuffer.allocate(0), session);
+            assertTrue(client.pongHandled.await(1, TimeUnit.SECONDS));
+            assertEquals(1, taskScheduler.pendingTaskCount(),
+                         "Pong handling should schedule the next ping before the stale timeout runs");
+            staleTimeout.run();
+
+            verify(session, never()).closeAsync(any());
+            assertEquals(1, taskScheduler.pendingTaskCount(),
+                         "A stale timeout must not remove the next ping registration");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void activePingTimeoutStillAbortsSession() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        TestClient client = new TestClient(mock(WebsocketConnector.class), clientConfig, taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+
+        try {
+            client.sendPing(session);
+            ThrowingRunnable activeTimeout = taskScheduler.dequeue();
+
+            activeTimeout.run();
+
+            verify(session).closeAsync(any());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void runtimeIngressOverflowPublishesSparseTransportMetric() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), new ManuallyTriggeredTaskScheduler());
+        WebsocketSession session = mockSession("client123_runtime456");
+        session.getUserProperties().put(AbstractWebsocketClient.RUNTIME_VERSION_USER_PROPERTY, "9.8.7");
+        JdkWebSocketSession.RuntimeDataDispatchException overflow =
+                JdkWebSocketSession.RuntimeDataDispatchException.overflow(
+                        runtimeDataState(2, 4_096L, 2, 0));
+
+        try {
+            client.handleError(session, overflow);
+
+            WebsocketTransportMetric metric = client.transportMetric.get();
+            assertEquals(WebsocketTransportMetric.Event.RUNTIME_INGRESS_OVERFLOW, metric.event());
+            assertEquals(2, metric.retainedMessages());
+            assertEquals(4_096L, metric.retainedBytes());
+            assertEquals(2, metric.inFlightMessages());
+            assertEquals(4_096L, metric.inFlightBytes());
+            assertEquals(2, metric.activeMessages());
+            assertEquals(4_096L, metric.activeBytes());
+            assertEquals(0, metric.pendingMessages());
+            assertEquals(0L, metric.pendingBytes());
+            assertEquals(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, metric.maxConcurrency());
+            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, metric.maxRetainedMessages());
+            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, metric.maxRetainedBytes());
+            assertEquals(Runtime.version().feature(), metric.javaFeatureVersion());
+            assertEquals("custom-connector", metric.workerMode());
+            assertEquals("9.8.7", metric.runtimeVersion());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void runtimeExecutorRejectionPublishesSparseTransportMetric() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), new ManuallyTriggeredTaskScheduler());
+        WebsocketSession session = mockSession("client123_runtime456");
+        JdkWebSocketSession.RuntimeDataDispatchException rejection =
+                JdkWebSocketSession.RuntimeDataDispatchException.executorRejected(
+                        runtimeDataState(1, 1_024L, 0, 1),
+                        new IllegalStateException("executor unavailable"));
+
+        try {
+            client.handleError(session, rejection);
+
+            WebsocketTransportMetric metric = client.transportMetric.get();
+            assertEquals(WebsocketTransportMetric.Event.RUNTIME_EXECUTOR_REJECTED, metric.event());
+            assertEquals(1, metric.retainedMessages());
+            assertEquals(1_024L, metric.retainedBytes());
+            assertEquals(0, metric.inFlightMessages());
+            assertEquals(0L, metric.inFlightBytes());
+            assertEquals(0, metric.activeMessages());
+            assertEquals(0L, metric.activeBytes());
+            assertEquals(1, metric.pendingMessages());
+            assertEquals(1_024L, metric.pendingBytes());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void transportMetricsAreSuppressedForMetricsWebsocket() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("metrics-client")
+                .build();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, false, transportMetricsProperties(), new ManuallyTriggeredTaskScheduler());
+        WebsocketSession session = mockSession("client123_runtime456");
+
+        try {
+            client.handleError(session, JdkWebSocketSession.RuntimeDataDispatchException.overflow(
+                    runtimeDataState(2, 4_096L, 2, 0)));
+
+            assertNull(client.transportMetric.get());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void pingTimeoutPublishesSparseTransportMetricAfterStartingSessionClose() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), taskScheduler);
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+
+        try {
+            client.sendPing(session);
+            taskScheduler.dequeue().run();
+
+            assertTrue(client.transportMetricPublished.await(1, TimeUnit.SECONDS));
+            assertEquals(WebsocketTransportMetric.Event.PING_TIMEOUT,
+                         client.transportMetric.get().event());
+            verify(session).closeAsync(any());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void transportMetricsAreSuppressedWhenMetricsAreDisabled() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .disableMetrics(true)
+                .build();
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), new ManuallyTriggeredTaskScheduler());
+        WebsocketSession session = mockSession("client123_runtime456");
+
+        try {
+            client.handleError(session, JdkWebSocketSession.RuntimeDataDispatchException.overflow(
+                    runtimeDataState(2, 4_096L, 2, 0)));
+
+            assertNull(client.transportMetric.get());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void transportMetricFailureDoesNotPreventPingTimeoutClose() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        CountDownLatch metricPublicationAttempted = new CountDownLatch(1);
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), taskScheduler) {
+            @Override
+            void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+                metricPublicationAttempted.countDown();
+                throw new IllegalStateException("metrics unavailable");
+            }
+        };
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+
+        try {
+            client.sendPing(session);
+
+            assertDoesNotThrow(() -> taskScheduler.dequeue().run());
+            verify(session).closeAsync(any());
+            assertTrue(metricPublicationAttempted.await(1, TimeUnit.SECONDS));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void transportMetricPublicationCannotDelayPingTimeoutClose() throws Exception {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .build();
+        ManuallyTriggeredTaskScheduler taskScheduler = new ManuallyTriggeredTaskScheduler();
+        CountDownLatch metricStarted = new CountDownLatch(1);
+        CountDownLatch releaseMetric = new CountDownLatch(1);
+        TransportMetricObservingClient client = new TransportMetricObservingClient(
+                clientConfig, true, transportMetricsProperties(), taskScheduler) {
+            @Override
+            void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+                metricStarted.countDown();
+                try {
+                    releaseMetric.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+        WebsocketSession session = mockSession("client123_runtime456");
+        when(session.isOpen()).thenReturn(true);
+        ExecutorService timeoutExecutor = Executors.newSingleThreadExecutor();
+
+        try {
+            client.sendPing(session);
+            Future<?> timeout = timeoutExecutor.submit(() -> {
+                try {
+                    taskScheduler.dequeue().run();
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+
+            assertTrue(metricStarted.await(1, TimeUnit.SECONDS));
+            verify(session, org.mockito.Mockito.timeout(250)).closeAsync(any());
+            releaseMetric.countDown();
+            timeout.get(1, TimeUnit.SECONDS);
+        } finally {
+            releaseMetric.countDown();
+            timeoutExecutor.shutdownNow();
+            client.close();
+        }
+    }
+
+    @Test
     void onPongIsHandledAsynchronously() throws Exception {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
@@ -760,17 +1169,21 @@ class AbstractWebsocketClientTest {
                 .build();
     }
 
-    private static TaskScheduler pingScheduler(AbstractWebsocketClient client) throws Exception {
-        Field field = AbstractWebsocketClient.class.getDeclaredField("pingScheduler");
-        field.setAccessible(true);
-        return (TaskScheduler) field.get(client);
+    private static SimplePropertySource transportMetricsProperties() {
+        return new SimplePropertySource(Map.of(
+                AbstractWebsocketClient.TRANSPORT_METRICS_ENABLED_PROPERTY, "true"));
     }
 
-    private static Object pingSchedulerWorkerPool(AbstractWebsocketClient client) throws Exception {
-        Object scheduler = pingScheduler(client);
-        Field field = scheduler.getClass().getDeclaredField("workerPool");
-        field.setAccessible(true);
-        return field.get(scheduler);
+    private static JdkWebSocketSession.RuntimeDataState runtimeDataState(
+            int retainedMessages, long retainedBytes, int inFlightMessages, int pendingMessages) {
+        return new JdkWebSocketSession.RuntimeDataState(
+                retainedMessages, retainedBytes, inFlightMessages,
+                inFlightMessages == 0 ? 0L : retainedBytes,
+                inFlightMessages, inFlightMessages == 0 ? 0L : retainedBytes,
+                pendingMessages, pendingMessages == 0 ? 0L : retainedBytes,
+                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
+                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
+                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 0L);
     }
 
     private static WebSocketClient websocketClient(AbstractWebsocketClient client) throws Exception {
@@ -789,8 +1202,20 @@ class AbstractWebsocketClientTest {
                   true, Duration.ofSeconds(1), defaultObjectMapper, numberOfSessions);
         }
 
+        TestClient(WebsocketConnector container, WebSocketClient.ClientConfig clientConfig,
+                   TaskScheduler pingScheduler) {
+            super(container, URI.create("ws://localhost"), WebSocketClient.newInstance(clientConfig),
+                  true, Duration.ofSeconds(1), defaultObjectMapper, 1,
+                  new SimplePropertySource(Map.of()), (client, numberOfSessions) -> pingScheduler);
+        }
+
         void publishTestMetric(Append append) {
             tryPublishMetrics(append, Metadata.empty());
+        }
+
+        @Override
+        void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+            // Transport metric publication is tested independently by TransportMetricObservingClient.
         }
     }
 
@@ -873,6 +1298,11 @@ class AbstractWebsocketClientTest {
             super(container, clientConfig);
         }
 
+        CallbackObservingClient(WebsocketConnector container, WebSocketClient.ClientConfig clientConfig,
+                                TaskScheduler pingScheduler) {
+            super(container, clientConfig, pingScheduler);
+        }
+
         @Override
         protected void handlePong(WebsocketSession session) {
             pongThread.set(Thread.currentThread().getName());
@@ -882,6 +1312,92 @@ class AbstractWebsocketClientTest {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+        }
+    }
+
+    private static class PongSchedulingClient extends TestClient {
+        private final CountDownLatch pongHandled = new CountDownLatch(1);
+
+        PongSchedulingClient(WebsocketConnector container, WebSocketClient.ClientConfig clientConfig) {
+            super(container, clientConfig);
+        }
+
+        PongSchedulingClient(WebsocketConnector container, WebSocketClient.ClientConfig clientConfig,
+                             TaskScheduler pingScheduler) {
+            super(container, clientConfig, pingScheduler);
+        }
+
+        @Override
+        protected void handlePong(WebsocketSession session) {
+            try {
+                super.handlePong(session);
+            } finally {
+                pongHandled.countDown();
+            }
+        }
+    }
+
+    private static class TransportMetricObservingClient extends AbstractWebsocketClient {
+        private final AtomicReference<WebsocketTransportMetric> transportMetric = new AtomicReference<>();
+        private final CountDownLatch transportMetricPublished = new CountDownLatch(1);
+
+        TransportMetricObservingClient(WebSocketClient.ClientConfig clientConfig, boolean allowMetrics) {
+            this(clientConfig, allowMetrics, new SimplePropertySource(Map.of()),
+                 new ManuallyTriggeredTaskScheduler());
+        }
+
+        TransportMetricObservingClient(WebSocketClient.ClientConfig clientConfig, boolean allowMetrics,
+                                       SimplePropertySource propertySource, TaskScheduler pingScheduler) {
+            super(mock(WebsocketConnector.class), URI.create("ws://localhost"), WebSocketClient.newInstance(clientConfig),
+                  allowMetrics, Duration.ofSeconds(1), defaultObjectMapper, 1, propertySource,
+                  (client, numberOfSessions) -> pingScheduler);
+        }
+
+        @Override
+        void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+            transportMetric.set(metric);
+            transportMetricPublished.countDown();
+        }
+    }
+
+    private static class ManuallyTriggeredTaskScheduler implements TaskScheduler {
+        private final ArrayDeque<ScheduledTask> scheduledTasks = new ArrayDeque<>();
+
+        @Override
+        public synchronized Registration schedule(long deadline, ThrowingRunnable task) {
+            ScheduledTask scheduledTask = new ScheduledTask(task);
+            scheduledTasks.add(scheduledTask);
+            return () -> {
+                synchronized (ManuallyTriggeredTaskScheduler.this) {
+                    scheduledTasks.remove(scheduledTask);
+                }
+            };
+        }
+
+        synchronized ThrowingRunnable dequeue() {
+            return scheduledTasks.remove().task();
+        }
+
+        synchronized int pendingTaskCount() {
+            return scheduledTasks.size();
+        }
+
+        @Override
+        public Clock clock() {
+            return Clock.fixed(java.time.Instant.EPOCH, java.time.ZoneOffset.UTC);
+        }
+
+        @Override
+        public void executeExpiredTasks() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public synchronized void shutdown() {
+            scheduledTasks.clear();
+        }
+
+        private record ScheduledTask(ThrowingRunnable task) {
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
@@ -135,6 +135,25 @@ class AbstractWebsocketClientTest {
     }
 
     @Test
+    void connectionSetupPropagatesEffectiveRuntimeWebSocketCapacity() {
+        WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
+                .runtimeBaseUrl("ws://localhost")
+                .name("test-client")
+                .maxConcurrentRuntimeWebSocketMessages(2)
+                .maxRetainedRuntimeWebSocketMessages(11)
+                .maxRetainedRuntimeWebSocketBytes(8L * 1024 * 1024)
+                .build();
+
+        Map<String, Object> userProperties = AbstractWebsocketClient.createConnectionSetup(clientConfig)
+                .options().userProperties();
+
+        assertEquals(2, userProperties.get(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY));
+        assertEquals(11, userProperties.get(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY));
+        assertEquals(8L * 1024 * 1024,
+                     userProperties.get(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY));
+    }
+
+    @Test
     void supportedCompressionAlgorithmsDefaultToConfiguredCompressionFirst() {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
@@ -908,6 +927,9 @@ class AbstractWebsocketClientTest {
         WebSocketClient.ClientConfig clientConfig = WebSocketClient.ClientConfig.builder()
                 .runtimeBaseUrl("ws://localhost")
                 .name("test-client")
+                .maxConcurrentRuntimeWebSocketMessages(2)
+                .maxRetainedRuntimeWebSocketMessages(11)
+                .maxRetainedRuntimeWebSocketBytes(8L * 1024 * 1024)
                 .build();
         TransportMetricObservingClient client = new TransportMetricObservingClient(
                 clientConfig, true, transportMetricsProperties(), new ManuallyTriggeredTaskScheduler());
@@ -915,7 +937,7 @@ class AbstractWebsocketClientTest {
         session.getUserProperties().put(AbstractWebsocketClient.RUNTIME_VERSION_USER_PROPERTY, "9.8.7");
         JdkWebSocketSession.RuntimeDataDispatchException overflow =
                 JdkWebSocketSession.RuntimeDataDispatchException.overflow(
-                        runtimeDataState(2, 4_096L, 2, 0));
+                        runtimeDataState(2, 4_096L, 2, 0, 2, 11, 8L * 1024 * 1024));
 
         try {
             client.handleError(session, overflow);
@@ -930,9 +952,9 @@ class AbstractWebsocketClientTest {
             assertEquals(4_096L, metric.activeBytes());
             assertEquals(0, metric.pendingMessages());
             assertEquals(0L, metric.pendingBytes());
-            assertEquals(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, metric.maxConcurrency());
-            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, metric.maxRetainedMessages());
-            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, metric.maxRetainedBytes());
+            assertEquals(clientConfig.getMaxConcurrentRuntimeWebSocketMessages(), metric.maxConcurrency());
+            assertEquals(clientConfig.getMaxRetainedRuntimeWebSocketMessages(), metric.maxRetainedMessages());
+            assertEquals(clientConfig.getMaxRetainedRuntimeWebSocketBytes(), metric.maxRetainedBytes());
             assertEquals(Runtime.version().feature(), metric.javaFeatureVersion());
             assertEquals("custom-connector", metric.workerMode());
             assertEquals("9.8.7", metric.runtimeVersion());
@@ -1176,14 +1198,21 @@ class AbstractWebsocketClientTest {
 
     private static JdkWebSocketSession.RuntimeDataState runtimeDataState(
             int retainedMessages, long retainedBytes, int inFlightMessages, int pendingMessages) {
+        return runtimeDataState(retainedMessages, retainedBytes, inFlightMessages, pendingMessages,
+                                JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES);
+    }
+
+    private static JdkWebSocketSession.RuntimeDataState runtimeDataState(
+            int retainedMessages, long retainedBytes, int inFlightMessages, int pendingMessages,
+            int maxConcurrency, int maxRetainedMessages, long maxRetainedBytes) {
         return new JdkWebSocketSession.RuntimeDataState(
                 retainedMessages, retainedBytes, inFlightMessages,
                 inFlightMessages == 0 ? 0L : retainedBytes,
                 inFlightMessages, inFlightMessages == 0 ? 0L : retainedBytes,
                 pendingMessages, pendingMessages == 0 ? 0L : retainedBytes,
-                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
-                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
-                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 0L);
+                maxConcurrency, maxRetainedMessages, maxRetainedBytes, 0L);
     }
 
     private static WebSocketClient websocketClient(AbstractWebsocketClient client) throws Exception {

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
@@ -504,7 +504,7 @@ class JdkWebsocketConnectorTest {
         Semaphore processedPermits = new Semaphore(0);
         try (ExecutorService callbackExecutor = Executors.newFixedThreadPool(4);
              ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
-                     JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+                     JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
              TestWebSocketServer server = TestWebSocketServer.start()) {
             JdkWebsocketConnector connector = new JdkWebsocketConnector(
                     HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(),
@@ -540,7 +540,7 @@ class JdkWebsocketConnectorTest {
                     if ((i + 1) % pongInterval == 0) {
                         server.sendFrame(true, 0xA, new byte[]{(byte) i});
                     }
-                    if (messagesInBatch == JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES) {
+                    if (messagesInBatch == JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES) {
                         int expectedCompletedMessages = i + 1;
                         assertTrue(awaitProcessedBatch(processedPermits, messagesInBatch, session),
                                    () -> burstFailureDiagnostics(
@@ -609,9 +609,9 @@ class JdkWebsocketConnectorTest {
     @Test
     void boundedBurstFailureDiagnosticsIncludeProgressAndRuntimeState() {
         JdkWebSocketSession.RuntimeDataState state = new JdkWebSocketSession.RuntimeDataState(
-                1, 4L, 1, 4L, 0, 0L, 0, 0L, JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
-                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
-                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 12L);
+                1, 4L, 1, 4L, 0, 0L, 0, 0L, JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES,
+                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES,
+                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES, 12L);
 
         String diagnostics = burstFailureDiagnostics(
                 3, 2, 1_024, 4, 64, state, new IllegalStateException("transport failed"));
@@ -625,7 +625,7 @@ class JdkWebsocketConnectorTest {
 
     @Test
     void smallBurstBeyondWorkerConcurrencyQueuesWithinRetainedBound() throws Exception {
-        int expectedConcurrency = JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES;
+        int expectedConcurrency = JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES;
         ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
                 expectedConcurrency);
         CountDownLatch processingStarted = new CountDownLatch(expectedConcurrency);
@@ -673,8 +673,8 @@ class JdkWebsocketConnectorTest {
             assertEquals(expectedConcurrency, state.inFlightMessages());
             assertEquals(expectedConcurrency, state.activeMessages());
             assertEquals(1, state.pendingMessages());
-            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, state.maxRetainedMessages());
-            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, state.maxRetainedBytes());
+            assertEquals(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES, state.maxRetainedMessages());
+            assertEquals(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES, state.maxRetainedBytes());
             allowProcessingToFinish.countDown();
             assertTrue(processingFinished.await(5, TimeUnit.SECONDS));
         } finally {
@@ -684,8 +684,88 @@ class JdkWebsocketConnectorTest {
     }
 
     @Test
+    void configuredRetainedMessagesDerivePendingCapacity() {
+        int maxConcurrency = 2;
+        int maxRetainedMessages = 5;
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint,
+                sdkRuntimeOptions(maxConcurrency, maxRetainedMessages, 1_024L),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        assertFalse(session.getUserProperties().containsKey(
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY));
+        assertFalse(session.getUserProperties().containsKey(
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY));
+        assertFalse(session.getUserProperties().containsKey(
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY));
+
+        for (int i = 0; i < maxRetainedMessages; i++) {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+        }
+
+        JdkWebSocketSession.RuntimeDataState fullState = session.runtimeDataState();
+        assertEquals(maxRetainedMessages, fullState.retainedMessages());
+        assertEquals(maxConcurrency, fullState.inFlightMessages());
+        assertEquals(maxRetainedMessages - maxConcurrency, fullState.pendingMessages());
+        assertEquals(maxConcurrency, fullState.maxConcurrency());
+        assertEquals(maxRetainedMessages, fullState.maxRetainedMessages());
+        assertEquals(1_024L, fullState.maxRetainedBytes());
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{99}), true);
+
+        assertInstanceOf(JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW,
+                     ((JdkWebSocketSession.RuntimeDataDispatchException) reportedError.get()).reason());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void configuredByteLimitStillAllowsOneSoleOversizedMessage() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(1, 4, 2L),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[3]), true);
+
+        JdkWebSocketSession.RuntimeDataState retainedState = session.runtimeDataState();
+        assertEquals(1, retainedState.retainedMessages());
+        assertEquals(3L, retainedState.retainedBytes());
+        assertEquals(2L, retainedState.maxRetainedBytes());
+        assertNull(reportedError.get());
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+
+        assertInstanceOf(JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        verify(webSocket).abort();
+    }
+
+    @Test
     void binaryDispatchOverflowFailsSessionInsteadOfBufferingWithoutBound() {
-        int expectedDispatchCapacity = JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES;
+        int expectedDispatchCapacity = JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES;
         ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
         AtomicReference<Throwable> reportedError = new AtomicReference<>();
         RecordingEndpoint endpoint = new RecordingEndpoint() {
@@ -714,9 +794,11 @@ class JdkWebsocketConnectorTest {
     void retainedAccountingIncludesSubmittedAndPendingRuntimeMessages() {
         ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
         JdkWebSocketSession session = new JdkWebSocketSession(
-                new JdkWebsocketConnector(), new RecordingEndpoint(), sdkRuntimeOptions(),
+                new JdkWebsocketConnector(), new RecordingEndpoint(), sdkRuntimeOptions(
+                1, JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES,
+                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES),
                 URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
-                Runnable::run, runtimeDataExecutor, 1);
+                Runnable::run, runtimeDataExecutor);
         WebSocket webSocket = mock(WebSocket.class);
         WebSocket.Listener listener = session.createListener();
         listener.onOpen(webSocket);
@@ -791,18 +873,18 @@ class JdkWebsocketConnectorTest {
         WebSocket.Listener listener = session.createListener();
         listener.onOpen(webSocket);
 
-        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+        for (int i = 0; i < JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES; i++) {
             listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
         }
 
-        verify(webSocket, times(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES + 1)).request(1);
+        verify(webSocket, times(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES + 1)).request(1);
         JdkWebSocketSession.RuntimeDataState fullState = session.runtimeDataState();
-        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, fullState.retainedMessages());
-        assertEquals(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, fullState.inFlightMessages());
-        assertEquals(JdkWebSocketSession.MAX_PENDING_RUNTIME_MESSAGES, fullState.pendingMessages());
+        assertEquals(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES, fullState.retainedMessages());
+        assertEquals(JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES, fullState.inFlightMessages());
+        assertEquals((JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES - JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES), fullState.pendingMessages());
         listener.onPong(webSocket, ByteBuffer.wrap(new byte[]{9}));
         runtimeDataExecutor.runAll();
-        verify(webSocket, times(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES + 2)).request(1);
+        verify(webSocket, times(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES + 2)).request(1);
     }
 
     @Test
@@ -839,7 +921,7 @@ class JdkWebsocketConnectorTest {
         WebSocket webSocket = mock(WebSocket.class);
         WebSocket.Listener listener = session.createListener();
         listener.onOpen(webSocket);
-        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+        for (int i = 0; i < JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES; i++) {
             listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
         }
 
@@ -869,7 +951,7 @@ class JdkWebsocketConnectorTest {
         WebSocket webSocket = mock(WebSocket.class);
         WebSocket.Listener listener = session.createListener();
         listener.onOpen(webSocket);
-        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+        for (int i = 0; i < JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES; i++) {
             listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
         }
         ByteBuffer rejectedPayload = ByteBuffer.allocate(4 * 1024 * 1024);
@@ -912,9 +994,9 @@ class JdkWebsocketConnectorTest {
         listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
         listener.onBinary(webSocket,
                           ByteBuffer.wrap(new byte[Math.toIntExact(
-                                  JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES - 1)]), false);
+                                  JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES - 1)]), false);
 
-        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES,
+        assertEquals(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES,
                      session.runtimeDataState().retainedBytes());
         listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), false);
 
@@ -922,7 +1004,7 @@ class JdkWebsocketConnectorTest {
                 JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
         assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW, error.reason());
         assertEquals(2, error.state().retainedMessages());
-        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, error.state().retainedBytes());
+        assertEquals(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES, error.state().retainedBytes());
         assertEquals(1, error.state().pendingMessages());
         assertFalse(session.isOpen());
         verify(webSocket).abort();
@@ -934,12 +1016,12 @@ class JdkWebsocketConnectorTest {
     @Test
     void peerCloseWaitsForAllParallelRuntimeMessagesDespiteReverseCompletion() throws Exception {
         ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
-                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
-        CountDownLatch processingStarted = new CountDownLatch(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+                JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
+        CountDownLatch processingStarted = new CountDownLatch(JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
         CountDownLatch allowFirstToFinish = new CountDownLatch(1);
         CountDownLatch allowLaterMessagesToFinish = new CountDownLatch(1);
         CountDownLatch laterMessagesFinished = new CountDownLatch(2);
-        CountDownLatch processingFinished = new CountDownLatch(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+        CountDownLatch processingFinished = new CountDownLatch(JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
         List<String> callbacks = Collections.synchronizedList(new ArrayList<>());
         RecordingEndpoint endpoint = new RecordingEndpoint() {
             @Override
@@ -1237,7 +1319,7 @@ class JdkWebsocketConnectorTest {
         listener.onOpen(webSocket);
 
         listener.onBinary(webSocket,
-                          ByteBuffer.wrap(new byte[Math.toIntExact(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES + 1)]),
+                          ByteBuffer.wrap(new byte[Math.toIntExact(JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES + 1)]),
                           true);
         listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
 
@@ -1425,6 +1507,16 @@ class JdkWebsocketConnectorTest {
     private static WebsocketConnectionOptions sdkRuntimeOptions() {
         return new WebsocketConnectionOptions(
                 Map.of(), Map.of(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true), null, List.of());
+    }
+
+    private static WebsocketConnectionOptions sdkRuntimeOptions(
+            int maxConcurrency, int maxRetainedMessages, long maxRetainedBytes) {
+        return new WebsocketConnectionOptions(Map.of(), Map.of(
+                JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true,
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY, maxConcurrency,
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY, maxRetainedMessages,
+                JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY, maxRetainedBytes),
+                                              null, List.of());
     }
 
     private static byte[] closePayload(int code, String reason) {

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/JdkWebsocketConnectorTest.java
@@ -14,8 +14,10 @@
 
 package io.fluxzero.sdk.common.websocket;
 
+import com.sun.management.ThreadMXBean;
 import io.fluxzero.common.serialization.compression.CompressionAlgorithm;
 import io.fluxzero.common.websocket.WebSocketCapabilities;
+import io.fluxzero.sdk.configuration.client.WebSocketClient;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -23,6 +25,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.InetAddress;
@@ -39,8 +42,10 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +57,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class JdkWebsocketConnectorTest {
@@ -75,6 +82,33 @@ class JdkWebsocketConnectorTest {
     @Test
     void defaultClientConnectorUsesJdkWebsocketConnector() {
         assertInstanceOf(JdkWebsocketConnector.class, AbstractWebsocketClient.defaultWebsocketConnector);
+    }
+
+    @Test
+    void inboundActivityTrackingIsDisabledWithoutTransportMetricsOptIn() throws Exception {
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new RecordingEndpoint(),
+                new WebsocketConnectionOptions(Map.of(), Map.of(), null, List.of()),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run);
+
+        Thread.sleep(10);
+
+        assertEquals(0L, session.runtimeDataState().lastInboundAgeMillis());
+    }
+
+    @Test
+    void inboundActivityTrackingCanBeEnabledForTransportMetrics() throws Exception {
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new RecordingEndpoint(),
+                new WebsocketConnectionOptions(Map.of(), Map.of(
+                        JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true), null, List.of()),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run);
+
+        Thread.sleep(10);
+
+        assertTrue(session.runtimeDataState().lastInboundAgeMillis() > 0L);
     }
 
     @Test
@@ -138,6 +172,35 @@ class JdkWebsocketConnectorTest {
             assertEquals("runtime123",
                          WebSocketCapabilities.getRuntimeSessionId(
                                  session.getHandshakeResponseHeaders()).orElseThrow());
+        }
+    }
+
+    @Test
+    void explicitConnectorExecutorRetainsSdkRuntimeCallbackAffinity() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor(
+                task -> new Thread(task, "custom-websocket-executor"));
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+        CountDownLatch messageReceived = new CountDownLatch(1);
+        try (TestWebSocketServer server = TestWebSocketServer.start()) {
+            JdkWebsocketConnector connector = new JdkWebsocketConnector(
+                    HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(), executor);
+            RecordingEndpoint endpoint = new RecordingEndpoint() {
+                @Override
+                public void onMessage(byte[] bytes, WebsocketSession session) {
+                    callbackThread.set(Thread.currentThread().getName());
+                    messageReceived.countDown();
+                }
+            };
+
+            JdkWebSocketSession session = (JdkWebSocketSession) connector.connect(
+                    endpoint, sdkRuntimeOptions(), server.uri());
+            server.sendFrame(true, 0x2, new byte[]{1});
+
+            assertTrue(messageReceived.await(1, TimeUnit.SECONDS));
+            assertEquals("custom-websocket-executor", callbackThread.get());
+            assertEquals("shared-caller-owned", session.runtimeDataWorkerMode());
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -332,17 +395,892 @@ class JdkWebsocketConnectorTest {
             JdkWebsocketConnector connector = new JdkWebsocketConnector();
             RecordingEndpoint endpoint = new RecordingEndpoint();
 
-            connector.connect(endpoint, new WebsocketConnectionOptions(Map.of(), Map.of(), null, List.of()),
-                              server.uri());
+            JdkWebSocketSession session = (JdkWebSocketSession) connector.connect(
+                    endpoint, sdkRuntimeOptions(), server.uri());
             server.sendFrame(false, 0x2, new byte[]{1});
-            server.sendFrame(true, 0x0, new byte[]{2, 3});
             server.sendFrame(true, 0xA, new byte[]{4});
+            server.sendFrame(true, 0x0, new byte[]{2, 3});
 
             assertTrue(endpoint.awaitBinaryMessage());
             assertTrue(endpoint.awaitPongMessage());
             assertArrayEquals(new byte[]{1, 2, 3}, endpoint.binaryMessage.get());
             assertArrayEquals(new byte[]{4}, endpoint.pongMessage.get());
+            assertTrue(session.runtimeDataWorkerMode().startsWith("isolated-sdk-default-"));
         }
+    }
+
+    @Test
+    void pongIsDeliveredAheadOfQueuedBinaryMessageWhilePreviousBinaryMessageIsStillProcessing() throws Exception {
+        CountDownLatch binaryProcessingStarted = new CountDownLatch(1);
+        CountDownLatch allowBinaryProcessingToFinish = new CountDownLatch(1);
+        CountDownLatch binaryMessagesProcessed = new CountDownLatch(2);
+        CountDownLatch secondMessageProcessed = new CountDownLatch(1);
+        List<Integer> processedMessages = Collections.synchronizedList(new ArrayList<>());
+        try (TestWebSocketServer server = TestWebSocketServer.start()) {
+            JdkWebsocketConnector connector = new JdkWebsocketConnector();
+            RecordingEndpoint endpoint = new RecordingEndpoint() {
+                @Override
+                public void onMessage(byte[] bytes, WebsocketSession session) {
+                    if (bytes[0] == 1) {
+                        binaryProcessingStarted.countDown();
+                        try {
+                            allowBinaryProcessingToFinish.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while blocking binary message processing", e);
+                        }
+                    }
+                    processedMessages.add((int) bytes[0]);
+                    if (bytes[0] == 2) {
+                        secondMessageProcessed.countDown();
+                    }
+                    binaryMessagesProcessed.countDown();
+                }
+            };
+
+            connector.connect(endpoint, sdkRuntimeOptions(), server.uri());
+            server.sendFrame(true, 0x2, new byte[]{1});
+            assertTrue(binaryProcessingStarted.await(1, TimeUnit.SECONDS));
+
+            try {
+                server.sendFrame(true, 0x2, new byte[]{2});
+                server.sendFrame(true, 0xA, new byte[]{3});
+
+                assertTrue(endpoint.awaitPongMessage(),
+                           "Pong delivery should bypass queued binary message processing");
+                assertTrue(secondMessageProcessed.await(1, TimeUnit.SECONDS),
+                           "The independent second message should complete while the first remains blocked");
+            } finally {
+                allowBinaryProcessingToFinish.countDown();
+            }
+            assertTrue(binaryMessagesProcessed.await(5, TimeUnit.SECONDS));
+            assertEquals(List.of(2, 1), processedMessages,
+                         "Complete message processing may finish out of ingress order");
+        }
+    }
+
+    @Test
+    void sdkRuntimePongIsHandledWhileBinaryRuntimeMessagesAreQueued() throws Exception {
+        try (TestWebSocketServer server = TestWebSocketServer.start();
+             BlockingSdkRuntimeClient client = new BlockingSdkRuntimeClient()) {
+            JdkWebsocketConnector connector = new JdkWebsocketConnector();
+            WebsocketSession session = connector.connect(
+                    new SdkRuntimeWebsocketEndpoint(client), sdkRuntimeOptions(), server.uri());
+            try {
+                server.sendFrame(true, 0x2, new byte[]{1});
+                assertTrue(client.binaryProcessingStarted.await(1, TimeUnit.SECONDS));
+                server.sendFrame(true, 0x2, new byte[]{2});
+                server.sendFrame(true, 0xA, new byte[]{3});
+
+                try {
+                    assertTrue(client.pongHandled.await(1, TimeUnit.SECONDS),
+                               "SDK pong handling should not wait for runtime message processing");
+                    assertTrue(client.secondMessageProcessed.await(1, TimeUnit.SECONDS),
+                               "The independent second SDK message should complete in parallel");
+                } finally {
+                    client.allowBinaryProcessingToFinish.countDown();
+                }
+                assertTrue(client.binaryMessagesProcessed.await(5, TimeUnit.SECONDS));
+                assertEquals(List.of(2, 1), client.processedMessages,
+                             "SDK runtime message processing should retain Undertow-era parallel completion");
+            } finally {
+                client.allowBinaryProcessingToFinish.countDown();
+                session.abort(new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "test complete"));
+            }
+        }
+    }
+
+    @Test
+    void sustainedBoundedBurstDoesNotLoseBinaryMessagesOrPongs() throws Exception {
+        int binaryMessageCount = 1_024;
+        int pongInterval = 16;
+        int pongCount = binaryMessageCount / pongInterval;
+        CountDownLatch binaryMessagesReceived = new CountDownLatch(binaryMessageCount);
+        CountDownLatch pongsReceived = new CountDownLatch(pongCount);
+        List<Integer> receivedMessages = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger completedMessageCount = new AtomicInteger();
+        AtomicInteger receivedPongs = new AtomicInteger();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        Semaphore processedPermits = new Semaphore(0);
+        try (ExecutorService callbackExecutor = Executors.newFixedThreadPool(4);
+             ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
+                     JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+             TestWebSocketServer server = TestWebSocketServer.start()) {
+            JdkWebsocketConnector connector = new JdkWebsocketConnector(
+                    HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(),
+                    callbackExecutor, runtimeDataExecutor);
+            RecordingEndpoint endpoint = new RecordingEndpoint() {
+                @Override
+                public void onMessage(byte[] bytes, WebsocketSession session) {
+                    receivedMessages.add(ByteBuffer.wrap(bytes).getInt());
+                    completedMessageCount.incrementAndGet();
+                    binaryMessagesReceived.countDown();
+                    processedPermits.release();
+                }
+
+                @Override
+                public void onPong(ByteBuffer data, WebsocketSession session) {
+                    receivedPongs.incrementAndGet();
+                    pongsReceived.countDown();
+                }
+
+                @Override
+                public void onError(WebsocketSession session, Throwable error) {
+                    reportedError.compareAndSet(null, error);
+                }
+            };
+
+            JdkWebSocketSession session = (JdkWebSocketSession) connector.connect(
+                    new SdkRuntimeWebsocketEndpoint(endpoint), sdkRuntimeOptions(), server.uri());
+            try {
+                int messagesInBatch = 0;
+                for (int i = 0; i < binaryMessageCount; i++) {
+                    server.sendFrame(true, 0x2, ByteBuffer.allocate(Integer.BYTES).putInt(i).array());
+                    messagesInBatch++;
+                    if ((i + 1) % pongInterval == 0) {
+                        server.sendFrame(true, 0xA, new byte[]{(byte) i});
+                    }
+                    if (messagesInBatch == JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES) {
+                        int expectedCompletedMessages = i + 1;
+                        assertTrue(awaitProcessedBatch(processedPermits, messagesInBatch, session),
+                                   () -> burstFailureDiagnostics(
+                                           expectedCompletedMessages, completedMessageCount.get(),
+                                           binaryMessageCount, receivedPongs.get(), pongCount,
+                                           session.runtimeDataState(), reportedError.get()));
+                        messagesInBatch = 0;
+                    }
+                }
+                if (messagesInBatch > 0) {
+                    assertTrue(awaitProcessedBatch(processedPermits, messagesInBatch, session),
+                               () -> burstFailureDiagnostics(
+                                       binaryMessageCount, completedMessageCount.get(), binaryMessageCount,
+                                       receivedPongs.get(), pongCount, session.runtimeDataState(), reportedError.get()));
+                }
+
+                assertTrue(binaryMessagesReceived.await(5, TimeUnit.SECONDS),
+                           () -> burstFailureDiagnostics(
+                                   binaryMessageCount, completedMessageCount.get(), binaryMessageCount,
+                                   receivedPongs.get(), pongCount, session.runtimeDataState(), reportedError.get()));
+                assertTrue(pongsReceived.await(5, TimeUnit.SECONDS),
+                           () -> burstFailureDiagnostics(
+                                   binaryMessageCount, completedMessageCount.get(), binaryMessageCount,
+                                   receivedPongs.get(), pongCount, session.runtimeDataState(), reportedError.get()));
+                assertNull(reportedError.get(), () -> "Unexpected transport error: " + reportedError.get());
+                List<Integer> receivedMessageSnapshot;
+                synchronized (receivedMessages) {
+                    receivedMessageSnapshot = List.copyOf(receivedMessages);
+                }
+                assertEquals(binaryMessageCount, receivedMessageSnapshot.size());
+                assertEquals(pongCount, receivedPongs.get());
+                assertEquals(binaryMessageCount, Set.copyOf(receivedMessageSnapshot).size());
+                assertTrue(receivedMessageSnapshot.stream()
+                                   .allMatch(value -> value >= 0 && value < binaryMessageCount));
+            } finally {
+                session.abort(new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "test complete"));
+            }
+        }
+    }
+
+    private static boolean awaitProcessedBatch(Semaphore processedPermits, int messagesInBatch,
+                                               JdkWebSocketSession session) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        if (!processedPermits.tryAcquire(messagesInBatch, 5, TimeUnit.SECONDS)) {
+            return false;
+        }
+        while (session.runtimeDataState().retainedMessages() != 0) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0) {
+                return false;
+            }
+            TimeUnit.NANOSECONDS.sleep(Math.min(remainingNanos, TimeUnit.MILLISECONDS.toNanos(1)));
+        }
+        return true;
+    }
+
+    private static String burstFailureDiagnostics(int expectedCompletedMessages, int completedMessages,
+                                                  int totalMessages, int receivedPongs, int totalPongs,
+                                                  JdkWebSocketSession.RuntimeDataState state, Throwable error) {
+        return ("Timed out during bounded websocket burst: completed=%d/%d (batch target %d), pongs=%d/%d, "
+                + "runtimeState=%s, transportError=%s")
+                .formatted(completedMessages, totalMessages, expectedCompletedMessages, receivedPongs, totalPongs,
+                           state, error);
+    }
+
+    @Test
+    void boundedBurstFailureDiagnosticsIncludeProgressAndRuntimeState() {
+        JdkWebSocketSession.RuntimeDataState state = new JdkWebSocketSession.RuntimeDataState(
+                1, 4L, 1, 4L, 0, 0L, 0, 0L, JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
+                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
+                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 12L);
+
+        String diagnostics = burstFailureDiagnostics(
+                3, 2, 1_024, 4, 64, state, new IllegalStateException("transport failed"));
+
+        assertTrue(diagnostics.contains("completed=2/1024 (batch target 3)"), diagnostics);
+        assertTrue(diagnostics.contains("pongs=4/64"), diagnostics);
+        assertTrue(diagnostics.contains("runtimeState=" + state), diagnostics);
+        assertTrue(diagnostics.contains("transportError=java.lang.IllegalStateException: transport failed"),
+                   diagnostics);
+    }
+
+    @Test
+    void smallBurstBeyondWorkerConcurrencyQueuesWithinRetainedBound() throws Exception {
+        int expectedConcurrency = JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES;
+        ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
+                expectedConcurrency);
+        CountDownLatch processingStarted = new CountDownLatch(expectedConcurrency);
+        CountDownLatch allowProcessingToFinish = new CountDownLatch(1);
+        CountDownLatch processingFinished = new CountDownLatch(expectedConcurrency + 1);
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                processingStarted.countDown();
+                try {
+                    allowProcessingToFinish.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while blocking runtime message processing", e);
+                } finally {
+                    processingFinished.countDown();
+                }
+            }
+
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket.Listener listener = session.createListener();
+        WebSocket webSocket = mock(WebSocket.class);
+        listener.onOpen(webSocket);
+
+        try {
+            for (int i = 0; i < expectedConcurrency; i++) {
+                listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+            }
+
+            assertTrue(processingStarted.await(1, TimeUnit.SECONDS),
+                       "All bounded runtime workers should start without waiting for the first message");
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{9}), true);
+
+            assertNull(reportedError.get(), "A normal small burst should not reconnect a healthy session");
+            JdkWebSocketSession.RuntimeDataState state = session.runtimeDataState();
+            assertEquals(expectedConcurrency + 1, state.retainedMessages());
+            assertEquals(expectedConcurrency, state.inFlightMessages());
+            assertEquals(expectedConcurrency, state.activeMessages());
+            assertEquals(1, state.pendingMessages());
+            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, state.maxRetainedMessages());
+            assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, state.maxRetainedBytes());
+            allowProcessingToFinish.countDown();
+            assertTrue(processingFinished.await(5, TimeUnit.SECONDS));
+        } finally {
+            allowProcessingToFinish.countDown();
+            runtimeDataExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void binaryDispatchOverflowFailsSessionInsteadOfBufferingWithoutBound() {
+        int expectedDispatchCapacity = JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES;
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        for (int i = 0; i <= expectedDispatchCapacity; i++) {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+        }
+
+        assertInstanceOf(RejectedExecutionException.class, reportedError.get());
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void retainedAccountingIncludesSubmittedAndPendingRuntimeMessages() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new RecordingEndpoint(), sdkRuntimeOptions(),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run, runtimeDataExecutor, 1);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{3}), true);
+
+        JdkWebSocketSession.RuntimeDataState state = session.runtimeDataState();
+        assertEquals(3, state.retainedMessages());
+        assertEquals(3L, state.retainedBytes());
+        assertEquals(1, state.inFlightMessages());
+        assertEquals(1L, state.inFlightBytes());
+        assertEquals(0, state.activeMessages());
+        assertEquals(0L, state.activeBytes());
+        assertEquals(2, state.pendingMessages());
+        assertEquals(2L, state.pendingBytes());
+        assertEquals(1, state.maxConcurrency());
+
+        runtimeDataExecutor.runAll();
+        assertEquals(0, session.runtimeDataState().retainedMessages());
+    }
+
+    @Test
+    void retainedAccountingIncludesIncompleteFragmentReassembly() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new RecordingEndpoint(), sdkRuntimeOptions(),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[4]), false);
+
+        JdkWebSocketSession.RuntimeDataState firstFragment = session.runtimeDataState();
+        assertEquals(1, firstFragment.retainedMessages());
+        assertEquals(4L, firstFragment.retainedBytes());
+        assertEquals(0, firstFragment.inFlightMessages());
+        assertEquals(1, firstFragment.pendingMessages());
+        assertEquals(4L, firstFragment.pendingBytes());
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[6]), false);
+
+        JdkWebSocketSession.RuntimeDataState secondFragment = session.runtimeDataState();
+        assertEquals(1, secondFragment.retainedMessages());
+        assertEquals(10L, secondFragment.retainedBytes());
+        assertEquals(1, secondFragment.pendingMessages());
+        assertEquals(10L, secondFragment.pendingBytes());
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[2]), true);
+
+        JdkWebSocketSession.RuntimeDataState completeMessage = session.runtimeDataState();
+        assertEquals(1, completeMessage.retainedMessages());
+        assertEquals(12L, completeMessage.retainedBytes());
+        assertEquals(1, completeMessage.inFlightMessages());
+        assertEquals(0, completeMessage.pendingMessages());
+
+        runtimeDataExecutor.runAll();
+        assertEquals(0, session.runtimeDataState().retainedMessages());
+    }
+
+    @Test
+    void runtimeIngressKeepsDemandOpenAtItsBoundSoProtocolFramesCanProgress() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new RecordingEndpoint(), sdkRuntimeOptions(),
+                URI.create("ws://localhost/test"), new JdkWebsocketConnector.CapturedHandshakeResponse(),
+                Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+        }
+
+        verify(webSocket, times(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES + 1)).request(1);
+        JdkWebSocketSession.RuntimeDataState fullState = session.runtimeDataState();
+        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES, fullState.retainedMessages());
+        assertEquals(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, fullState.inFlightMessages());
+        assertEquals(JdkWebSocketSession.MAX_PENDING_RUNTIME_MESSAGES, fullState.pendingMessages());
+        listener.onPong(webSocket, ByteBuffer.wrap(new byte[]{9}));
+        runtimeDataExecutor.runAll();
+        verify(webSocket, times(JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES + 2)).request(1);
+    }
+
+    @Test
+    void sdkRuntimePongBypassesAdditionalCallbackDispatch() throws Exception {
+        ManuallyTriggeredExecutor callbackExecutor = new ManuallyTriggeredExecutor();
+        RecordingEndpoint endpoint = new RecordingEndpoint();
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), new SdkRuntimeWebsocketEndpoint(endpoint), sdkRuntimeOptions(),
+                URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), callbackExecutor, Runnable::run);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onPong(webSocket, ByteBuffer.wrap(new byte[]{9}));
+
+        assertTrue(endpoint.awaitPongMessage());
+        assertEquals(0, callbackExecutor.pendingTaskCount());
+    }
+
+    @Test
+    void dataFragmentBeyondFullRuntimeBoundFailsFastWithoutReassembly() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+        }
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{9}), false);
+
+        JdkWebSocketSession.RuntimeDataDispatchException error = assertInstanceOf(
+                JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW, error.reason());
+        assertTrue(error.getMessage().contains("reconnect"));
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void completeMessageBeyondFullRuntimeBoundFailsBeforePayloadCopy() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        for (int i = 0; i < JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES; i++) {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{(byte) i}), true);
+        }
+        ByteBuffer rejectedPayload = ByteBuffer.allocate(4 * 1024 * 1024);
+        ThreadMXBean allocationBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+        assertTrue(allocationBean.isThreadAllocatedMemorySupported());
+        if (!allocationBean.isThreadAllocatedMemoryEnabled()) {
+            allocationBean.setThreadAllocatedMemoryEnabled(true);
+        }
+        long threadId = Thread.currentThread().threadId();
+        long allocatedBefore = allocationBean.getThreadAllocatedBytes(threadId);
+
+        listener.onBinary(webSocket, rejectedPayload, true);
+
+        long allocatedBytes = allocationBean.getThreadAllocatedBytes(threadId) - allocatedBefore;
+        JdkWebSocketSession.RuntimeDataDispatchException error = assertInstanceOf(
+                JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW, error.reason());
+        assertTrue(allocatedBytes < rejectedPayload.capacity() / 2,
+                   () -> "Rejected payload allocated " + allocatedBytes + " bytes before overflow");
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void fragmentContinuationBeyondRetainedByteBoundFailsBeforeFurtherReassembly() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket,
+                          ByteBuffer.wrap(new byte[Math.toIntExact(
+                                  JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES - 1)]), false);
+
+        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES,
+                     session.runtimeDataState().retainedBytes());
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), false);
+
+        JdkWebSocketSession.RuntimeDataDispatchException error = assertInstanceOf(
+                JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.OVERFLOW, error.reason());
+        assertEquals(2, error.state().retainedMessages());
+        assertEquals(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, error.state().retainedBytes());
+        assertEquals(1, error.state().pendingMessages());
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+
+        runtimeDataExecutor.runAll();
+        assertEquals(0, session.runtimeDataState().retainedMessages());
+    }
+
+    @Test
+    void peerCloseWaitsForAllParallelRuntimeMessagesDespiteReverseCompletion() throws Exception {
+        ExecutorService runtimeDataExecutor = Executors.newFixedThreadPool(
+                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+        CountDownLatch processingStarted = new CountDownLatch(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+        CountDownLatch allowFirstToFinish = new CountDownLatch(1);
+        CountDownLatch allowLaterMessagesToFinish = new CountDownLatch(1);
+        CountDownLatch laterMessagesFinished = new CountDownLatch(2);
+        CountDownLatch processingFinished = new CountDownLatch(JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+        List<String> callbacks = Collections.synchronizedList(new ArrayList<>());
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                processingStarted.countDown();
+                try {
+                    (bytes[0] == 1 ? allowFirstToFinish : allowLaterMessagesToFinish).await();
+                    callbacks.add("binary-" + bytes[0]);
+                    if (bytes[0] != 1) {
+                        laterMessagesFinished.countDown();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while awaiting test completion order", e);
+                } finally {
+                    processingFinished.countDown();
+                }
+            }
+
+            @Override
+            public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+                callbacks.add("close");
+                super.onClose(session, closeReason);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        try {
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+            listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{3}), true);
+            assertTrue(processingStarted.await(1, TimeUnit.SECONDS));
+            listener.onClose(webSocket, WebsocketCloseReason.NORMAL_CLOSURE, "done");
+
+            allowLaterMessagesToFinish.countDown();
+            assertTrue(laterMessagesFinished.await(1, TimeUnit.SECONDS),
+                       "Both later messages should finish while the first remains active");
+            assertFalse(callbacks.contains("close"), "Peer close must remain behind every accepted message");
+
+            allowFirstToFinish.countDown();
+            assertTrue(processingFinished.await(5, TimeUnit.SECONDS));
+            assertTrue(endpoint.awaitClose());
+            assertEquals(4, callbacks.size());
+            assertTrue(callbacks.contains("binary-1"));
+            assertTrue(callbacks.contains("binary-2"));
+            assertTrue(callbacks.contains("binary-3"));
+            assertEquals("close", callbacks.getLast());
+        } finally {
+            allowLaterMessagesToFinish.countDown();
+            allowFirstToFinish.countDown();
+            runtimeDataExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void peerCloseIsDeliveredAfterAlreadyReceivedRuntimeMessages() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        List<String> callbacks = new ArrayList<>();
+        WebsocketEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                callbacks.add("binary-" + bytes[0]);
+            }
+
+            @Override
+            public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+                callbacks.add("close");
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+        listener.onClose(webSocket, WebsocketCloseReason.NORMAL_CLOSURE, "done");
+
+        assertTrue(callbacks.isEmpty(), "Peer close should not overtake runtime messages already accepted for dispatch");
+        runtimeDataExecutor.runAll();
+        assertEquals(List.of("binary-1", "binary-2", "close"), callbacks);
+    }
+
+    @Test
+    void runtimeMessageFailureStillDeliversPeerCloseAfterReportingError() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        IllegalStateException processingFailure = new IllegalStateException("decode failed");
+        List<String> callbacks = new ArrayList<>();
+        WebsocketEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                callbacks.add("binary");
+                throw processingFailure;
+            }
+
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                assertSame(processingFailure, error);
+                callbacks.add("error");
+            }
+
+            @Override
+            public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+                callbacks.add("close");
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onClose(webSocket, WebsocketCloseReason.NORMAL_CLOSURE, "done");
+        runtimeDataExecutor.runAll();
+
+        assertEquals(List.of("binary", "error", "close"), callbacks);
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void localAbortStillDeliversPeerCloseThatWasAlreadyDeferred() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        List<String> callbacks = new ArrayList<>();
+        WebsocketEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                callbacks.add("binary");
+            }
+
+            @Override
+            public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+                callbacks.add("close-" + closeReason.reason());
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onClose(webSocket, WebsocketCloseReason.NORMAL_CLOSURE, "peer done");
+        session.abort(new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "local abort"));
+        runtimeDataExecutor.runAll();
+
+        assertEquals(List.of("close-peer done"), callbacks);
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void localAbortDiscardsRuntimeMessagesThatHaveNotStarted() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        List<String> callbacks = new ArrayList<>();
+        WebsocketEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                callbacks.add("binary-" + bytes[0]);
+            }
+
+            @Override
+            public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+                callbacks.add("close");
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+
+        session.abort(new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "shutdown"));
+        runtimeDataExecutor.runAll();
+
+        assertEquals(List.of("close"), callbacks);
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void runtimeDataExecutorRejectionFailsSession() {
+        RejectedExecutionException rejection = new RejectedExecutionException("executor saturated");
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, task -> {
+                    throw rejection;
+                });
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+
+        JdkWebSocketSession.RuntimeDataDispatchException reported = assertInstanceOf(
+                JdkWebSocketSession.RuntimeDataDispatchException.class, reportedError.get());
+        assertEquals(JdkWebSocketSession.RuntimeDataDispatchException.Reason.EXECUTOR_REJECTED, reported.reason());
+        assertSame(rejection, reported.getCause());
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void runtimeMessageFailureFailsSessionAndDiscardsLaterMessages() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        IllegalStateException processingFailure = new IllegalStateException("decode failed");
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        AtomicInteger processedMessages = new AtomicInteger();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                processedMessages.incrementAndGet();
+                throw processingFailure;
+            }
+
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+
+        runtimeDataExecutor.runAll();
+
+        assertSame(processingFailure, reportedError.get());
+        assertEquals(1, processedMessages.get());
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void runtimeMessageFailureDoesNotRequestMoreIngressAfterFailure() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session) {
+                throw new IllegalStateException("decode failed");
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{3}), true);
+
+        runtimeDataExecutor.runAll();
+
+        verify(webSocket, times(4)).request(1);
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void retainedRuntimeDataBytesAreBoundedWhileOneOversizedActiveMessageCanProgress() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public void onError(WebsocketSession session, Throwable error) {
+                reportedError.set(error);
+            }
+        };
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), endpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket,
+                          ByteBuffer.wrap(new byte[Math.toIntExact(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES + 1)]),
+                          true);
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{2}), true);
+
+        assertInstanceOf(RejectedExecutionException.class, reportedError.get());
+        assertFalse(session.isOpen());
+        verify(webSocket).abort();
+    }
+
+    @Test
+    void heavyReceiveTimingIncludesRuntimeQueueTiming() {
+        ManuallyTriggeredExecutor runtimeDataExecutor = new ManuallyTriggeredExecutor();
+        AtomicReference<WebsocketEndpoint.ReceiveTiming> receiveTiming = new AtomicReference<>();
+        AtomicReference<SdkRuntimeWebsocketEndpoint.RuntimeDispatchTiming> runtimeTiming = new AtomicReference<>();
+        AtomicReference<SdkRuntimeWebsocketEndpoint> runtimeEndpointReference = new AtomicReference<>();
+        RecordingEndpoint endpoint = new RecordingEndpoint() {
+            @Override
+            public boolean captureReceiveTiming() {
+                return true;
+            }
+
+            @Override
+            public void onMessage(byte[] bytes, WebsocketSession session, ReceiveTiming frameTiming) {
+                receiveTiming.set(frameTiming);
+                runtimeTiming.set(runtimeEndpointReference.get().currentDispatchTiming());
+            }
+        };
+        SdkRuntimeWebsocketEndpoint runtimeEndpoint = new SdkRuntimeWebsocketEndpoint(endpoint);
+        runtimeEndpointReference.set(runtimeEndpoint);
+        JdkWebSocketSession session = new JdkWebSocketSession(
+                new JdkWebsocketConnector(), runtimeEndpoint, sdkRuntimeOptions(), URI.create("ws://localhost/test"),
+                new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, runtimeDataExecutor);
+        WebSocket webSocket = mock(WebSocket.class);
+        WebSocket.Listener listener = session.createListener();
+        listener.onOpen(webSocket);
+
+        listener.onBinary(webSocket, ByteBuffer.wrap(new byte[]{1}), true);
+        assertNull(runtimeTiming.get());
+        runtimeDataExecutor.runAll();
+
+        assertTrue(receiveTiming.get().frameReceivedTimestamp() > 0L);
+        assertTrue(runtimeTiming.get().queuedTimestamp() > 0L);
+        assertTrue(runtimeTiming.get().startedTimestamp() >= runtimeTiming.get().queuedTimestamp());
+        assertTrue(runtimeTiming.get().queueDuration() >= 0L);
     }
 
     @Test
@@ -484,6 +1422,11 @@ class JdkWebsocketConnectorTest {
         assertArrayEquals(expected.payload(), actual.payload());
     }
 
+    private static WebsocketConnectionOptions sdkRuntimeOptions() {
+        return new WebsocketConnectionOptions(
+                Map.of(), Map.of(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true), null, List.of());
+    }
+
     private static byte[] closePayload(int code, String reason) {
         byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
         byte[] payload = new byte[2 + reasonBytes.length];
@@ -545,6 +1488,85 @@ class JdkWebsocketConnectorTest {
 
         boolean awaitClose() throws InterruptedException {
             return closed.await(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class ManuallyTriggeredExecutor implements java.util.concurrent.Executor {
+        private final ArrayDeque<Runnable> tasks = new ArrayDeque<>();
+
+        @Override
+        public synchronized void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        void runAll() {
+            while (true) {
+                Runnable task;
+                synchronized (this) {
+                    task = tasks.poll();
+                }
+                if (task == null) {
+                    return;
+                }
+                task.run();
+            }
+        }
+
+        synchronized int pendingTaskCount() {
+            return tasks.size();
+        }
+    }
+
+    private static class BlockingSdkRuntimeClient extends AbstractWebsocketClient {
+        private final CountDownLatch binaryProcessingStarted = new CountDownLatch(1);
+        private final CountDownLatch allowBinaryProcessingToFinish = new CountDownLatch(1);
+        private final CountDownLatch binaryMessagesProcessed = new CountDownLatch(2);
+        private final CountDownLatch secondMessageProcessed = new CountDownLatch(1);
+        private final CountDownLatch pongHandled = new CountDownLatch(1);
+        private final List<Integer> processedMessages = Collections.synchronizedList(new ArrayList<>());
+
+        BlockingSdkRuntimeClient() {
+            super(mock(WebsocketConnector.class), URI.create("ws://localhost"),
+                  WebSocketClient.newInstance(WebSocketClient.ClientConfig.builder()
+                                                      .runtimeBaseUrl("ws://localhost")
+                                                      .name("test-client")
+                                                      .build()),
+                  false, Duration.ofSeconds(1), defaultObjectMapper, 1);
+        }
+
+        @Override
+        public void onOpen(WebsocketSession session) {
+            // This session is opened directly by the transport test rather than by this client's session pool.
+            session.getUserProperties().put(CLIENT_SESSION_ID_USER_PROPERTY, "test-client-session");
+            session.getUserProperties().put(RUNTIME_SESSION_ID_USER_PROPERTY, "test-runtime-session");
+        }
+
+        @Override
+        protected void handleMessage(byte[] bytes, WebsocketSession session, ReceiveTiming receiveTiming) {
+            if (bytes[0] == 1) {
+                binaryProcessingStarted.countDown();
+                try {
+                    allowBinaryProcessingToFinish.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while blocking runtime message processing", e);
+                }
+            }
+            processedMessages.add((int) bytes[0]);
+            if (bytes[0] == 2) {
+                secondMessageProcessed.countDown();
+            }
+            binaryMessagesProcessed.countDown();
+        }
+
+        @Override
+        protected void handlePong(WebsocketSession session) {
+            pongHandled.countDown();
+        }
+
+        @Override
+        public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+            // The directly connected transport session is explicitly aborted by the test.
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/WebsocketRuntimeDispatchBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/WebsocketRuntimeDispatchBenchmark.java
@@ -1,0 +1,739 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.common.websocket;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.sun.management.ThreadMXBean;
+import io.fluxzero.common.Registration;
+import io.fluxzero.common.TaskScheduler;
+import io.fluxzero.common.ThrowingRunnable;
+import io.fluxzero.common.api.JsonType;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.StringResult;
+import io.fluxzero.common.application.SimplePropertySource;
+import io.fluxzero.common.serialization.compression.CompressionAlgorithm;
+import io.fluxzero.common.websocket.WebSocketTransportCodec;
+import io.fluxzero.common.websocket.WebSocketTransportCodecs;
+import io.fluxzero.sdk.common.Message;
+import io.fluxzero.sdk.configuration.client.WebSocketClient;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Opt-in microbenchmark for SDK runtime-message isolation and bounded parallel processing.
+ *
+ * <p>The low-level direct baseline deliberately omits the internal SDK runtime marker. Production SDK clients always
+ * enable isolation; the baseline exists only to quantify its bookkeeping cost. The isolated scenario uses a direct
+ * backing executor so executor scheduling variance does not dominate this comparison. Each receive scenario runs with
+ * transport metrics disabled and enabled. A separate bounded-load comparison uses a controlled fixed worker pool to
+ * measure effective per-session concurrency with one through three runtime workers. Its latency percentiles represent
+ * the time to drain one full retained-capacity batch, not an amortized per-message latency. An anomaly comparison
+ * measures metric construction, fallback serialization, and hand-off to a local sink without network variance.</p>
+ */
+public class WebsocketRuntimeDispatchBenchmark {
+    private static final int[] MESSAGE_SIZES = {1 << 10, 64 << 10, 1 << 20};
+    private static final long TARGET_BYTES = Long.getLong("targetBytes", 64L << 20);
+    private static final int MAX_ITERATIONS = Integer.getInteger("maxIterations", 100_000);
+    private static final int MIN_ITERATIONS = Integer.getInteger("minIterations", 128);
+    private static final int WARMUPS = Integer.getInteger("warmups", 3);
+    private static final int LATENCY_SAMPLES = Integer.getInteger("latencySamples", 2_000);
+    private static final int METRIC_ITERATIONS = Integer.getInteger("metricIterations", 100_000);
+    private static final int LOAD_ITERATIONS = Integer.getInteger("loadIterations", 3_000);
+    private static final int LOAD_SESSION_COUNT = Integer.getInteger("loadSessions", 4);
+    private static final int LOAD_PAYLOAD_BYTES = Integer.getInteger("loadPayloadBytes", 64 << 10);
+    private static final long LOAD_WORK_NANOS = TimeUnit.MICROSECONDS.toNanos(
+            Long.getLong("loadWorkMicros", 250L));
+    private static final int FRAGMENTS = Integer.getInteger("fragments", 4);
+    private static final String BENCHMARK_MODE = System.getProperty("benchmarkMode", "all");
+    private static final ThreadMXBean ALLOCATION_BEAN = allocationBean();
+    private static volatile long blackhole;
+
+    public static void main(String[] args) {
+        System.out.printf("java=%s feature=%d targetBytes=%d warmups=%d fragments=%d benchmarkMode=%s%n",
+                          Runtime.version(), Runtime.version().feature(), TARGET_BYTES, WARMUPS, FRAGMENTS,
+                          BENCHMARK_MODE);
+        if (modeEnabled("receive")) {
+            for (int messageSize : MESSAGE_SIZES) {
+                runComparison(messageSize, 1);
+                runComparison(messageSize, FRAGMENTS);
+            }
+        }
+        if (modeEnabled("load")) {
+            runBoundedLoadComparison();
+        }
+        if (modeEnabled("metrics")) {
+            runTransportMetricComparison();
+        }
+        System.out.println("blackhole=" + blackhole);
+    }
+
+    private static boolean modeEnabled(String mode) {
+        if ("all".equals(BENCHMARK_MODE) || mode.equals(BENCHMARK_MODE)) {
+            return true;
+        }
+        if (List.of("receive", "load", "metrics").contains(BENCHMARK_MODE)) {
+            return false;
+        }
+        throw new IllegalArgumentException(
+                "benchmarkMode must be one of all, receive, load, or metrics: " + BENCHMARK_MODE);
+    }
+
+    private static void runComparison(int messageSize, int fragments) {
+        int iterations = Math.max(MIN_ITERATIONS,
+                                  (int) Math.min(MAX_ITERATIONS, TARGET_BYTES / messageSize));
+        try (Scenario legacyMetricsOff = new Scenario(messageSize, fragments, false, false);
+             Scenario legacyMetricsOn = new Scenario(messageSize, fragments, false, true);
+             Scenario isolatedMetricsOff = new Scenario(messageSize, fragments, true, false);
+             Scenario isolatedMetricsOn = new Scenario(messageSize, fragments, true, true)) {
+            for (int i = 0; i < WARMUPS; i++) {
+                legacyMetricsOff.run(iterations);
+                legacyMetricsOn.run(iterations);
+                isolatedMetricsOff.run(iterations);
+                isolatedMetricsOn.run(iterations);
+            }
+            measure("low-level-direct-baseline-metrics-off", legacyMetricsOff, iterations);
+            measure("low-level-direct-baseline-metrics-on", legacyMetricsOn, iterations);
+            measure("runtime-isolated-metrics-off", isolatedMetricsOff, iterations);
+            measure("runtime-isolated-metrics-on", isolatedMetricsOn, iterations);
+            measureLatency("low-level-direct-baseline-metrics-off", legacyMetricsOff,
+                           Math.min(iterations, LATENCY_SAMPLES));
+            measureLatency("low-level-direct-baseline-metrics-on", legacyMetricsOn,
+                           Math.min(iterations, LATENCY_SAMPLES));
+            measureLatency("runtime-isolated-metrics-off", isolatedMetricsOff,
+                           Math.min(iterations, LATENCY_SAMPLES));
+            measureLatency("runtime-isolated-metrics-on", isolatedMetricsOn,
+                           Math.min(iterations, LATENCY_SAMPLES));
+        }
+    }
+
+    private static void runBoundedLoadComparison() {
+        for (CompressionAlgorithm compression : List.of(CompressionAlgorithm.LZ4, CompressionAlgorithm.ZSTD)) {
+            for (int sessions : List.of(1, LOAD_SESSION_COUNT)) {
+                double singleWorkerElapsed = 0d;
+                for (int concurrency = 1;
+                     concurrency <= JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES; concurrency++) {
+                    try (BoundedLoadScenario scenario = new BoundedLoadScenario(
+                            concurrency, sessions, compression, false)) {
+                        for (int i = 0; i < WARMUPS; i++) {
+                            scenario.run(LOAD_ITERATIONS);
+                        }
+                        BoundedLoadMeasurement measurement = measureBoundedLoad(scenario, LOAD_ITERATIONS);
+                        if (concurrency == 1) {
+                            singleWorkerElapsed = measurement.elapsedNanos();
+                        } else {
+                            System.out.printf(
+                                    "runtime-bounded-speedup compression=%s sessions=%d concurrency=%d: %.2fx%n",
+                                    compression, sessions, concurrency,
+                                    singleWorkerElapsed / measurement.elapsedNanos());
+                        }
+                    }
+                }
+            }
+        }
+        runMetricsEnabledBoundedLoad();
+    }
+
+    private static void runMetricsEnabledBoundedLoad() {
+        for (int sessions : List.of(1, LOAD_SESSION_COUNT)) {
+            try (BoundedLoadScenario scenario = new BoundedLoadScenario(
+                    JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, sessions, CompressionAlgorithm.LZ4, true)) {
+                for (int i = 0; i < WARMUPS; i++) {
+                    scenario.run(LOAD_ITERATIONS);
+                }
+                measureBoundedLoad(scenario, LOAD_ITERATIONS);
+            }
+        }
+    }
+
+    private static BoundedLoadMeasurement measureBoundedLoad(BoundedLoadScenario scenario, int iterations) {
+        stabilizeHeap();
+        BoundedLoadMeasurement measurement = scenario.measure(iterations);
+        long[] latencies = measurement.batchDrainLatencies();
+        Arrays.sort(latencies);
+        System.out.printf("runtime-bounded-load compression=%s sessions=%d concurrency=%d metrics=%s "
+                                  + "compressedBytes=%d retainedMessagesPerSession=%d retainedUpperBoundBytes=%d "
+                                  + "iterations=%d: "
+                                  + "%.2f ns/op, %.1f ops/s, batchDrainP50=%dns, batchDrainP95=%dns, "
+                                  + "batchDrainP99=%dns%n",
+                          scenario.compression, scenario.sessions.size(), scenario.maxConcurrency,
+                          scenario.transportMetrics, scenario.payload.length,
+                          scenario.messagesPerSession,
+                          (long) scenario.sessions.size() * scenario.messagesPerSession * scenario.payload.length,
+                          measurement.iterations(),
+                          (double) measurement.elapsedNanos() / measurement.iterations(),
+                          measurement.iterations() * 1_000_000_000d / measurement.elapsedNanos(),
+                          percentile(latencies, 0.50), percentile(latencies, 0.95), percentile(latencies, 0.99));
+        return measurement;
+    }
+
+    private static void runTransportMetricComparison() {
+        try (TransportMetricScenario metricsOff = new TransportMetricScenario(false);
+             TransportMetricScenario metricsOn = new TransportMetricScenario(true)) {
+            for (int i = 0; i < WARMUPS; i++) {
+                metricsOff.run(METRIC_ITERATIONS);
+                metricsOn.run(METRIC_ITERATIONS);
+            }
+            measureTransportMetric("transport-anomaly-metrics-off", metricsOff, METRIC_ITERATIONS);
+            measureTransportMetric("transport-anomaly-metrics-on", metricsOn, METRIC_ITERATIONS);
+            measureTransportMetricLatency("transport-anomaly-metrics-off", metricsOff, LATENCY_SAMPLES);
+            measureTransportMetricLatency("transport-anomaly-metrics-on", metricsOn, LATENCY_SAMPLES);
+        }
+    }
+
+    private static void measure(String name, Scenario scenario, int iterations) {
+        stabilizeHeap();
+        long threadId = Thread.currentThread().threadId();
+        long allocatedBefore = ALLOCATION_BEAN == null ? 0L : ALLOCATION_BEAN.getThreadAllocatedBytes(threadId);
+        GcSnapshot gcBefore = GcSnapshot.capture();
+        long started = System.nanoTime();
+        scenario.run(iterations);
+        long elapsed = System.nanoTime() - started;
+        GcSnapshot gcDelta = GcSnapshot.capture().minus(gcBefore);
+        long allocated = ALLOCATION_BEAN == null ? 0L
+                : ALLOCATION_BEAN.getThreadAllocatedBytes(threadId) - allocatedBefore;
+        System.out.printf("%s size=%d fragments=%d iterations=%d: %.2f ns/op, %.2f bytes/op, %.1f K ops/s, "
+                                  + "gcCollections=%d, gcMillis=%d%n",
+                          name, scenario.payload.length, scenario.fragments, iterations,
+                          (double) elapsed / iterations, (double) allocated / iterations,
+                          iterations * 1_000_000d / elapsed, gcDelta.collections, gcDelta.millis);
+    }
+
+    private static void measureLatency(String name, Scenario scenario, int samples) {
+        stabilizeHeap();
+        long[] latencies = new long[samples];
+        for (int i = 0; i < samples; i++) {
+            long started = System.nanoTime();
+            scenario.runOne();
+            latencies[i] = System.nanoTime() - started;
+        }
+        Arrays.sort(latencies);
+        System.out.printf("%s-latency size=%d fragments=%d samples=%d: p50=%dns, p95=%dns, p99=%dns%n",
+                          name, scenario.payload.length, scenario.fragments, samples,
+                          percentile(latencies, 0.50), percentile(latencies, 0.95), percentile(latencies, 0.99));
+    }
+
+    private static void measureTransportMetric(String name, TransportMetricScenario scenario, int iterations) {
+        stabilizeHeap();
+        long threadId = Thread.currentThread().threadId();
+        long allocatedBefore = ALLOCATION_BEAN == null ? 0L : ALLOCATION_BEAN.getThreadAllocatedBytes(threadId);
+        GcSnapshot gcBefore = GcSnapshot.capture();
+        long started = System.nanoTime();
+        scenario.run(iterations);
+        long elapsed = System.nanoTime() - started;
+        GcSnapshot gcDelta = GcSnapshot.capture().minus(gcBefore);
+        long allocated = ALLOCATION_BEAN == null ? 0L
+                : ALLOCATION_BEAN.getThreadAllocatedBytes(threadId) - allocatedBefore;
+        System.out.printf("%s iterations=%d: %.2f ns/op, %.2f bytes/op, %.1f K ops/s, "
+                                  + "gcCollections=%d, gcMillis=%d%n",
+                          name, iterations, (double) elapsed / iterations, (double) allocated / iterations,
+                          iterations * 1_000_000d / elapsed, gcDelta.collections, gcDelta.millis);
+    }
+
+    private static void measureTransportMetricLatency(String name, TransportMetricScenario scenario, int samples) {
+        stabilizeHeap();
+        long[] latencies = new long[samples];
+        for (int i = 0; i < samples; i++) {
+            long started = System.nanoTime();
+            scenario.runOne();
+            latencies[i] = System.nanoTime() - started;
+        }
+        Arrays.sort(latencies);
+        System.out.printf("%s-latency samples=%d: p50=%dns, p95=%dns, p99=%dns%n",
+                          name, samples, percentile(latencies, 0.50), percentile(latencies, 0.95),
+                          percentile(latencies, 0.99));
+    }
+
+    private static long percentile(long[] sortedValues, double percentile) {
+        int index = Math.min(sortedValues.length - 1, (int) Math.ceil(sortedValues.length * percentile) - 1);
+        return sortedValues[Math.max(0, index)];
+    }
+
+    private static void stabilizeHeap() {
+        System.gc();
+    }
+
+    private static ThreadMXBean allocationBean() {
+        java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        if (!(bean instanceof ThreadMXBean threadBean) || !threadBean.isThreadAllocatedMemorySupported()) {
+            return null;
+        }
+        if (!threadBean.isThreadAllocatedMemoryEnabled()) {
+            threadBean.setThreadAllocatedMemoryEnabled(true);
+        }
+        return threadBean;
+    }
+
+    private static class Scenario implements AutoCloseable {
+        private final byte[] payload;
+        private final int fragments;
+        private final JdkWebSocketSession session;
+        private final WebSocket.Listener listener;
+        private final BenchmarkWebSocket webSocket = new BenchmarkWebSocket();
+
+        private Scenario(int messageSize, int fragments, boolean isolated, boolean transportMetrics) {
+            this.payload = new byte[messageSize];
+            this.payload[0] = 1;
+            this.fragments = fragments;
+            Map<String, Object> userProperties = userProperties(isolated, transportMetrics);
+            WebsocketEndpoint endpoint = new BenchmarkEndpoint();
+            this.session = new JdkWebSocketSession(
+                    new JdkWebsocketConnector(),
+                    isolated ? new SdkRuntimeWebsocketEndpoint(endpoint) : endpoint,
+                    new WebsocketConnectionOptions(Map.of(), userProperties, Duration.ofSeconds(1), List.of()),
+                    URI.create("ws://localhost/benchmark"),
+                    new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, Runnable::run);
+            this.listener = session.createListener();
+            listener.onOpen(webSocket);
+        }
+
+        private void run(int iterations) {
+            for (int i = 0; i < iterations; i++) {
+                runOne();
+            }
+        }
+
+        private void runOne() {
+            int offset = 0;
+            for (int fragment = 0; fragment < fragments; fragment++) {
+                int remainingFragments = fragments - fragment;
+                int length = (payload.length - offset) / remainingFragments;
+                boolean last = fragment == fragments - 1;
+                listener.onBinary(webSocket, ByteBuffer.wrap(payload, offset, length), last);
+                offset += length;
+            }
+        }
+
+        @Override
+        public void close() {
+            session.abort(new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "benchmark complete"));
+        }
+    }
+
+    private static class BoundedLoadScenario implements AutoCloseable {
+        private final int maxConcurrency;
+        private final CompressionAlgorithm compression;
+        private final boolean transportMetrics;
+        private final byte[] payload;
+        private final int messagesPerSession;
+        private final ExecutorService executor;
+        private final Semaphore processed = new Semaphore(0);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private final List<JdkWebSocketSession> sessions;
+        private final List<WebSocket.Listener> listeners;
+        private final List<BenchmarkWebSocket> webSockets;
+
+        private BoundedLoadScenario(int maxConcurrency, int sessionCount, CompressionAlgorithm compression,
+                                    boolean transportMetrics) {
+            this.maxConcurrency = maxConcurrency;
+            this.compression = compression;
+            this.transportMetrics = transportMetrics;
+            this.payload = compressedLoadPayload(compression);
+            this.messagesPerSession = Math.max(1, Math.min(
+                    JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
+                    Math.toIntExact(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES / payload.length)));
+            this.executor = Executors.newFixedThreadPool(
+                    sessionCount * JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+            this.sessions = new java.util.ArrayList<>(sessionCount);
+            this.listeners = new java.util.ArrayList<>(sessionCount);
+            this.webSockets = new java.util.ArrayList<>(sessionCount);
+            LoadEndpoint endpoint = new LoadEndpoint(compression, processed, failure);
+            Map<String, Object> userProperties = userProperties(true, transportMetrics);
+            for (int i = 0; i < sessionCount; i++) {
+                JdkWebSocketSession session = new JdkWebSocketSession(
+                        new JdkWebsocketConnector(), new SdkRuntimeWebsocketEndpoint(endpoint),
+                        new WebsocketConnectionOptions(
+                                Map.of(), userProperties, Duration.ofSeconds(1), List.of()),
+                        URI.create("ws://localhost/benchmark-load/" + i),
+                        new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, executor,
+                        maxConcurrency);
+                BenchmarkWebSocket webSocket = new BenchmarkWebSocket();
+                WebSocket.Listener listener = session.createListener();
+                listener.onOpen(webSocket);
+                sessions.add(session);
+                listeners.add(listener);
+                webSockets.add(webSocket);
+            }
+        }
+
+        private void run(int iterations) {
+            execute(iterations, false);
+        }
+
+        private BoundedLoadMeasurement measure(int iterations) {
+            return execute(iterations, true);
+        }
+
+        private BoundedLoadMeasurement execute(int requestedIterations, boolean captureLatencies) {
+            int batchCapacity = sessions.size() * messagesPerSession;
+            int iterations = Math.max(batchCapacity, requestedIterations / batchCapacity * batchCapacity);
+            long[] latencies = captureLatencies ? new long[iterations / batchCapacity] : new long[0];
+            long totalStarted = System.nanoTime();
+            int latencyIndex = 0;
+            int remaining = iterations;
+            while (remaining > 0) {
+                long batchStarted = System.nanoTime();
+                for (int sessionIndex = 0; sessionIndex < sessions.size(); sessionIndex++) {
+                    WebSocket.Listener listener = listeners.get(sessionIndex);
+                    WebSocket webSocket = webSockets.get(sessionIndex);
+                    for (int i = 0; i < messagesPerSession; i++) {
+                        listener.onBinary(webSocket, ByteBuffer.wrap(payload), true);
+                    }
+                }
+                awaitProcessed(batchCapacity);
+                awaitRuntimeDataDrain();
+                if (captureLatencies) {
+                    latencies[latencyIndex++] = System.nanoTime() - batchStarted;
+                }
+                remaining -= batchCapacity;
+            }
+            long elapsed = System.nanoTime() - totalStarted;
+            return new BoundedLoadMeasurement(iterations, elapsed, latencies);
+        }
+
+        private void awaitProcessed(int batchSize) {
+            try {
+                if (!processed.tryAcquire(batchSize, 30, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out awaiting bounded runtime work");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while awaiting bounded runtime work", e);
+            }
+            Throwable endpointFailure = failure.get();
+            if (endpointFailure != null) {
+                throw new IllegalStateException("Bounded runtime work failed", endpointFailure);
+            }
+        }
+
+        private void awaitRuntimeDataDrain() {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (sessions.stream().anyMatch(session -> session.runtimeDataState().retainedMessages() != 0)) {
+                if (System.nanoTime() >= deadline) {
+                    throw new IllegalStateException("Timed out awaiting runtime dispatcher bookkeeping");
+                }
+                Thread.onSpinWait();
+            }
+        }
+
+        @Override
+        public void close() {
+            sessions.forEach(session -> session.abort(
+                    new WebsocketCloseReason(WebsocketCloseReason.GOING_AWAY, "benchmark complete")));
+            executor.shutdownNow();
+        }
+    }
+
+    private static byte[] compressedLoadPayload(CompressionAlgorithm compression) {
+        return LoadPayloads.PAYLOADS.get(compression).clone();
+    }
+
+    private static byte[] createCompressedLoadPayload(CompressionAlgorithm compression) {
+        try {
+            StringBuilder value = new StringBuilder(LOAD_PAYLOAD_BYTES);
+            int state = 0x13579bdf;
+            for (int i = 0; i < LOAD_PAYLOAD_BYTES; i++) {
+                state = state * 1_103_515_245 + 12_345;
+                value.append((char) (' ' + Math.floorMod(state, 95)));
+            }
+            WebSocketTransportCodec codec = WebSocketTransportCodecs.json(
+                    AbstractWebsocketClient.defaultObjectMapper);
+            return compression.compress(codec.encode(new StringResult(1L, value.toString())));
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not create bounded-load payload", e);
+        }
+    }
+
+    private static class LoadPayloads {
+        private static final Map<CompressionAlgorithm, byte[]> PAYLOADS = Map.of(
+                CompressionAlgorithm.LZ4, createCompressedLoadPayload(CompressionAlgorithm.LZ4),
+                CompressionAlgorithm.ZSTD, createCompressedLoadPayload(CompressionAlgorithm.ZSTD));
+    }
+
+    private record BoundedLoadMeasurement(int iterations, long elapsedNanos, long[] batchDrainLatencies) {
+    }
+
+    private static Map<String, Object> userProperties(boolean isolated, boolean transportMetrics) {
+        if (isolated && transportMetrics) {
+            return Map.of(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true,
+                          JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true);
+        }
+        if (isolated) {
+            return Map.of(JdkWebSocketSession.SDK_RUNTIME_DATA_DISPATCH_USER_PROPERTY, true);
+        }
+        if (transportMetrics) {
+            return Map.of(JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true);
+        }
+        return Map.of();
+    }
+
+    private static class TransportMetricScenario implements AutoCloseable {
+        private static final JdkWebSocketSession.RuntimeDataDispatchException ANOMALY =
+                JdkWebSocketSession.RuntimeDataDispatchException.overflow(
+                        new JdkWebSocketSession.RuntimeDataState(
+                                2, 4_096L, 2, 4_096L, 2, 4_096L, 0, 0L,
+                                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 0L));
+
+        private final TransportMetricBenchmarkClient client;
+        private final JdkWebSocketSession session;
+        private final Logger logger;
+        private final Level previousLogLevel;
+
+        private TransportMetricScenario(boolean transportMetrics) {
+            client = new TransportMetricBenchmarkClient(transportMetrics);
+            logger = (Logger) LoggerFactory.getLogger(
+                    "%s.%s".formatted(client.getClass().getPackageName(), client));
+            previousLogLevel = logger.getLevel();
+            logger.setLevel(Level.OFF);
+            Map<String, Object> userProperties = transportMetrics
+                    ? Map.of(JdkWebSocketSession.SDK_TRANSPORT_METRICS_ENABLED_USER_PROPERTY, true,
+                             AbstractWebsocketClient.NEGOTIATED_SESSION_ID_USER_PROPERTY, "benchmark_runtime",
+                             AbstractWebsocketClient.RUNTIME_VERSION_USER_PROPERTY, "benchmark",
+                             AbstractWebsocketClient.SELECTED_COMPRESSION_ALGORITHM_USER_PROPERTY,
+                             CompressionAlgorithm.NONE)
+                    : Map.of(AbstractWebsocketClient.NEGOTIATED_SESSION_ID_USER_PROPERTY, "benchmark_runtime",
+                             AbstractWebsocketClient.RUNTIME_VERSION_USER_PROPERTY, "benchmark",
+                             AbstractWebsocketClient.SELECTED_COMPRESSION_ALGORITHM_USER_PROPERTY,
+                             CompressionAlgorithm.NONE);
+            session = new JdkWebSocketSession(
+                    new JdkWebsocketConnector(), new BenchmarkEndpoint(),
+                    new WebsocketConnectionOptions(Map.of(), userProperties, Duration.ofSeconds(1), List.of()),
+                    URI.create("ws://localhost/benchmark"),
+                    new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run);
+        }
+
+        private void run(int iterations) {
+            for (int i = 0; i < iterations; i++) {
+                runOne();
+            }
+        }
+
+        private void runOne() {
+            client.handleError(session, ANOMALY);
+        }
+
+        @Override
+        public void close() {
+            try {
+                client.close();
+            } finally {
+                logger.setLevel(previousLogLevel);
+            }
+        }
+    }
+
+    private static class TransportMetricBenchmarkClient extends AbstractWebsocketClient {
+        private TransportMetricBenchmarkClient(boolean transportMetrics) {
+            super((endpoint, options, uri) -> {
+                      throw new UnsupportedOperationException("Benchmark connector must not connect");
+                  }, URI.create("ws://localhost"),
+                  WebSocketClient.newInstance(WebSocketClient.ClientConfig.builder()
+                                                      .runtimeBaseUrl("ws://localhost")
+                                                      .name("transport-metric-benchmark")
+                                                      .build()),
+                  true, Duration.ofSeconds(1), defaultObjectMapper, 1,
+                  new SimplePropertySource(transportMetrics
+                                                   ? Map.of(TRANSPORT_METRICS_ENABLED_PROPERTY, "true") : Map.of()),
+                  (client, numberOfSessions) -> NoOpTaskScheduler.INSTANCE);
+        }
+
+        @Override
+        void publishTransportMetric(WebsocketTransportMetric metric, Metadata metadata) {
+            blackhole += Message.asMessage(metric).addMetadata(metadata)
+                    .serialize(getFallbackSerializer()).getBytes();
+        }
+    }
+
+    private enum NoOpTaskScheduler implements TaskScheduler {
+        INSTANCE;
+
+        private static final Clock CLOCK = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
+
+        @Override
+        public Registration schedule(long deadline, ThrowingRunnable task) {
+            return () -> {
+            };
+        }
+
+        @Override
+        public Clock clock() {
+            return CLOCK;
+        }
+
+        @Override
+        public void executeExpiredTasks() {
+        }
+
+        @Override
+        public void shutdown() {
+        }
+    }
+
+    private static class BenchmarkEndpoint implements WebsocketEndpoint {
+        @Override
+        public void onOpen(WebsocketSession session) {
+        }
+
+        @Override
+        public void onMessage(byte[] bytes, WebsocketSession session) {
+            blackhole += bytes[0];
+        }
+
+        @Override
+        public void onPong(ByteBuffer data, WebsocketSession session) {
+        }
+
+        @Override
+        public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+        }
+
+        @Override
+        public void onError(WebsocketSession session, Throwable error) {
+            throw new IllegalStateException("Unexpected benchmark transport failure", error);
+        }
+    }
+
+    private record LoadEndpoint(CompressionAlgorithm compression, Semaphore processed,
+                                AtomicReference<Throwable> failure) implements WebsocketEndpoint {
+        private static final WebSocketTransportCodec CODEC = WebSocketTransportCodecs.json(
+                AbstractWebsocketClient.defaultObjectMapper);
+
+        @Override
+        public void onOpen(WebsocketSession session) {
+        }
+
+        @Override
+        public void onMessage(byte[] bytes, WebsocketSession session) {
+            try {
+                JsonType decoded = CODEC.decode(compression.decompress(bytes));
+                blackhole += ((StringResult) decoded).getResult().length();
+                LockSupport.parkNanos(LOAD_WORK_NANOS);
+            } catch (Throwable e) {
+                failure.compareAndSet(null, e);
+                throw new IllegalStateException("Could not decode bounded-load payload", e);
+            } finally {
+                processed.release();
+            }
+        }
+
+        @Override
+        public void onPong(ByteBuffer data, WebsocketSession session) {
+        }
+
+        @Override
+        public void onClose(WebsocketSession session, WebsocketCloseReason closeReason) {
+        }
+
+        @Override
+        public void onError(WebsocketSession session, Throwable error) {
+            failure.compareAndSet(null, error);
+        }
+    }
+
+    private static class BenchmarkWebSocket implements WebSocket {
+        private long requested;
+        private boolean aborted;
+
+        @Override
+        public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> sendPong(ByteBuffer message) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override
+        public void request(long n) {
+            requested += n;
+        }
+
+        @Override
+        public String getSubprotocol() {
+            return "";
+        }
+
+        @Override
+        public boolean isOutputClosed() {
+            return aborted;
+        }
+
+        @Override
+        public boolean isInputClosed() {
+            return aborted;
+        }
+
+        @Override
+        public void abort() {
+            aborted = true;
+            blackhole += requested;
+        }
+    }
+
+    private record GcSnapshot(long collections, long millis) {
+        private static GcSnapshot capture() {
+            long collections = 0L;
+            long millis = 0L;
+            for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+                collections += Math.max(0L, bean.getCollectionCount());
+                millis += Math.max(0L, bean.getCollectionTime());
+            }
+            return new GcSnapshot(collections, millis);
+        }
+
+        private GcSnapshot minus(GcSnapshot previous) {
+            return new GcSnapshot(collections - previous.collections, millis - previous.millis);
+        }
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/WebsocketRuntimeDispatchBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/WebsocketRuntimeDispatchBenchmark.java
@@ -145,7 +145,7 @@ public class WebsocketRuntimeDispatchBenchmark {
             for (int sessions : List.of(1, LOAD_SESSION_COUNT)) {
                 double singleWorkerElapsed = 0d;
                 for (int concurrency = 1;
-                     concurrency <= JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES; concurrency++) {
+                     concurrency <= JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES; concurrency++) {
                     try (BoundedLoadScenario scenario = new BoundedLoadScenario(
                             concurrency, sessions, compression, false)) {
                         for (int i = 0; i < WARMUPS; i++) {
@@ -165,17 +165,26 @@ public class WebsocketRuntimeDispatchBenchmark {
             }
         }
         runMetricsEnabledBoundedLoad();
+        runConfiguredCapacitySmoke();
     }
 
     private static void runMetricsEnabledBoundedLoad() {
         for (int sessions : List.of(1, LOAD_SESSION_COUNT)) {
             try (BoundedLoadScenario scenario = new BoundedLoadScenario(
-                    JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES, sessions, CompressionAlgorithm.LZ4, true)) {
+                    JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES, sessions, CompressionAlgorithm.LZ4, true)) {
                 for (int i = 0; i < WARMUPS; i++) {
                     scenario.run(LOAD_ITERATIONS);
                 }
                 measureBoundedLoad(scenario, LOAD_ITERATIONS);
             }
+        }
+    }
+
+    private static void runConfiguredCapacitySmoke() {
+        try (BoundedLoadScenario scenario = new BoundedLoadScenario(
+                2, 1, CompressionAlgorithm.LZ4, false, 7, 256L * 1024)) {
+            scenario.run(LOAD_ITERATIONS);
+            measureBoundedLoad(scenario, LOAD_ITERATIONS);
         }
     }
 
@@ -185,12 +194,14 @@ public class WebsocketRuntimeDispatchBenchmark {
         long[] latencies = measurement.batchDrainLatencies();
         Arrays.sort(latencies);
         System.out.printf("runtime-bounded-load compression=%s sessions=%d concurrency=%d metrics=%s "
-                                  + "compressedBytes=%d retainedMessagesPerSession=%d retainedUpperBoundBytes=%d "
+                                  + "maxRetainedMessages=%d maxRetainedBytes=%d compressedBytes=%d "
+                                  + "retainedMessagesPerSession=%d retainedUpperBoundBytes=%d "
                                   + "iterations=%d: "
                                   + "%.2f ns/op, %.1f ops/s, batchDrainP50=%dns, batchDrainP95=%dns, "
                                   + "batchDrainP99=%dns%n",
                           scenario.compression, scenario.sessions.size(), scenario.maxConcurrency,
-                          scenario.transportMetrics, scenario.payload.length,
+                          scenario.transportMetrics, scenario.maxRetainedMessages, scenario.maxRetainedBytes,
+                          scenario.payload.length,
                           scenario.messagesPerSession,
                           (long) scenario.sessions.size() * scenario.messagesPerSession * scenario.payload.length,
                           measurement.iterations(),
@@ -347,6 +358,8 @@ public class WebsocketRuntimeDispatchBenchmark {
         private final int maxConcurrency;
         private final CompressionAlgorithm compression;
         private final boolean transportMetrics;
+        private final int maxRetainedMessages;
+        private final long maxRetainedBytes;
         private final byte[] payload;
         private final int messagesPerSession;
         private final ExecutorService executor;
@@ -358,28 +371,48 @@ public class WebsocketRuntimeDispatchBenchmark {
 
         private BoundedLoadScenario(int maxConcurrency, int sessionCount, CompressionAlgorithm compression,
                                     boolean transportMetrics) {
+            this(maxConcurrency, sessionCount, compression, transportMetrics,
+                 JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES,
+                 JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES);
+        }
+
+        private BoundedLoadScenario(int maxConcurrency, int sessionCount, CompressionAlgorithm compression,
+                                    boolean transportMetrics, int maxRetainedMessages, long maxRetainedBytes) {
             this.maxConcurrency = maxConcurrency;
             this.compression = compression;
             this.transportMetrics = transportMetrics;
+            this.maxRetainedMessages = maxRetainedMessages;
+            this.maxRetainedBytes = maxRetainedBytes;
             this.payload = compressedLoadPayload(compression);
             this.messagesPerSession = Math.max(1, Math.min(
-                    JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
-                    Math.toIntExact(JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES / payload.length)));
+                    maxRetainedMessages, Math.toIntExact(maxRetainedBytes / payload.length)));
             this.executor = Executors.newFixedThreadPool(
-                    sessionCount * JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES);
+                    sessionCount * JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES);
             this.sessions = new java.util.ArrayList<>(sessionCount);
             this.listeners = new java.util.ArrayList<>(sessionCount);
             this.webSockets = new java.util.ArrayList<>(sessionCount);
             LoadEndpoint endpoint = new LoadEndpoint(compression, processed, failure);
-            Map<String, Object> userProperties = userProperties(true, transportMetrics);
+            Map<String, Object> userProperties = new java.util.HashMap<>(
+                    userProperties(true, transportMetrics));
+            userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_CONCURRENCY_USER_PROPERTY,
+                               maxConcurrency);
+            userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_MESSAGES_USER_PROPERTY,
+                               maxRetainedMessages);
+            userProperties.put(JdkWebSocketSession.SDK_RUNTIME_DATA_MAX_RETAINED_BYTES_USER_PROPERTY,
+                               maxRetainedBytes);
             for (int i = 0; i < sessionCount; i++) {
                 JdkWebSocketSession session = new JdkWebSocketSession(
                         new JdkWebsocketConnector(), new SdkRuntimeWebsocketEndpoint(endpoint),
                         new WebsocketConnectionOptions(
                                 Map.of(), userProperties, Duration.ofSeconds(1), List.of()),
                         URI.create("ws://localhost/benchmark-load/" + i),
-                        new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, executor,
-                        maxConcurrency);
+                        new JdkWebsocketConnector.CapturedHandshakeResponse(), Runnable::run, executor);
+                JdkWebSocketSession.RuntimeDataState initialState = session.runtimeDataState();
+                if (initialState.maxConcurrency() != maxConcurrency
+                        || initialState.maxRetainedMessages() != maxRetainedMessages
+                        || initialState.maxRetainedBytes() != maxRetainedBytes) {
+                    throw new IllegalStateException("Runtime dispatcher did not apply the benchmark capacity");
+                }
                 BenchmarkWebSocket webSocket = new BenchmarkWebSocket();
                 WebSocket.Listener listener = session.createListener();
                 listener.onOpen(webSocket);
@@ -505,9 +538,9 @@ public class WebsocketRuntimeDispatchBenchmark {
                 JdkWebSocketSession.RuntimeDataDispatchException.overflow(
                         new JdkWebSocketSession.RuntimeDataState(
                                 2, 4_096L, 2, 4_096L, 2, 4_096L, 0, 0L,
-                                JdkWebSocketSession.MAX_CONCURRENT_RUNTIME_MESSAGES,
-                                JdkWebSocketSession.MAX_RETAINED_RUNTIME_MESSAGES,
-                                JdkWebSocketSession.MAX_RETAINED_RUNTIME_BYTES, 0L));
+                                JdkWebSocketSession.DEFAULT_MAX_CONCURRENT_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_MESSAGES,
+                                JdkWebSocketSession.DEFAULT_MAX_RETAINED_RUNTIME_BYTES, 0L));
 
         private final TransportMetricBenchmarkClient client;
         private final JdkWebSocketSession session;

--- a/sdk/src/test/java/io/fluxzero/sdk/configuration/client/WebSocketClientConfigTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/configuration/client/WebSocketClientConfigTest.java
@@ -22,9 +22,90 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WebSocketClientConfigTest {
+
+    @Test
+    void defaultsToBoundedRuntimeWebSocketCapacity() {
+        withProperties(Map.of(), () -> {
+            WebSocketClient.ClientConfig config = clientConfig();
+
+            assertEquals(3, config.getMaxConcurrentRuntimeWebSocketMessages());
+            assertEquals(19, config.getMaxRetainedRuntimeWebSocketMessages());
+            assertEquals(16L * 1024 * 1024, config.getMaxRetainedRuntimeWebSocketBytes());
+        });
+    }
+
+    @Test
+    void readsRuntimeWebSocketCapacityFromApplicationProperties() {
+        withProperties(Map.of(
+                WebSocketClient.ClientConfig.MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY, "2",
+                WebSocketClient.ClientConfig.MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY, "11",
+                WebSocketClient.ClientConfig.MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES_PROPERTY, "8388608"), () -> {
+            WebSocketClient.ClientConfig config = clientConfig();
+
+            assertEquals(2, config.getMaxConcurrentRuntimeWebSocketMessages());
+            assertEquals(11, config.getMaxRetainedRuntimeWebSocketMessages());
+            assertEquals(8L * 1024 * 1024, config.getMaxRetainedRuntimeWebSocketBytes());
+        });
+    }
+
+    @Test
+    void explicitRuntimeWebSocketCapacityOverridesApplicationProperties() {
+        withProperties(Map.of(
+                WebSocketClient.ClientConfig.MAX_CONCURRENT_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY, "2",
+                WebSocketClient.ClientConfig.MAX_RETAINED_RUNTIME_WEBSOCKET_MESSAGES_PROPERTY, "11",
+                WebSocketClient.ClientConfig.MAX_RETAINED_RUNTIME_WEBSOCKET_BYTES_PROPERTY, "8388608"), () -> {
+            WebSocketClient.ClientConfig config = clientConfigBuilder()
+                    .maxConcurrentRuntimeWebSocketMessages(4)
+                    .maxRetainedRuntimeWebSocketMessages(28)
+                    .maxRetainedRuntimeWebSocketBytes(32L * 1024 * 1024)
+                    .build();
+
+            assertEquals(4, config.getMaxConcurrentRuntimeWebSocketMessages());
+            assertEquals(28, config.getMaxRetainedRuntimeWebSocketMessages());
+            assertEquals(32L * 1024 * 1024, config.getMaxRetainedRuntimeWebSocketBytes());
+        });
+    }
+
+    @Test
+    void rejectsInvalidRuntimeWebSocketCapacityAtClientConstruction() {
+        IllegalArgumentException concurrencyError = assertThrows(IllegalArgumentException.class,
+                                                                  () -> WebSocketClient.newInstance(
+                                                                          clientConfigBuilder()
+                                                                                  .maxConcurrentRuntimeWebSocketMessages(0)
+                                                                                  .build()));
+        IllegalArgumentException messageError = assertThrows(IllegalArgumentException.class,
+                                                              () -> WebSocketClient.newInstance(
+                                                                      clientConfigBuilder()
+                                                                              .maxConcurrentRuntimeWebSocketMessages(4)
+                                                                              .maxRetainedRuntimeWebSocketMessages(3)
+                                                                              .build()));
+        IllegalArgumentException byteError = assertThrows(IllegalArgumentException.class,
+                                                           () -> WebSocketClient.newInstance(
+                                                                   clientConfigBuilder()
+                                                                           .maxRetainedRuntimeWebSocketBytes(0)
+                                                                           .build()));
+
+        assertTrue(concurrencyError.getMessage().contains("maxConcurrentRuntimeWebSocketMessages"));
+        assertTrue(messageError.getMessage().contains("maxRetainedRuntimeWebSocketMessages"));
+        assertTrue(byteError.getMessage().contains("maxRetainedRuntimeWebSocketBytes"));
+    }
+
+    @Test
+    void acceptsZeroPendingCapacityAndIntegerLimitWithoutOverflow() {
+        assertDoesNotThrow(() -> WebSocketClient.newInstance(clientConfigBuilder()
+                                                                      .maxConcurrentRuntimeWebSocketMessages(
+                                                                              Integer.MAX_VALUE)
+                                                                      .maxRetainedRuntimeWebSocketMessages(
+                                                                              Integer.MAX_VALUE)
+                                                                      .maxRetainedRuntimeWebSocketBytes(Long.MAX_VALUE)
+                                                                      .build()));
+    }
 
     @Test
     void defaultsToExistingMaxInFlightWebSocketBytesWhenPropertyIsUnset() {


### PR DESCRIPTION
## Summary

- acknowledge SDK WebSocket pong responses on the protocol ingress path and fence stale ping-timeout callbacks;
- dispatch complete SDK runtime-data messages through an always-on bounded parallel lane, with three concurrent messages per session by default;
- retain up to 19 submitted, active, pending, or assembling messages and 16 MiB compressed data per session by default;
- keep protocol demand open at the bound so pong and close frames remain observable, while the next excess data message fails before its rejected payload is copied, with a clear ingress-overflow/reconnect failure;
- expose the three finite capacity limits through `WebSocketClient.ClientConfig` and operational properties;
- expose sparse WebSocket transport diagnostics for timeout, overflow, and executor rejection behind `fluxzero.websocket.transportMetrics.enabled=true` (disabled by default).

## Root cause and behavior

The JDK WebSocket client is demand-driven. Runtime-data processing could therefore occupy the same callback/execution path that had to consume a pong. Under sustained or blocked application work, the pong could be delayed until after its deadline even though the peer had responded in time. Compiling with `maven.compiler.release=21` and running on JDK 25 does not remove that scheduling/backpressure interaction; focused regression tests reproduce and verify the behavior on both runtimes.

The isolated runtime-data path is always enabled; no defaults-version, feature property, or client setting is required. Up to three complete runtime messages may be processed concurrently by default, restoring the useful parallelism of the older Undertow transport. Completion order and single-threaded result completion are intentionally not guaranteed; request/result correlation remains ID-based. Normal peer close waits for already accepted complete messages; abort, overflow, handler failure, or executor rejection terminate promptly.

The default connector uses a separate JVM-wide SDK runtime-data executor. On Java 21 that adds a lazy pool capped at eight platform threads; on Java 25 it uses virtual thread-per-task execution. Explicit connectors that supply an `HttpClient` or executor preserve their configured executor affinity. The retained-byte limit counts compressed wire bytes and does not cap decompressed object graphs.

Increasing a ping timeout (for example to 20 seconds) remains a reasonable temporary mitigation for older SDK versions, but it delays detection and recovery of genuinely failed connections and does not remove the scheduling cause addressed here.

## Capacity configuration

The defaults remain finite and require no application configuration:

| `WebSocketClient.ClientConfig` setting | Operational property | Default |
| --- | --- | ---: |
| `maxConcurrentRuntimeWebSocketMessages` | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_CONCURRENCY` | 3 |
| `maxRetainedRuntimeWebSocketMessages` | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_MESSAGES` | 19 |
| `maxRetainedRuntimeWebSocketBytes` | `FLUXZERO_WEBSOCKET_RUNTIME_MAX_RETAINED_BYTES` | 16 MiB |

Explicit builder values take precedence over operational properties, which take precedence over SDK defaults. Pending capacity is derived as retained messages minus concurrency. Concurrency must be at least one, retained messages must be at least concurrency, and retained bytes must be positive; invalid configurations fail at client construction before connecting. There is no disable or unbounded mode. Concurrency one is the compatibility setting for serial runtime callbacks while preserving protocol-liveness isolation.

## Verification

- 105 focused configuration and WebSocket tests are green on Java 21 and Java 25;
- the production-shaped 1,024-message burst uses periodic pongs, batches of at most 19 retained messages, and the original five-second deadline;
- red-first coverage proves derived custom pending capacity, custom message and byte overflow, the sole-oversized-message exception, property/builder precedence, fail-fast validation, and propagation through production connection setup;
- full Maven installs are green on Java 21 and Java 25, including 1,781 SDK tests, test-server, 109 proxy tests, and Java and Kotlin downstream projects;
- a representative multi-module application builds and starts on JDK 25 against the locally installed Java-21-targeted `0-SNAPSHOT` SDK without application configuration changes, runtime-ingress overflow, close 1011, ping failure, or reconnect;
- Javadoc/site generation is green and public API inspection confirms no new public connector constructor or internal runtime endpoint type on `AbstractWebsocketClient`;
- receive-path, bounded-load, metrics-enabled, sparse-anomaly, and Proxy/test-server benchmarks ran on Java 21 and Java 25;
- after fixing the harness to keep executor capacity constant across configurations, three-process LZ4 medians for default concurrency three were 6,395/23,497 ops/s on Java 21 and 6,659/24,774 ops/s on Java 25 for one/four sessions, above the prior measurement window without treating the cross-run difference as a speedup claim;
- metrics-enabled normal-load medians differed by +0.3%/+0.6% on Java 21 and +2.3%/+1.0% on Java 25 for one/four sessions, with no observed negative steady-state impact;
- sparse metrics add work only when explicitly enabled and are not emitted per message, ping, or pong.

## Intended changelog

Prevent false WebSocket ping failures when SDK runtime-message processing is busy. Pong handling now remains on the protocol ingress path, while complete runtime messages use a bounded parallel dispatcher. The default per-session capacity is three concurrent messages, 19 total retained messages, and 16 MiB compressed data. These finite limits can be tuned through `WebSocketClient.ClientConfig` or operational properties without disabling protocol isolation. Sparse timeout, ingress-overflow, and executor-rejection metrics can be enabled with `fluxzero.websocket.transportMetrics.enabled=true`.
