### PR TITLE
fix(web): redact sensitive request diagnostics

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/ExpiredRequestDecorator.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/ExpiredRequestDecorator.java
@@ -193,7 +193,7 @@ class ExpiredRequestDecorator implements HandlerDecorator {
             try {
                 var webPatterns = WebUtils.getWebPatterns(targetClass, null, executable);
                 String uriPattern = webPatterns.size() == 1
-                        ? webPatterns.getFirst().getUri() : WebRequest.getUrl(message.getMetadata());
+                        ? webPatterns.getFirst().getUri() : WebRequest.getPathForLogging(message.getMetadata());
                 return "%s %s".formatted(WebRequest.getMethod(message.getMetadata()), uriPattern);
             } catch (Exception ignored) {}
         }

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/errorreporting/ErrorReportingInterceptor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/errorreporting/ErrorReportingInterceptor.java
@@ -14,6 +14,7 @@
 
 package io.fluxzero.sdk.tracking.handling.errorreporting;
 
+import io.fluxzero.common.MessageType;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.handling.HandlerDescriptor;
 import io.fluxzero.common.handling.HandlerInput;
@@ -25,6 +26,7 @@ import io.fluxzero.sdk.common.exception.TechnicalException;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.publishing.ErrorGateway;
 import io.fluxzero.sdk.tracking.handling.HandlerInterceptor;
+import io.fluxzero.sdk.web.WebRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -154,13 +156,30 @@ public class ErrorReportingInterceptor implements HandlerInterceptor {
 
     protected void reportError(Throwable e, HandlerDescriptor invoker, DeserializingMessage cause) {
         e = unwrapException(e);
-        Metadata metadata = cause.getMetadata();
+        Metadata metadata = errorMetadata(cause);
         if (!(e instanceof FunctionalException || e instanceof TechnicalException)) {
             metadata = metadata.with("stackTrace", stackTrace(e));
             e = new TechnicalException(FluxzeroErrors.handlerInvocationFailed(
-                    invoker.getTargetClass().getName(), cause.toString(), e));
+                    invoker.getTargetClass().getName(), errorCauseDescription(cause), e));
         }
         errorGateway.report(new Message(e, metadata));
+    }
+
+    private static Metadata errorMetadata(DeserializingMessage cause) {
+        if (cause.getMessageType() != MessageType.WEBREQUEST) {
+            return cause.getMetadata();
+        }
+        Metadata requestMetadata = cause.getMetadata();
+        return Metadata.of(WebRequest.methodKey, WebRequest.getMethod(requestMetadata),
+                           WebRequest.urlKey, WebRequest.getPathForLogging(requestMetadata));
+    }
+
+    private static String errorCauseDescription(DeserializingMessage cause) {
+        if (cause.getMessageType() != MessageType.WEBREQUEST) {
+            return cause.toString();
+        }
+        Metadata metadata = cause.getMetadata();
+        return "%s %s".formatted(WebRequest.getMethod(metadata), WebRequest.getPathForLogging(metadata));
     }
 
     private record HandlerErrorPolicy(boolean localHandler, boolean reportSelfHandlers) {

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/metrics/HandlerMonitor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/metrics/HandlerMonitor.java
@@ -173,7 +173,7 @@ public class HandlerMonitor implements HandlerInterceptor {
             try {
                 var webPatterns = getWebPatterns(handler.getTargetClass(), null, handler.getMethod());
                 String uriPattern = webPatterns.size() == 1
-                        ? webPatterns.getFirst().getUri() : WebRequest.getUrl(message.getMetadata());
+                        ? webPatterns.getFirst().getUri() : WebRequest.getPathForLogging(message.getMetadata());
                 return "%s %s".formatted(WebRequest.getMethod(message.getMetadata()), uriPattern);
             } catch (Exception ignored) {}
         }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
@@ -81,12 +81,12 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
             currentThread().interrupt();
             throw new GatewayException(FluxzeroErrors.threadInterrupted(
                     "the web response", request.getMessageId(),
-                    request.getMethod() + " " + WebRequest.getUrl(request.getMetadata())), e);
+                    request.getMethod() + " " + WebRequest.getPathForLogging(request.getMetadata())), e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof java.util.concurrent.TimeoutException) {
                 throw new TimeoutException(FluxzeroErrors.requestTimedOut(
-                        "web request", request.getMethod() + " " + WebRequest.getUrl(request.getMetadata()),
+                        "web request", request.getMethod() + " " + WebRequest.getPathForLogging(request.getMetadata()),
                         request.getMessageId(), null, MessageType.WEBRESPONSE.name(),
                         settings.getTimeout().plusMillis(5_000L)));
             }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebHandlerMatcher.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebHandlerMatcher.java
@@ -198,26 +198,19 @@ public class WebHandlerMatcher implements HandlerMatcher<Object, DeserializingMe
     }
 
     static void putWebRequestDescription(DeserializingMessage message, DefaultWebRequestContext context) {
-        message.putContext(MessageDescription.class, new MessageDescription(describeWebRequest(context)));
+        message.putContext(MessageDescription.class, new MessageDescription(
+                describeWebRequest(context, WebRequest.getPathForLogging(message.getMetadata()))));
     }
 
-    static String describeWebRequest(DefaultWebRequestContext context) {
+    static String describeWebRequest(DefaultWebRequestContext context, String safeRequestPath) {
         String method = context.getMethod();
-        String target = requestTarget(context);
         if (WS_HANDSHAKE.equals(method)) {
-            return "websocket handshake " + target;
+            return "websocket handshake " + safeRequestPath;
         }
         if (isWebsocket(method)) {
-            return "websocket request %s %s".formatted(method, target);
+            return "websocket request %s %s".formatted(method, safeRequestPath);
         }
-        return "web request %s %s".formatted(method, target);
-    }
-
-    private static String requestTarget(DefaultWebRequestContext context) {
-        String query = context.getUri().getRawQuery();
-        return query == null || query.isBlank()
-                ? context.getRequestPath()
-                : context.getRequestPath() + "?" + query;
+        return "web request %s %s".formatted(method, safeRequestPath);
     }
 
     private Optional<WebRouteHandler> automaticOptionsMatcher(DefaultWebRequestContext context) {

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
@@ -88,6 +88,7 @@ import static io.fluxzero.common.api.Data.JSON_FORMAT;
 public class WebRequest extends Message {
 
     public static final String urlKey = "url", methodKey = "method", headersKey = "headers", sessionIdKey = "sessionId";
+    private static final int MAX_LOGGED_PATH_LENGTH = 512;
 
     /**
      * Creates a new {@link Builder} instance for constructing a {@link WebRequest}.
@@ -369,6 +370,39 @@ public class WebRequest extends Message {
     public static String getUrl(Metadata metadata) {
         return Optional.ofNullable(metadata.get(urlKey)).map(u -> u.startsWith("/") || u.contains("://") ? u : "/" + u)
                 .orElseThrow(() -> new IllegalStateException("WebRequest is malformed: url is missing"));
+    }
+
+    /**
+     * Extracts a bounded request path that is safe to include in logs, metrics and error reports.
+     * <p>
+     * The origin, query string and fragment are intentionally omitted because they may contain credentials or
+     * ceremony state. Use {@link #getUrl(Metadata)} when the complete request target is required for request handling.
+     *
+     * @param metadata the request metadata
+     * @return the path without origin, query string or fragment, limited to 512 characters
+     */
+    public static String getPathForLogging(Metadata metadata) {
+        String url = getUrl(metadata);
+        int start = 0;
+        int schemeSeparator = url.indexOf("://");
+        if (url.startsWith("//")) {
+            int firstPathSeparator = url.indexOf('/', 2);
+            start = firstPathSeparator < 0 ? url.length() : firstPathSeparator;
+        } else if (!url.startsWith("/") && schemeSeparator >= 0) {
+            int firstPathSeparator = url.indexOf('/', schemeSeparator + 3);
+            start = firstPathSeparator < 0 ? url.length() : firstPathSeparator;
+        }
+        int querySeparator = url.indexOf('?', start);
+        int fragmentSeparator = url.indexOf('#', start);
+        int end = querySeparator < 0 ? url.length() : querySeparator;
+        if (fragmentSeparator >= 0 && fragmentSeparator < end) {
+            end = fragmentSeparator;
+        }
+        String path = start == url.length() ? "/" : url.substring(start, end);
+        if (path.isEmpty()) {
+            path = "/";
+        }
+        return path.length() <= MAX_LOGGED_PATH_LENGTH ? path : path.substring(0, MAX_LOGGED_PATH_LENGTH);
     }
 
     /**

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/errorreporting/ErrorReportingInterceptorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/errorreporting/ErrorReportingInterceptorTest.java
@@ -22,6 +22,7 @@ import io.fluxzero.common.handling.Handler;
 import io.fluxzero.common.handling.HandlerFilter;
 import io.fluxzero.common.handling.HandlerInspector;
 import io.fluxzero.common.handling.HandlerMethod;
+import io.fluxzero.sdk.MockException;
 import io.fluxzero.sdk.common.Message;
 import io.fluxzero.sdk.common.exception.TechnicalException;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
@@ -31,6 +32,7 @@ import io.fluxzero.sdk.tracking.TrackSelf;
 import io.fluxzero.sdk.tracking.handling.HandleEvent;
 import io.fluxzero.sdk.tracking.handling.LocalHandler;
 import io.fluxzero.sdk.tracking.handling.MessageParameterResolver;
+import io.fluxzero.sdk.web.WebRequest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -82,6 +85,79 @@ class ErrorReportingInterceptorTest {
         assertThrows(CompletionException.class, () -> result.toCompletableFuture().join());
         assertEquals(1, errorGateway.errors.size());
         assertInstanceOf(TechnicalException.class, errorGateway.errors.getFirst().getPayload());
+    }
+
+    @Test
+    void redactsWebRequestMetadataFromSynchronousErrors() {
+        RecordingErrorGateway errorGateway = new RecordingErrorGateway();
+        Handler<DeserializingMessage> handler = HandlerInspector.createHandler(
+                new ThrowingHandler(), HandleEvent.class, List.of(new MessageParameterResolver()));
+        Handler<DeserializingMessage> wrapped = new ErrorReportingInterceptor(errorGateway).wrap(handler);
+        DeserializingMessage message = webMessage();
+
+        assertThrows(IllegalStateException.class, () -> wrapped.getHandlerMethodOrNull(message).invoke(message));
+
+        Message error = errorGateway.errors.getFirst();
+        assertEquals("POST", error.getMetadata().get(WebRequest.methodKey));
+        assertEquals("/auth/flow/registration/profile", error.getMetadata().get(WebRequest.urlKey));
+        assertTrue(error.getMetadata().containsKey("stackTrace"));
+        assertFalse(error.getMetadata().containsKey(WebRequest.headersKey));
+        assertFalse(error.getMetadata().containsKey(WebRequest.sessionIdKey));
+        assertFalse(error.getMetadata().containsKey("unsafe"));
+        String serializedError = error.getPayload().toString();
+        for (String secret : List.of("flow-secret", "cookie-secret", "authorization-secret", "context-secret",
+                                     "signature-secret", "session-secret", "metadata-secret", "payload-secret")) {
+            assertFalse(serializedError.contains(secret));
+        }
+    }
+
+    @Test
+    void redactsWebRequestMetadataFromFunctionalErrors() {
+        RecordingErrorGateway errorGateway = new RecordingErrorGateway();
+        Handler<DeserializingMessage> handler = HandlerInspector.createHandler(
+                new FunctionalThrowingHandler(), HandleEvent.class, List.of(new MessageParameterResolver()));
+        Handler<DeserializingMessage> wrapped = new ErrorReportingInterceptor(errorGateway).wrap(handler);
+        DeserializingMessage message = webMessage();
+
+        assertThrows(MockException.class, () -> wrapped.getHandlerMethodOrNull(message).invoke(message));
+
+        Message error = errorGateway.errors.getFirst();
+        assertInstanceOf(MockException.class, error.getPayload());
+        assertEquals("/auth/flow/registration/profile", error.getMetadata().get(WebRequest.urlKey));
+        assertFalse(error.getMetadata().containsKey("stackTrace"));
+        assertFalse(error.getMetadata().containsKey(WebRequest.headersKey));
+        assertFalse(error.getMetadata().containsKey("unsafe"));
+    }
+
+    @Test
+    void redactsWebRequestMetadataFromAsyncErrors() {
+        RecordingErrorGateway errorGateway = new RecordingErrorGateway();
+        Handler<DeserializingMessage> handler = HandlerInspector.createHandler(
+                new AsyncThrowingHandler(), HandleEvent.class, List.of(new MessageParameterResolver()));
+        Handler<DeserializingMessage> wrapped = new ErrorReportingInterceptor(errorGateway).wrap(handler);
+        DeserializingMessage message = webMessage();
+
+        CompletionStage<?> result = (CompletionStage<?>) wrapped.getHandlerMethodOrNull(message).invoke(message);
+        assertThrows(CompletionException.class, () -> result.toCompletableFuture().join());
+
+        Message error = errorGateway.errors.getFirst();
+        assertEquals("/auth/flow/registration/profile", error.getMetadata().get(WebRequest.urlKey));
+        assertFalse(error.getMetadata().containsKey(WebRequest.headersKey));
+        assertFalse(error.getMetadata().containsKey("unsafe"));
+    }
+
+    @Test
+    void preservesMetadataForNonWebRequestErrors() {
+        RecordingErrorGateway errorGateway = new RecordingErrorGateway();
+        Handler<DeserializingMessage> handler = HandlerInspector.createHandler(
+                new ThrowingHandler(), HandleEvent.class, List.of(new MessageParameterResolver()));
+        Handler<DeserializingMessage> wrapped = new ErrorReportingInterceptor(errorGateway).wrap(handler);
+        DeserializingMessage message = new DeserializingMessage(
+                new Message("payload", Metadata.of("custom", "value")), MessageType.EVENT, null);
+
+        assertThrows(IllegalStateException.class, () -> wrapped.getHandlerMethodOrNull(message).invoke(message));
+
+        assertEquals("value", errorGateway.errors.getFirst().getMetadata().get("custom"));
     }
 
     @Test
@@ -153,10 +229,30 @@ class ErrorReportingInterceptorTest {
         return new DeserializingMessage(new Message(payload), MessageType.EVENT, null);
     }
 
+    private static DeserializingMessage webMessage() {
+        WebRequest request = WebRequest.post(
+                        "https://auth.example.test/auth/flow/registration/profile?flow=flow-secret")
+                .header("Cookie", "session=cookie-secret")
+                .header("Authorization", "Bearer authorization-secret")
+                .header("Fzc", "context-secret")
+                .header("Fzc-Sig", "signature-secret")
+                .metadata(Metadata.of(WebRequest.sessionIdKey, "session-secret", "unsafe", "metadata-secret"))
+                .body("payload-secret")
+                .build();
+        return new DeserializingMessage(request, MessageType.WEBREQUEST, null);
+    }
+
     private static class ThrowingHandler {
         @HandleEvent
         void handle(DeserializingMessage ignored) {
             throw new IllegalStateException("boom");
+        }
+    }
+
+    private static class FunctionalThrowingHandler {
+        @HandleEvent
+        void handle(DeserializingMessage ignored) {
+            throw new MockException();
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/HandleWebTest.java
@@ -679,7 +679,7 @@ public class HandleWebTest {
                                     MessageType.WEBREQUEST,
                                     c -> c.toBuilder().errorHandler(errorHandler).build()),
                                new Handler())
-                    .whenGet("/users/abc")
+                    .whenGet("/users/abc?token=query-secret")
                     .expectWebResponse(r -> r.getStatus() == 403)
                     .expectThat(fc -> assertEquals(
                             "Handler \"Handler\" failed to handle a web request GET /users/abc",

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebMessageTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebMessageTest.java
@@ -27,8 +27,31 @@ import static io.fluxzero.common.MessageType.WEBREQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WebMessageTest {
+
+    @Test
+    void pathForLoggingOmitsOriginQueryAndFragment() {
+        Metadata metadata = Metadata.of(WebRequest.urlKey,
+                                        "https://auth.example.test/auth/flow?flow=query-secret#fragment-secret");
+
+        assertEquals("/auth/flow", WebRequest.getPathForLogging(metadata));
+        assertEquals("/auth/flow", WebRequest.getPathForLogging(Metadata.of(
+                WebRequest.urlKey, "/auth/flow?return=https://example.test/query-secret")));
+        assertEquals("/auth/flow", WebRequest.getPathForLogging(Metadata.of(
+                WebRequest.urlKey, "//auth.example.test/auth/flow?flow=query-secret")));
+    }
+
+    @Test
+    void pathForLoggingHandlesOriginWithoutPathAndBoundsResult() {
+        assertEquals("/", WebRequest.getPathForLogging(
+                Metadata.of(WebRequest.urlKey, "https://auth.example.test?flow=query-secret")));
+
+        String result = WebRequest.getPathForLogging(Metadata.of(WebRequest.urlKey, "/" + "a".repeat(600)));
+        assertEquals(512, result.length());
+        assertTrue(result.startsWith("/aaa"));
+    }
 
     @Test
     void testConvertComplexResponseViaBuilder() {


### PR DESCRIPTION
## Summary
- remove request headers and arbitrary web metadata from durable SDK error reports
- omit origins, query strings and fragments from logs, metrics and gateway error descriptions
- keep non-web error metadata behavior unchanged

## Verification
- focused web/error-reporting tests
- full SDK reactor test suite

This closes the production IDP smoke-test security gate discovered while validating the Lux Transport auth boundary.