### PR TITLE
feat(web): support native requests and configurable retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2975,9 +2975,10 @@ statuses are 500, 502, 503, and 504; override `retryableStatusCodes` for a desti
 empty set to retry transport failures only. `retryDelay` adds a fixed wait before each additional attempt. The delay and
 all attempts share the configured `timeout`; a retry is skipped when its delay no longer fits before the deadline.
 Native execution requires an absolute HTTP(S) URL and bypasses Fluxzero message logging, local web handlers, dispatch
-interceptors, and consumer isolation. A failure or response may occur after the destination accepted a request, so only
-retry non-idempotent calls when that destination provides deduplication. The proxy route and zero retries remain the
-defaults; when retries are enabled, `retryDelay` defaults to one second.
+interceptors, and consumer isolation. Cancelling the future returned by `send` also cancels the active native HTTP call
+or pending retry delay on a best-effort basis. A failure or response may occur after the destination accepted a request,
+so only retry non-idempotent calls when that destination provides deduplication. The proxy route and zero retries remain
+the defaults; when retries are enabled, `retryDelay` defaults to one second.
 
 ### Mocking External Endpoints in Tests
 

--- a/README.md
+++ b/README.md
@@ -3009,7 +3009,9 @@ You can match requests by:
 - Headers, body, or any other property
 
 > ✅ This gives you **full end-to-end test coverage**, even when integrating with external APIs.
-> Native HTTP execution bypasses local handlers, so keep the default proxy route in tests that use these mocks.
+> `TestFixture` deliberately ignores native HTTP transport selection so these mocks also handle requests configured
+> with `useNativeHttpClient(true)`. Retry counts and retryable statuses still apply, but fixture retries do not wait for
+> the configured `retryDelay`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2955,23 +2955,29 @@ When set, the Flux Web Proxy will isolate this request in its own internal proce
 ### Native HTTP execution and retries
 
 For calls that should leave the application directly instead of passing through the Fluxzero proxy, opt into the SDK's
-native HTTP client. You can independently configure transport retries for both native and proxy execution:
+native HTTP client. You can independently configure retry behavior for both native and proxy execution:
 
 ```java
 WebRequestSettings settings = WebRequestSettings.builder()
         .useNativeHttpClient(true)
         .maxRetries(2)
+        .retryDelay(Duration.ofMillis(250))
+        .retryableStatusCodes(Set.of(502, 503, 504))
         .timeout(Duration.ofSeconds(10))
         .build();
 
 WebResponse response = Fluxzero.get().webRequestGateway().sendAndWait(request, settings);
 ```
 
-`maxRetries` is the number of additional attempts after the first transport failure. All attempts share the configured
-`timeout`; completed HTTP responses, including 4xx and 5xx statuses, are returned without retrying. Native execution
-requires an absolute HTTP(S) URL and bypasses Fluxzero message logging, local web handlers, dispatch interceptors, and
-consumer isolation. A transport failure may occur after the destination accepted a request, so only retry
-non-idempotent calls when that destination provides deduplication. The proxy route and zero retries remain the defaults.
+`maxRetries` is the number of additional attempts after a transport failure or a configured response status. Transport
+failures include problems such as a failed connection, reset connection, or request timeout. The default retryable
+statuses are 500, 502, 503, and 504; override `retryableStatusCodes` for a destination-specific selection, or use an
+empty set to retry transport failures only. `retryDelay` adds a fixed wait before each additional attempt. The delay and
+all attempts share the configured `timeout`; a retry is skipped when its delay no longer fits before the deadline.
+Native execution requires an absolute HTTP(S) URL and bypasses Fluxzero message logging, local web handlers, dispatch
+interceptors, and consumer isolation. A failure or response may occur after the destination accepted a request, so only
+retry non-idempotent calls when that destination provides deduplication. The proxy route and zero retries remain the
+defaults; when retries are enabled, `retryDelay` defaults to one second.
 
 ### Mocking External Endpoints in Tests
 

--- a/README.md
+++ b/README.md
@@ -1674,7 +1674,7 @@ Fluxzero.schedulePeriodic(new PollExternalApi());
 
 ### Web Requests
 
-Send an outbound HTTP call via the proxy mechanism in Fluxzero Runtime:
+Send an outbound HTTP call via the default proxy mechanism in Fluxzero Runtime:
 
 [//]: # (@formatter:off)
 ```java
@@ -2881,7 +2881,7 @@ This keeps tests expressive and avoids boilerplate, especially for flows that in
 
 Fluxzero provides a unified API for sending HTTP requests through the `WebRequestGateway`.
 
-Unlike traditional HTTP clients, Flux logs outbound requests as `WebRequest` messages. These are then handled by:
+By default, Flux logs outbound requests as `WebRequest` messages. These are then handled by:
 
 - A **local handler** that tracks requests if the URL is **relative**, or
 - A **connected remote client or proxy**, if the URL is **absolute**.
@@ -2899,7 +2899,8 @@ WebResponse response = Fluxzero.get()
 String body = response.getBodyString();
 ```
 
-> ✅ All outbound traffic is logged and traceable in the Fluxzero Runtime.
+> ✅ Proxy-routed outbound traffic is logged and traceable in the Fluxzero Runtime. Opt-in native HTTP calls bypass
+> Fluxzero message logging.
 
 ### Asynchronous and Fire-and-Forget
 
@@ -2927,7 +2928,8 @@ Fluxzero.get().webRequestGateway()
 
 Flux supports both local and remote handling:
 
-- **Absolute URLs** (e.g., `https://...`): The request is forwarded via the Flux **Web Proxy** and executed externally.
+- **Absolute URLs** (e.g., `https://...`): The request is forwarded via the Flux **Web Proxy** by default, or executed
+  directly when native HTTP execution is enabled.
 - **Relative URLs** (e.g., `/internal/doSomething`): The request is routed to a handler within another connected Flux
   application.
 
@@ -2949,6 +2951,27 @@ When set, the Flux Web Proxy will isolate this request in its own internal proce
 - Want to isolate third-party integrations (e.g., API rate limits)
 - Need different retry or error handling strategies per destination
 - Want fault isolation between outgoing endpoints
+
+### Native HTTP execution and retries
+
+For calls that should leave the application directly instead of passing through the Fluxzero proxy, opt into the SDK's
+native HTTP client. You can independently configure transport retries for both native and proxy execution:
+
+```java
+WebRequestSettings settings = WebRequestSettings.builder()
+        .useNativeHttpClient(true)
+        .maxRetries(2)
+        .timeout(Duration.ofSeconds(10))
+        .build();
+
+WebResponse response = Fluxzero.get().webRequestGateway().sendAndWait(request, settings);
+```
+
+`maxRetries` is the number of additional attempts after the first transport failure. All attempts share the configured
+`timeout`; completed HTTP responses, including 4xx and 5xx statuses, are returned without retrying. Native execution
+requires an absolute HTTP(S) URL and bypasses Fluxzero message logging, local web handlers, dispatch interceptors, and
+consumer isolation. A transport failure may occur after the destination accepted a request, so only retry
+non-idempotent calls when that destination provides deduplication. The proxy route and zero retries remain the defaults.
 
 ### Mocking External Endpoints in Tests
 
@@ -2980,14 +3003,15 @@ You can match requests by:
 - Headers, body, or any other property
 
 > ✅ This gives you **full end-to-end test coverage**, even when integrating with external APIs.
+> Native HTTP execution bypasses local handlers, so keep the default proxy route in tests that use these mocks.
 
 ---
 
 ### Summary
 
 - ✅ Use `WebRequest` for centralized, traceable outbound HTTP calls.
-- ✅ Automatically routes to a proxy or local handler depending on URL.
-- ✅ Supports timeouts, consumers, and structured request settings.
+- ✅ Routes through the proxy or a local handler by default, with opt-in native HTTP execution.
+- ✅ Supports timeouts, consumers, and bounded transport retries.
 - ✅ Easily mock remote endpoints for testing full business flows.
 
 ---

--- a/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -184,11 +185,13 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             //the deadline of this request is in the past. Skipping the request to prevent handling 'old' requests.
             sendResponse(WebResponse.builder().status(504).payload("Timeout in forward proxy".getBytes())
                             .build(), request);
+            return;
         }
         WebResponse webResponse;
         try {
-            HttpRequest httpRequest = asHttpRequest(request, uri, settings);
-            webResponse = executeRequest(httpRequest);
+            webResponse = settings.getMaxRetries() > 0
+                    ? executeRequestWithRetries(request, uri, settings, deadline)
+                    : executeRequest(asHttpRequest(request, uri, settings));
         } catch (Throwable e) {
             publishHandleMessageMetrics(request, true, start);
             throw e;
@@ -218,6 +221,35 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         } catch (Throwable e) {
             log.error("Failed to handle external request. Returning error.. ", e);
             return asWebResponse(e);
+        }
+    }
+
+    private WebResponse executeRequestWithRetries(SerializedMessage request, URI uri, WebRequestSettings settings,
+                                                  Instant deadline) {
+        int retriesRemaining = Math.max(0, settings.getMaxRetries());
+        while (true) {
+            Duration remaining = Duration.between(Instant.now(), deadline);
+            if (remaining.isNegative() || remaining.isZero()) {
+                return asWebResponse(new java.net.http.HttpTimeoutException("Timeout in forward proxy"));
+            }
+            try {
+                HttpRequest httpRequest = asHttpRequest(
+                        request, uri, settings.toBuilder().timeout(remaining).build());
+                return asWebResponse(httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray()));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while handling external request. Returning error.. ", e);
+                return asWebResponse(e);
+            } catch (IOException e) {
+                if (retriesRemaining-- > 0 && Instant.now().isBefore(deadline)) {
+                    continue;
+                }
+                log.error("Failed to handle external request after retries. Returning error.. ", e);
+                return asWebResponse(e);
+            } catch (Throwable e) {
+                log.error("Failed to handle external request. Returning error.. ", e);
+                return asWebResponse(e);
+            }
         }
     }
 

--- a/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
@@ -235,14 +235,30 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             try {
                 HttpRequest httpRequest = asHttpRequest(
                         request, uri, settings.toBuilder().timeout(remaining).build());
-                return asWebResponse(httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray()));
+                HttpResponse<byte[]> response = httpClient.send(
+                        httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+                if (retriesRemaining > 0 && settings.getRetryableStatusCodes().contains(response.statusCode())
+                        && awaitRetryDelay(settings, deadline)) {
+                    retriesRemaining--;
+                    continue;
+                }
+                return asWebResponse(response);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.error("Interrupted while handling external request. Returning error.. ", e);
                 return asWebResponse(e);
             } catch (IOException e) {
-                if (retriesRemaining-- > 0 && Instant.now().isBefore(deadline)) {
-                    continue;
+                if (retriesRemaining > 0) {
+                    try {
+                        if (awaitRetryDelay(settings, deadline)) {
+                            retriesRemaining--;
+                            continue;
+                        }
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        log.error("Interrupted before retrying external request. Returning error.. ", interrupted);
+                        return asWebResponse(interrupted);
+                    }
                 }
                 log.error("Failed to handle external request after retries. Returning error.. ", e);
                 return asWebResponse(e);
@@ -251,6 +267,18 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 return asWebResponse(e);
             }
         }
+    }
+
+    private boolean awaitRetryDelay(WebRequestSettings settings, Instant deadline) throws InterruptedException {
+        Duration delay = settings.getRetryDelay().isNegative() ? Duration.ZERO : settings.getRetryDelay();
+        Duration remaining = Duration.between(Instant.now(), deadline);
+        if (remaining.isNegative() || remaining.isZero() || delay.compareTo(remaining) >= 0) {
+            return false;
+        }
+        if (!delay.isZero()) {
+            Thread.sleep(delay);
+        }
+        return Instant.now().isBefore(deadline);
     }
 
     protected void sendResponse(WebResponse response, SerializedMessage request) {

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
@@ -37,10 +37,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,7 +64,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @Slf4j
@@ -196,5 +205,67 @@ class ForwardProxyConsumerTest {
                 BatchProcessingException.class, () -> consumer.accept(List.of(request)));
 
         assertEquals(42L, error.getMessageIndex());
+    }
+
+    @Test
+    void retriesTransportFailuresWithinRequestTimeout() throws Exception {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> httpResponse = mock(HttpResponse.class);
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn("ok".getBytes());
+        when(httpResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("first"))
+                .thenThrow(new IOException("second"))
+                .thenReturn(httpResponse);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
+        WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
+                .timeout(Duration.ofSeconds(5)).maxRetries(2).build();
+        WebRequest request = WebRequest.get("https://example.com").metadata(
+                Metadata.of("settings", settings)).build();
+        SerializedMessage serializedRequest = request.serialize(ForwardProxyConsumer.serializer);
+        serializedRequest.setIndex(IndexUtils.indexForCurrentTime());
+        serializedRequest.setRequestId(42);
+        serializedRequest.setSource("requester");
+        WebRequestSettings deserializedSettings = consumer.getSettings(serializedRequest);
+
+        consumer.handle(serializedRequest, URI.create(request.getPath()), deserializedSettings);
+
+        assertEquals(2, deserializedSettings.getMaxRetries());
+        verify(httpClient, times(3)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
+    }
+
+    @Test
+    void expiredRequestIsNotSentAfterTimeoutResponse() {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
+        SerializedMessage request = new SerializedMessage(
+                new Data<>(new byte[0], Object.class.getName(), 0), Metadata.empty(), "request", 0L);
+        request.setIndex(0L);
+        request.setRequestId(42);
+        request.setSource("requester");
+
+        consumer.handle(request, URI.create("https://example.com"),
+                        WebRequestSettings.builder().timeout(Duration.ofMillis(1)).build());
+
+        verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
+        verifyNoInteractions(httpClient);
     }
 }

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
@@ -48,6 +48,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -228,7 +229,7 @@ class ForwardProxyConsumerTest {
         ForwardProxyConsumer consumer = new ForwardProxyConsumer(
                 client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
         WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
-                .timeout(Duration.ofSeconds(5)).maxRetries(2).build();
+                .timeout(Duration.ofSeconds(5)).maxRetries(2).retryDelay(Duration.ZERO).build();
         WebRequest request = WebRequest.get("https://example.com").metadata(
                 Metadata.of("settings", settings)).build();
         SerializedMessage serializedRequest = request.serialize(ForwardProxyConsumer.serializer);
@@ -241,6 +242,47 @@ class ForwardProxyConsumerTest {
 
         assertEquals(2, deserializedSettings.getMaxRetries());
         verify(httpClient, times(3)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
+    }
+
+    @Test
+    void retriesConfiguredResponseStatusWithinRequestTimeout() throws Exception {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> retryResponse = mock(HttpResponse.class);
+        HttpResponse<byte[]> successResponse = mock(HttpResponse.class);
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(retryResponse.statusCode()).thenReturn(429);
+        when(retryResponse.body()).thenReturn("retry".getBytes());
+        when(retryResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
+        when(successResponse.statusCode()).thenReturn(200);
+        when(successResponse.body()).thenReturn("ok".getBytes());
+        when(successResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(retryResponse, successResponse);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
+        WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
+                .timeout(Duration.ofSeconds(5)).maxRetries(1).retryDelay(Duration.ofMillis(1))
+                .retryableStatusCodes(Set.of(429)).build();
+        WebRequest request = WebRequest.get("https://example.com").metadata(
+                Metadata.of("settings", settings)).build();
+        SerializedMessage serializedRequest = request.serialize(ForwardProxyConsumer.serializer);
+        serializedRequest.setIndex(IndexUtils.indexForCurrentTime());
+        serializedRequest.setRequestId(42);
+        serializedRequest.setSource("requester");
+        WebRequestSettings deserializedSettings = consumer.getSettings(serializedRequest);
+
+        consumer.handle(serializedRequest, URI.create(request.getPath()), deserializedSettings);
+
+        assertEquals(Set.of(429), deserializedSettings.getRetryableStatusCodes());
+        assertEquals(Duration.ofMillis(1), deserializedSettings.getRetryDelay());
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
         verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/Fluxzero.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/Fluxzero.java
@@ -730,7 +730,7 @@ public interface Fluxzero extends AutoCloseable {
      * Sends the given web request using default request settings and returns a future that completes with the
      * response.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      */
     static CompletableFuture<WebResponse> sendWebRequest(WebRequest request) {
         return get().webRequestGateway().send(request);
@@ -740,7 +740,7 @@ public interface Fluxzero extends AutoCloseable {
      * Sends the given web request using the given request settings and returns a future that completes with the
      * response.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      */
     static CompletableFuture<WebResponse> sendWebRequest(WebRequest request, WebRequestSettings settings) {
         return get().webRequestGateway().send(request, settings);
@@ -751,7 +751,7 @@ public interface Fluxzero extends AutoCloseable {
      * <p>
      * This method blocks the calling thread until the request is completed or times out.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      */
     static WebResponse sendWebRequestAndWait(WebRequest request) {
         return get().webRequestGateway().sendAndWait(request);
@@ -762,7 +762,7 @@ public interface Fluxzero extends AutoCloseable {
      * <p>
      * This method blocks the calling thread until the request is completed or times out.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      */
     static WebResponse sendWebRequestAndWait(WebRequest request, WebRequestSettings settings) {
         return get().webRequestGateway().sendAndWait(request, settings);

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
@@ -982,7 +982,7 @@ public class DefaultFluxzero implements Fluxzero {
                     new DefaultWebRequestGateway(createRequestGateway(client, WEBREQUEST, null, webRequestHandler,
                                                                       dispatchChains, handlerChains,
                                                                       runtimeParameterResolvers, handlerRepositorySupplier,
-                                                                      repositorySupplier, webResponseMapper));
+                                                                      repositorySupplier, webResponseMapper), serializer);
             Function<String, GenericGateway> customGateways = memoize(topic -> createRequestGateway(
                     client, CUSTOM, topic, defaultRequestHandler, dispatchChains, handlerChains,
                     runtimeParameterResolvers, handlerRepositorySupplier, repositorySupplier, defaultResponseMapper));

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
@@ -79,6 +79,8 @@ public interface WebRequestGateway extends Namespaced<WebRequestGateway>, HasLoc
      * Sends the given web request using given request settings and returns a future that completes with the response.
      * <p>
      * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
+     * Cancelling the returned future for a native request also cancels its active HTTP call or pending retry delay on a
+     * best-effort basis.
      *
      * @param request the web request to send
      * @return a future completed with the {@link WebResponse}

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
@@ -28,8 +28,9 @@ import java.util.concurrent.CompletableFuture;
  * Gateway for sending outbound web requests via Fluxzero's proxy mechanism or the SDK's native HTTP client.
  * <p>
  * By default, this gateway logs the request as a {@link WebRequest} message, which is then picked up by the Fluxzero
- * Runtime's proxy. {@link WebRequestSettings#isUseNativeHttpClient()} can instead execute an absolute HTTP(S) request
- * directly from the application. Native execution deliberately bypasses message logging and local handlers.
+ * Runtime's proxy. Enabling {@code useNativeHttpClient} in {@link WebRequestSettings} instead executes an absolute
+ * HTTP(S) request directly from the application. Native execution deliberately bypasses message logging and local
+ * handlers.
  * <p>
  * <strong>Benefits of this approach include:</strong>
  * <ul>

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/WebRequestGateway.java
@@ -25,15 +25,15 @@ import io.fluxzero.sdk.web.WebResponse;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Gateway for sending outbound web requests via Fluxzero’s proxy mechanism.
+ * Gateway for sending outbound web requests via Fluxzero's proxy mechanism or the SDK's native HTTP client.
  * <p>
- * This gateway does not directly execute the request. Instead, it logs the request as a {@link WebRequest} message,
- * which is then picked up by the Fluxzero Runtime's proxy. The proxy only executes the request if the request URL is
- * <strong>absolute</strong> (e.g., starts with {@code http://} or {@code https://}).
+ * By default, this gateway logs the request as a {@link WebRequest} message, which is then picked up by the Fluxzero
+ * Runtime's proxy. {@link WebRequestSettings#isUseNativeHttpClient()} can instead execute an absolute HTTP(S) request
+ * directly from the application. Native execution deliberately bypasses message logging and local handlers.
  * <p>
  * <strong>Benefits of this approach include:</strong>
  * <ul>
- *     <li><strong>Traceability:</strong> All outbound web traffic is traceable through Fluxzero message logs.</li>
+ *     <li><strong>Traceability:</strong> Proxy-routed outbound web traffic is traceable through Fluxzero message logs.</li>
  *     <li><strong>Centralization:</strong> Outgoing requests are routed via a centralized proxy, simplifying firewalling and monitoring.</li>
  *     <li><strong>Proxy-level enhancements:</strong> The proxy can apply retries, circuit breakers, filtering, and other behaviors.</li>
  * </ul>
@@ -65,7 +65,7 @@ public interface WebRequestGateway extends Namespaced<WebRequestGateway>, HasLoc
     /**
      * Sends the given web request using default request settings and returns a future that completes with the response.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      *
      * @param request the web request to send
      * @return a future completed with the {@link WebResponse}
@@ -77,7 +77,7 @@ public interface WebRequestGateway extends Namespaced<WebRequestGateway>, HasLoc
     /**
      * Sends the given web request using given request settings and returns a future that completes with the response.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      *
      * @param request the web request to send
      * @return a future completed with the {@link WebResponse}
@@ -89,7 +89,7 @@ public interface WebRequestGateway extends Namespaced<WebRequestGateway>, HasLoc
      * <p>
      * This method blocks the calling thread until the request is completed or times out.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      *
      * @param request the web request to send
      * @return the received {@link WebResponse}
@@ -103,7 +103,7 @@ public interface WebRequestGateway extends Namespaced<WebRequestGateway>, HasLoc
      * <p>
      * This method blocks the calling thread until the request is completed or times out.
      * <p>
-     * The request must have an absolute URL to be forwarded by the Fluxzero proxy.
+     * Proxy and native HTTP execution require an absolute URL; relative URLs may be handled by a local web handler.
      *
      * @param request  the web request to send
      * @param settings configuration settings for this request (e.g., timeouts, accepted encodings)

--- a/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
@@ -28,12 +28,12 @@ import io.fluxzero.sdk.publishing.GenericGateway;
 import io.fluxzero.sdk.publishing.TimeoutException;
 import io.fluxzero.sdk.publishing.WebRequestGateway;
 import lombok.SneakyThrows;
-import lombok.With;
 import lombok.experimental.Delegate;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import static io.fluxzero.common.ObjectUtils.memoize;
 import static java.lang.Thread.currentThread;
@@ -51,8 +51,8 @@ import static java.lang.Thread.currentThread;
 public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGateway>
         implements WebRequestGateway {
     @Delegate(excludes = Namespaced.class)
-    @With
     private final GenericGateway delegate;
+    private final Supplier<NativeWebRequestClient> nativeHttpClientFactory;
     private final MemoizingSupplier<NativeWebRequestClient> nativeHttpClient;
     private final boolean nativeHttpClientOwner;
 
@@ -62,7 +62,7 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
      * @param delegate gateway used for proxy-routed requests
      */
     public DefaultWebRequestGateway(GenericGateway delegate) {
-        this(delegate, memoize(() -> new NativeWebRequestClient(new JacksonSerializer())), true);
+        this(delegate, () -> new NativeWebRequestClient(new JacksonSerializer()));
     }
 
     /**
@@ -72,17 +72,23 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
      * @param serializer serializer used to encode native HTTP request bodies
      */
     public DefaultWebRequestGateway(GenericGateway delegate, Serializer serializer) {
-        this(delegate, memoize(() -> new NativeWebRequestClient(serializer)), true);
+        this(delegate, () -> new NativeWebRequestClient(serializer));
     }
 
     DefaultWebRequestGateway(GenericGateway delegate, NativeWebRequestClient nativeHttpClient) {
-        this(delegate, memoize(() -> nativeHttpClient), true);
+        this(delegate, () -> nativeHttpClient);
+    }
+
+    DefaultWebRequestGateway(GenericGateway delegate, Supplier<NativeWebRequestClient> nativeHttpClientFactory) {
+        this(delegate, nativeHttpClientFactory, memoize(nativeHttpClientFactory), true);
     }
 
     private DefaultWebRequestGateway(GenericGateway delegate,
+                                     Supplier<NativeWebRequestClient> nativeHttpClientFactory,
                                      MemoizingSupplier<NativeWebRequestClient> nativeHttpClient,
                                      boolean nativeHttpClientOwner) {
         this.delegate = delegate;
+        this.nativeHttpClientFactory = nativeHttpClientFactory;
         this.nativeHttpClient = nativeHttpClient;
         this.nativeHttpClientOwner = nativeHttpClientOwner;
     }
@@ -95,7 +101,23 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
-        return sendRequest(request, settings).thenApply(response -> stripHeadPayload(request, response));
+        CompletableFuture<WebResponse> requestFuture = sendRequest(request, settings);
+        if (!settings.isUseNativeHttpClient()) {
+            return requestFuture.thenApply(response -> stripHeadPayload(request, response));
+        }
+        CancellableResponseFuture result = new CancellableResponseFuture(requestFuture);
+        requestFuture.whenComplete((response, error) -> {
+            if (error != null) {
+                result.completeExceptionally(error);
+                return;
+            }
+            try {
+                result.complete(stripHeadPayload(request, response));
+            } catch (Throwable e) {
+                result.completeExceptionally(e);
+            }
+        });
+        return result;
     }
 
     @Override
@@ -126,12 +148,23 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
     protected WebRequestGateway createForNamespace(String namespace) {
         GenericGateway namespacedDelegate = delegate.forNamespace(namespace);
         return namespacedDelegate == delegate ? this
-                : new DefaultWebRequestGateway(namespacedDelegate, nativeHttpClient, false);
+                : new DefaultWebRequestGateway(
+                        namespacedDelegate, nativeHttpClientFactory, nativeHttpClient, false);
     }
 
     @Override
     public DefaultWebRequestGateway forNamespace(String namespace) {
         return (DefaultWebRequestGateway) super.forNamespace(namespace);
+    }
+
+    /**
+     * Returns a gateway backed by the given proxy delegate and an independently owned native HTTP client.
+     *
+     * @param delegate gateway used for proxy-routed requests
+     * @return this gateway if the delegate is unchanged, otherwise a gateway with an independent lifecycle
+     */
+    public DefaultWebRequestGateway withDelegate(GenericGateway delegate) {
+        return this.delegate == delegate ? this : new DefaultWebRequestGateway(delegate, nativeHttpClientFactory);
     }
 
     private WebResponse stripHeadPayload(WebRequest request, WebResponse response) {
@@ -160,6 +193,23 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
 
     private Duration responseTimeout(WebRequestSettings settings) {
         return settings.getTimeout().plusMillis(5_000L);
+    }
+
+    private static final class CancellableResponseFuture extends CompletableFuture<WebResponse> {
+        private final CompletableFuture<WebResponse> requestFuture;
+
+        private CancellableResponseFuture(CompletableFuture<WebResponse> requestFuture) {
+            this.requestFuture = requestFuture;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (!super.cancel(mayInterruptIfRunning)) {
+                return false;
+            }
+            requestFuture.cancel(mayInterruptIfRunning);
+            return true;
+        }
     }
 
     @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/DefaultWebRequestGateway.java
@@ -16,15 +16,17 @@
 package io.fluxzero.sdk.web;
 
 import io.fluxzero.common.Guarantee;
+import io.fluxzero.common.MemoizingSupplier;
 import io.fluxzero.common.MessageType;
 import io.fluxzero.sdk.common.AbstractNamespaced;
 import io.fluxzero.sdk.common.Namespaced;
 import io.fluxzero.sdk.common.exception.FluxzeroErrors;
+import io.fluxzero.sdk.common.serialization.Serializer;
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import io.fluxzero.sdk.publishing.GatewayException;
 import io.fluxzero.sdk.publishing.GenericGateway;
 import io.fluxzero.sdk.publishing.TimeoutException;
 import io.fluxzero.sdk.publishing.WebRequestGateway;
-import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.With;
 import lombok.experimental.Delegate;
@@ -33,25 +35,57 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static io.fluxzero.common.ObjectUtils.memoize;
 import static java.lang.Thread.currentThread;
 
 /**
  * Default implementation of the {@link WebRequestGateway} interface that delegates requests to a configured
- * {@link GenericGateway}. This class acts as a bridge for handling outbound web requests using Fluxzero Runtime’s proxy
- * mechanism.
+ * {@link GenericGateway}, or executes them through a lifecycle-managed native HTTP client when explicitly requested.
  * <p>
  * It supports sending web requests in both asynchronous (fire-and-forget, future-based) and synchronous (blocking)
- * manners, utilizing the underlying delegate to process the actual interactions with the Fluxzero Runtime.
+ * manners. Proxy execution remains the default and preserves Fluxzero message handling and traceability.
  *
  * @see WebRequestGateway
  * @see GenericGateway
  */
-@AllArgsConstructor
 public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGateway>
         implements WebRequestGateway {
     @Delegate(excludes = Namespaced.class)
     @With
     private final GenericGateway delegate;
+    private final MemoizingSupplier<NativeWebRequestClient> nativeHttpClient;
+    private final boolean nativeHttpClientOwner;
+
+    /**
+     * Creates a gateway using a default Jackson serializer for opt-in native HTTP request bodies.
+     *
+     * @param delegate gateway used for proxy-routed requests
+     */
+    public DefaultWebRequestGateway(GenericGateway delegate) {
+        this(delegate, memoize(() -> new NativeWebRequestClient(new JacksonSerializer())), true);
+    }
+
+    /**
+     * Creates a gateway using the configured application serializer for opt-in native HTTP request bodies.
+     *
+     * @param delegate   gateway used for proxy-routed requests
+     * @param serializer serializer used to encode native HTTP request bodies
+     */
+    public DefaultWebRequestGateway(GenericGateway delegate, Serializer serializer) {
+        this(delegate, memoize(() -> new NativeWebRequestClient(serializer)), true);
+    }
+
+    DefaultWebRequestGateway(GenericGateway delegate, NativeWebRequestClient nativeHttpClient) {
+        this(delegate, memoize(() -> nativeHttpClient), true);
+    }
+
+    private DefaultWebRequestGateway(GenericGateway delegate,
+                                     MemoizingSupplier<NativeWebRequestClient> nativeHttpClient,
+                                     boolean nativeHttpClientOwner) {
+        this.delegate = delegate;
+        this.nativeHttpClient = nativeHttpClient;
+        this.nativeHttpClientOwner = nativeHttpClientOwner;
+    }
 
     @Override
     public CompletableFuture<Void> sendAndForget(Guarantee guarantee, WebRequest... requests) {
@@ -61,10 +95,7 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
-        WebRequest webRequest = addSettings(request, settings);
-        Duration timeout = responseTimeout(settings);
-        CompletableFuture<WebResponse> result = (CompletableFuture) sendForMessage(webRequest, timeout);
-        return result.thenApply(response -> stripHeadPayload(webRequest, response));
+        return sendRequest(request, settings).thenApply(response -> stripHeadPayload(request, response));
     }
 
     @Override
@@ -72,10 +103,7 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
     @SuppressWarnings({"unchecked", "rawtypes"})
     public WebResponse sendAndWait(WebRequest request, WebRequestSettings settings) {
         try {
-            Duration timeout = responseTimeout(settings);
-            request = addSettings(request, settings);
-            CompletableFuture<WebResponse> result = (CompletableFuture) sendForMessage(request, timeout);
-            WebResponse response = result.get();
+            WebResponse response = sendRequest(request, settings).get();
             return stripHeadPayload(request, response);
         } catch (InterruptedException e) {
             currentThread().interrupt();
@@ -97,7 +125,8 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
     @Override
     protected WebRequestGateway createForNamespace(String namespace) {
         GenericGateway namespacedDelegate = delegate.forNamespace(namespace);
-        return namespacedDelegate == delegate ? this : new DefaultWebRequestGateway(namespacedDelegate);
+        return namespacedDelegate == delegate ? this
+                : new DefaultWebRequestGateway(namespacedDelegate, nativeHttpClient, false);
     }
 
     @Override
@@ -116,11 +145,28 @@ public class DefaultWebRequestGateway extends AbstractNamespaced<WebRequestGatew
         return delegate.sendForMessage(request, timeout);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private CompletableFuture<WebResponse> sendRequest(WebRequest request, WebRequestSettings settings) {
+        if (settings.isUseNativeHttpClient()) {
+            return nativeHttpClient.get().send(request, settings);
+        }
+        WebRequest webRequest = addSettings(request, settings);
+        return (CompletableFuture) sendForMessage(webRequest, responseTimeout(settings));
+    }
+
     private WebRequest addSettings(WebRequest request, WebRequestSettings settings) {
         return request.withMetadata(request.getMetadata().with("settings", settings));
     }
 
     private Duration responseTimeout(WebRequestSettings settings) {
         return settings.getTimeout().plusMillis(5_000L);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+        if (nativeHttpClientOwner && nativeHttpClient.isCached()) {
+            nativeHttpClient.get().close();
+        }
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
@@ -33,12 +33,14 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 final class NativeWebRequestClient implements AutoCloseable {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
 
     private final HttpClient httpClient;
     private final Serializer serializer;
+    private final Function<Duration, CompletableFuture<Void>> retryDelay;
 
     NativeWebRequestClient(Serializer serializer) {
         this(HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL)
@@ -46,8 +48,14 @@ final class NativeWebRequestClient implements AutoCloseable {
     }
 
     NativeWebRequestClient(HttpClient httpClient, Serializer serializer) {
+        this(httpClient, serializer, NativeWebRequestClient::delay);
+    }
+
+    NativeWebRequestClient(HttpClient httpClient, Serializer serializer,
+                           Function<Duration, CompletableFuture<Void>> retryDelay) {
         this.httpClient = Objects.requireNonNull(httpClient);
         this.serializer = Objects.requireNonNull(serializer);
+        this.retryDelay = Objects.requireNonNull(retryDelay);
     }
 
     CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
@@ -80,15 +88,51 @@ final class NativeWebRequestClient implements AutoCloseable {
 
         CompletableFuture<CompletableFuture<WebResponse>> result = attempt.handle((response, error) -> {
             if (error == null) {
+                if (shouldRetry(response.statusCode(), settings, retriesRemaining, deadline)) {
+                    return retry(request, serializedRequest, settings, retriesRemaining, deadline,
+                                 asWebResponse(response));
+                }
                 return CompletableFuture.completedFuture(asWebResponse(response));
             }
             Throwable failure = unwrap(error);
             if (retriesRemaining > 0 && failure instanceof IOException && Instant.now().isBefore(deadline)) {
-                return send(request, serializedRequest, settings, retriesRemaining - 1, deadline);
+                return retry(request, serializedRequest, settings, retriesRemaining, deadline,
+                             asWebResponse(failure));
             }
             return CompletableFuture.completedFuture(asWebResponse(failure));
         });
         return result.thenCompose(Function.identity());
+    }
+
+    private boolean shouldRetry(int status, WebRequestSettings settings, int retriesRemaining, Instant deadline) {
+        return retriesRemaining > 0 && settings.getRetryableStatusCodes().contains(status)
+                && Instant.now().isBefore(deadline);
+    }
+
+    private CompletableFuture<WebResponse> retry(WebRequest request, SerializedMessage serializedRequest,
+                                                 WebRequestSettings settings, int retriesRemaining, Instant deadline,
+                                                 WebResponse exhaustedResult) {
+        Duration delay = normalizedRetryDelay(settings);
+        Duration remaining = Duration.between(Instant.now(), deadline);
+        if (remaining.isNegative() || remaining.isZero() || delay.compareTo(remaining) >= 0) {
+            return CompletableFuture.completedFuture(exhaustedResult);
+        }
+        return retryDelay.apply(delay).thenCompose(ignored -> Instant.now().isBefore(deadline)
+                ? send(request, serializedRequest, settings, retriesRemaining - 1, deadline)
+                : CompletableFuture.completedFuture(exhaustedResult));
+    }
+
+    private Duration normalizedRetryDelay(WebRequestSettings settings) {
+        Duration delay = settings.getRetryDelay();
+        return delay.isNegative() ? Duration.ZERO : delay;
+    }
+
+    private static CompletableFuture<Void> delay(Duration duration) {
+        if (duration.isZero()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.runAsync(
+                () -> {}, CompletableFuture.delayedExecutor(duration.toNanos(), NANOSECONDS));
     }
 
     private HttpRequest asHttpRequest(WebRequest request, SerializedMessage serializedRequest,

--- a/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
@@ -28,8 +28,10 @@ import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -61,11 +63,24 @@ final class NativeWebRequestClient implements AutoCloseable {
     CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
         SerializedMessage serializedRequest = request.serialize(serializer);
         Instant deadline = Instant.now().plus(settings.getTimeout());
-        return send(request, serializedRequest, settings, Math.max(0, settings.getMaxRetries()), deadline);
+        CancellableRequestFuture result = new CancellableRequestFuture();
+        send(request, serializedRequest, settings, Math.max(0, settings.getMaxRetries()), deadline, result)
+                .whenComplete((response, error) -> {
+                    if (error == null) {
+                        result.complete(response);
+                    } else {
+                        result.completeExceptionally(error);
+                    }
+                });
+        return result;
     }
 
     private CompletableFuture<WebResponse> send(WebRequest request, SerializedMessage serializedRequest,
-                                                WebRequestSettings settings, int retriesRemaining, Instant deadline) {
+                                                WebRequestSettings settings, int retriesRemaining, Instant deadline,
+                                                CancellableRequestFuture requestFuture) {
+        if (requestFuture.isCancelled()) {
+            return CompletableFuture.failedFuture(new CancellationException());
+        }
         Duration remaining = Duration.between(Instant.now(), deadline);
         if (remaining.isNegative() || remaining.isZero()) {
             return CompletableFuture.completedFuture(asWebResponse(
@@ -85,19 +100,20 @@ final class NativeWebRequestClient implements AutoCloseable {
         } catch (Throwable e) {
             return CompletableFuture.completedFuture(asWebResponse(e));
         }
+        requestFuture.track(attempt);
 
         CompletableFuture<CompletableFuture<WebResponse>> result = attempt.handle((response, error) -> {
             if (error == null) {
                 if (shouldRetry(response.statusCode(), settings, retriesRemaining, deadline)) {
                     return retry(request, serializedRequest, settings, retriesRemaining, deadline,
-                                 asWebResponse(response));
+                                 asWebResponse(response), requestFuture);
                 }
                 return CompletableFuture.completedFuture(asWebResponse(response));
             }
             Throwable failure = unwrap(error);
             if (retriesRemaining > 0 && failure instanceof IOException && Instant.now().isBefore(deadline)) {
                 return retry(request, serializedRequest, settings, retriesRemaining, deadline,
-                             asWebResponse(failure));
+                             asWebResponse(failure), requestFuture);
             }
             return CompletableFuture.completedFuture(asWebResponse(failure));
         });
@@ -111,14 +127,17 @@ final class NativeWebRequestClient implements AutoCloseable {
 
     private CompletableFuture<WebResponse> retry(WebRequest request, SerializedMessage serializedRequest,
                                                  WebRequestSettings settings, int retriesRemaining, Instant deadline,
-                                                 WebResponse exhaustedResult) {
+                                                 WebResponse exhaustedResult,
+                                                 CancellableRequestFuture requestFuture) {
         Duration delay = normalizedRetryDelay(settings);
         Duration remaining = Duration.between(Instant.now(), deadline);
         if (remaining.isNegative() || remaining.isZero() || delay.compareTo(remaining) >= 0) {
             return CompletableFuture.completedFuture(exhaustedResult);
         }
-        return retryDelay.apply(delay).thenCompose(ignored -> Instant.now().isBefore(deadline)
-                ? send(request, serializedRequest, settings, retriesRemaining - 1, deadline)
+        CompletableFuture<Void> delayFuture = retryDelay.apply(delay);
+        requestFuture.track(delayFuture);
+        return delayFuture.thenCompose(ignored -> Instant.now().isBefore(deadline)
+                ? send(request, serializedRequest, settings, retriesRemaining - 1, deadline, requestFuture)
                 : CompletableFuture.completedFuture(exhaustedResult));
     }
 
@@ -174,6 +193,29 @@ final class NativeWebRequestClient implements AutoCloseable {
             result = result.getCause();
         }
         return result;
+    }
+
+    private static final class CancellableRequestFuture extends CompletableFuture<WebResponse> {
+        private final AtomicReference<CompletableFuture<?>> activeOperation = new AtomicReference<>();
+
+        private void track(CompletableFuture<?> operation) {
+            activeOperation.set(operation);
+            if (isCancelled()) {
+                operation.cancel(true);
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (!super.cancel(mayInterruptIfRunning)) {
+                return false;
+            }
+            CompletableFuture<?> operation = activeOperation.get();
+            if (operation != null) {
+                operation.cancel(mayInterruptIfRunning);
+            }
+            return true;
+        }
     }
 
     @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/NativeWebRequestClient.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.web;
+
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.sdk.common.serialization.Serializer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+final class NativeWebRequestClient implements AutoCloseable {
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+
+    private final HttpClient httpClient;
+    private final Serializer serializer;
+
+    NativeWebRequestClient(Serializer serializer) {
+        this(HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL)
+                     .connectTimeout(CONNECT_TIMEOUT).build(), serializer);
+    }
+
+    NativeWebRequestClient(HttpClient httpClient, Serializer serializer) {
+        this.httpClient = Objects.requireNonNull(httpClient);
+        this.serializer = Objects.requireNonNull(serializer);
+    }
+
+    CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
+        SerializedMessage serializedRequest = request.serialize(serializer);
+        Instant deadline = Instant.now().plus(settings.getTimeout());
+        return send(request, serializedRequest, settings, Math.max(0, settings.getMaxRetries()), deadline);
+    }
+
+    private CompletableFuture<WebResponse> send(WebRequest request, SerializedMessage serializedRequest,
+                                                WebRequestSettings settings, int retriesRemaining, Instant deadline) {
+        Duration remaining = Duration.between(Instant.now(), deadline);
+        if (remaining.isNegative() || remaining.isZero()) {
+            return CompletableFuture.completedFuture(asWebResponse(
+                    new HttpTimeoutException("Timeout in native HTTP client")));
+        }
+
+        HttpRequest httpRequest;
+        try {
+            httpRequest = asHttpRequest(request, serializedRequest, settings, remaining);
+        } catch (Throwable e) {
+            return CompletableFuture.completedFuture(asWebResponse(e));
+        }
+
+        CompletableFuture<HttpResponse<byte[]>> attempt;
+        try {
+            attempt = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+        } catch (Throwable e) {
+            return CompletableFuture.completedFuture(asWebResponse(e));
+        }
+
+        CompletableFuture<CompletableFuture<WebResponse>> result = attempt.handle((response, error) -> {
+            if (error == null) {
+                return CompletableFuture.completedFuture(asWebResponse(response));
+            }
+            Throwable failure = unwrap(error);
+            if (retriesRemaining > 0 && failure instanceof IOException && Instant.now().isBefore(deadline)) {
+                return send(request, serializedRequest, settings, retriesRemaining - 1, deadline);
+            }
+            return CompletableFuture.completedFuture(asWebResponse(failure));
+        });
+        return result.thenCompose(Function.identity());
+    }
+
+    private HttpRequest asHttpRequest(WebRequest request, SerializedMessage serializedRequest,
+                                      WebRequestSettings settings, Duration timeout) {
+        URI uri = URI.create(request.getPath());
+        if (!uri.isAbsolute() || !("http".equalsIgnoreCase(uri.getScheme())
+                || "https".equalsIgnoreCase(uri.getScheme()))) {
+            throw new IllegalArgumentException("Native HTTP requests require an absolute HTTP(S) URL");
+        }
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
+                .version(HttpClient.Version.valueOf(settings.getHttpVersion().name()))
+                .timeout(timeout);
+        request.getHeaders().forEach((name, values) -> values.forEach(value -> builder.header(name, value)));
+        return builder.method(request.getMethod(), bodyPublisher(serializedRequest)).build();
+    }
+
+    private HttpRequest.BodyPublisher bodyPublisher(SerializedMessage request) {
+        byte[] value = request.data().getValue();
+        String type = request.data().getType();
+        return type == null || Void.class.getName().equals(type) || value.length == 0
+                ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofByteArray(value);
+    }
+
+    private WebResponse asWebResponse(HttpResponse<byte[]> response) {
+        WebResponse.Builder builder = WebResponse.builder();
+        response.headers().map().forEach((name, values) -> values.forEach(value -> builder.header(name, value)));
+        return builder.status(response.statusCode()).payload(response.body()).build();
+    }
+
+    private WebResponse asWebResponse(Throwable error) {
+        String message = error.getMessage() == null ? "Exception while handling native HTTP request"
+                : error.getMessage();
+        return WebResponse.builder().status(502).payload(message.getBytes(UTF_8)).build();
+    }
+
+    private Throwable unwrap(Throwable error) {
+        Throwable result = error;
+        while (result instanceof CompletionException && result.getCause() != null) {
+            result = result.getCause();
+        }
+        return result;
+    }
+
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequest.java
@@ -76,8 +76,9 @@ import static io.fluxzero.common.api.Data.JSON_FORMAT;
  *     .build();
  * }</pre>
  *
- * <p>Outbound requests with an absolute URL that are dispatched using the {@link WebRequestGateway} will be forwarded
- * by the proxy in Fluxzero Runtime.
+ * <p>Outbound requests with an absolute URL that are dispatched using the {@link WebRequestGateway} are forwarded by
+ * the proxy in Fluxzero Runtime by default, or can be executed by the SDK's native HTTP client through
+ * {@link WebRequestSettings}.
  *
  * @see WebResponse
  * @see HandleWeb

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequestSettings.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequestSettings.java
@@ -17,16 +17,19 @@ package io.fluxzero.sdk.web;
 import io.fluxzero.sdk.publishing.WebRequestGateway;
 import lombok.Builder;
 import lombok.Builder.Default;
+import lombok.NonNull;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 import java.time.Duration;
+import java.util.Set;
 
 /**
  * Configuration settings for a {@link WebRequest} sent via the {@link WebRequestGateway}.
  * <p>
  * By default, requests are published as Fluxzero messages and forwarded by the Fluxzero proxy. Applications can opt
- * into execution by the SDK's native HTTP client instead. Transport retries apply within the configured overall
- * timeout; HTTP error responses are returned without retrying.
+ * into execution by the SDK's native HTTP client instead. Retries after transport failures or configured HTTP response
+ * statuses apply within the configured overall timeout.
  *
  * <p><strong>Example usage:</strong></p>
  * <pre>{@code
@@ -35,6 +38,8 @@ import java.time.Duration;
  *     .timeout(Duration.ofSeconds(30))
  *     .consumer("google-traffic")
  *     .maxRetries(2)
+ *     .retryDelay(Duration.ofMillis(250))
+ *     .retryableStatusCodes(Set.of(502, 503, 504))
  *     .build();
  * }</pre>
  *
@@ -42,6 +47,7 @@ import java.time.Duration;
  */
 @Value
 @Builder(toBuilder = true)
+@Jacksonized
 public class WebRequestSettings {
 
     /**
@@ -71,11 +77,28 @@ public class WebRequestSettings {
     boolean useNativeHttpClient = false;
 
     /**
-     * Maximum number of additional attempts after a transport failure. Retries share the configured {@link #timeout}
-     * and do not apply to completed HTTP responses, including 4xx and 5xx status codes. Values below zero are treated
-     * as zero. A transport failure can occur after the remote server accepted a request, so retry non-idempotent calls
+     * Maximum number of additional attempts after a transport failure or a response whose status occurs in
+     * {@link #retryableStatusCodes}. Retries share the configured {@link #timeout}. Values below zero are treated as
+     * zero. A failure or response can occur after the remote server accepted a request, so retry non-idempotent calls
      * only when the destination provides suitable deduplication.
      */
     @Default
     int maxRetries = 0;
+
+    /**
+     * Fixed delay before each retry. Defaults to one second. The delay counts toward {@link #timeout}; no new attempt
+     * starts when the delay no longer fits before the request deadline. Negative values are treated as zero.
+     */
+    @Default
+    @NonNull
+    Duration retryDelay = Duration.ofSeconds(1);
+
+    /**
+     * HTTP response statuses that may trigger a retry when {@link #maxRetries} is positive. Defaults to common
+     * transient server failures: 500, 502, 503, and 504. Configure an empty set to retry transport failures only, or
+     * provide a custom set for destination-specific response statuses. Other responses are returned immediately.
+     */
+    @Default
+    @NonNull
+    Set<Integer> retryableStatusCodes = Set.of(500, 502, 503, 504);
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/web/WebRequestSettings.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/web/WebRequestSettings.java
@@ -24,9 +24,9 @@ import java.time.Duration;
 /**
  * Configuration settings for a {@link WebRequest} sent via the {@link WebRequestGateway}.
  * <p>
- * These settings influence how the request is processed and forwarded by the Fluxzero proxy. While currently limited to
- * a few essential fields, this class is designed for extensibility and may be expanded over time to support headers,
- * retry policies, authentication strategies, and more.
+ * By default, requests are published as Fluxzero messages and forwarded by the Fluxzero proxy. Applications can opt
+ * into execution by the SDK's native HTTP client instead. Transport retries apply within the configured overall
+ * timeout; HTTP error responses are returned without retrying.
  *
  * <p><strong>Example usage:</strong></p>
  * <pre>{@code
@@ -34,6 +34,7 @@ import java.time.Duration;
  *     .httpVersion(HttpVersion.HTTP_2)
  *     .timeout(Duration.ofSeconds(30))
  *     .consumer("google-traffic")
+ *     .maxRetries(2)
  *     .build();
  * }</pre>
  *
@@ -60,4 +61,21 @@ public class WebRequestSettings {
      */
     @Default
     String consumer = "forward-proxy";
+
+    /**
+     * Whether the SDK should execute the request directly with its native HTTP client instead of publishing it for the
+     * Fluxzero proxy. Native execution requires an absolute HTTP(S) URL and bypasses Fluxzero message logging, local
+     * web handlers, dispatch interceptors, and consumer isolation.
+     */
+    @Default
+    boolean useNativeHttpClient = false;
+
+    /**
+     * Maximum number of additional attempts after a transport failure. Retries share the configured {@link #timeout}
+     * and do not apply to completed HTTP responses, including 4xx and 5xx status codes. Values below zero are treated
+     * as zero. A transport failure can occur after the remote server accepted a request, so retry non-idempotent calls
+     * only when the destination provides suitable deduplication.
+     */
+    @Default
+    int maxRetries = 0;
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/test/FixtureFluxzero.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/FixtureFluxzero.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.test;
+
+import io.fluxzero.common.ThrowingConsumer;
+import io.fluxzero.common.ThrowingFunction;
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.publishing.WebRequestGateway;
+import lombok.experimental.Delegate;
+
+final class FixtureFluxzero implements Fluxzero {
+
+    @Delegate
+    private final Fluxzero delegate;
+    private final WebRequestGateway webRequestGateway;
+
+    FixtureFluxzero(Fluxzero delegate) {
+        this.delegate = delegate;
+        this.webRequestGateway = new FixtureWebRequestGateway(delegate.webRequestGateway());
+    }
+
+    @Override
+    public WebRequestGateway webRequestGateway() {
+        return webRequestGateway;
+    }
+
+    Fluxzero delegate() {
+        return delegate;
+    }
+
+    @Override
+    public <R> R apply(ThrowingFunction<Fluxzero, R> function) {
+        return Fluxzero.super.apply(function);
+    }
+
+    @Override
+    public void execute(ThrowingConsumer<Fluxzero> task) {
+        Fluxzero.super.execute(task);
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGateway.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGateway.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.test;
+
+import io.fluxzero.sdk.publishing.WebRequestGateway;
+import io.fluxzero.sdk.web.WebRequest;
+import io.fluxzero.sdk.web.WebRequestSettings;
+import io.fluxzero.sdk.web.WebResponse;
+import lombok.experimental.Delegate;
+
+import java.time.Duration;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+final class FixtureWebRequestGateway implements WebRequestGateway {
+
+    @Delegate
+    private final WebRequestGateway delegate;
+    private final Map<WebRequestGateway, FixtureWebRequestGateway> gateways;
+
+    FixtureWebRequestGateway(WebRequestGateway delegate) {
+        this(delegate, new IdentityHashMap<>());
+        gateways.put(delegate, this);
+    }
+
+    private FixtureWebRequestGateway(WebRequestGateway delegate,
+                                     Map<WebRequestGateway, FixtureWebRequestGateway> gateways) {
+        this.delegate = delegate;
+        this.gateways = gateways;
+    }
+
+    @Override
+    public CompletableFuture<WebResponse> send(WebRequest request, WebRequestSettings settings) {
+        int retries = Math.max(0, settings.getMaxRetries());
+        WebRequestSettings fixtureSettings = fixtureSettings(settings);
+        CompletableFuture<WebResponse> result = delegate.send(request, fixtureSettings);
+        for (int i = 0; i < retries; i++) {
+            result = result.thenCompose(response -> settings.getRetryableStatusCodes().contains(response.getStatus())
+                    ? delegate.send(request, fixtureSettings)
+                    : CompletableFuture.completedFuture(response));
+        }
+        return result;
+    }
+
+    @Override
+    public WebResponse sendAndWait(WebRequest request, WebRequestSettings settings) {
+        int retries = Math.max(0, settings.getMaxRetries());
+        WebRequestSettings fixtureSettings = fixtureSettings(settings);
+        WebResponse result = delegate.sendAndWait(request, fixtureSettings);
+        while (retries-- > 0 && settings.getRetryableStatusCodes().contains(result.getStatus())) {
+            result = delegate.sendAndWait(request, fixtureSettings);
+        }
+        return result;
+    }
+
+    @Override
+    public WebRequestGateway forNamespace(String namespace) {
+        WebRequestGateway namespaced = delegate.forNamespace(namespace);
+        synchronized (gateways) {
+            FixtureWebRequestGateway result = gateways.get(namespaced);
+            if (result == null) {
+                result = new FixtureWebRequestGateway(namespaced, gateways);
+                gateways.put(namespaced, result);
+            }
+            return result;
+        }
+    }
+
+    private WebRequestSettings fixtureSettings(WebRequestSettings settings) {
+        return settings.toBuilder()
+                .useNativeHttpClient(false)
+                .maxRetries(0)
+                .retryDelay(Duration.ZERO)
+                .build();
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGatewayTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGatewayTest.java
@@ -15,6 +15,7 @@
 package io.fluxzero.sdk.test;
 
 import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.publishing.EventGateway;
 import io.fluxzero.sdk.tracking.handling.HandleCommand;
 import io.fluxzero.sdk.web.HandleGet;
 import io.fluxzero.sdk.web.WebRequest;
@@ -27,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class FixtureWebRequestGatewayTest {
 
@@ -67,6 +69,19 @@ class FixtureWebRequestGatewayTest {
         assertEquals(2, endpoint.attempts.get());
     }
 
+    @Test
+    void asynchronousWorkflowDoesNotRouteUnrelatedCallsThroughFixtureSpies() {
+        RetryingEndpoint endpoint = new RetryingEndpoint();
+        TestFixture fixture = TestFixture.createAsync(endpoint, new PublishingWorkflow()).spy();
+        EventGateway eventGateway = fixture.getFluxzero().eventGateway();
+
+        fixture.whenCommand(new CallEndpoint())
+                .expectResult(200);
+
+        assertEquals(2, endpoint.attempts.get());
+        verifyNoInteractions(eventGateway);
+    }
+
     private static WebRequestSettings retrySettings() {
         return WebRequestSettings.builder()
                 .useNativeHttpClient(true)
@@ -95,6 +110,18 @@ class FixtureWebRequestGatewayTest {
         }
     }
 
+    private static class PublishingWorkflow {
+        @HandleCommand
+        int handle(CallEndpoint ignored) {
+            Fluxzero.publishEvent(new EndpointCalled());
+            return Fluxzero.get().webRequestGateway().sendAndWait(
+                    WebRequest.get(ENDPOINT).build(), retrySettings()).getStatus();
+        }
+    }
+
     private record CallEndpoint() {
+    }
+
+    private record EndpointCalled() {
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGatewayTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/FixtureWebRequestGatewayTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.test;
+
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.tracking.handling.HandleCommand;
+import io.fluxzero.sdk.web.HandleGet;
+import io.fluxzero.sdk.web.WebRequest;
+import io.fluxzero.sdk.web.WebRequestSettings;
+import io.fluxzero.sdk.web.WebResponse;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FixtureWebRequestGatewayTest {
+
+    private static final String ENDPOINT = "https://api.example.com/resource";
+
+    @Test
+    void synchronousFixtureRoutesNativeAsyncRequestToMockAndRetriesImmediately() {
+        RetryingEndpoint endpoint = new RetryingEndpoint();
+
+        TestFixture.create(endpoint)
+                .whenApplying(fluxzero -> fluxzero.webRequestGateway().send(
+                        WebRequest.get(ENDPOINT).build(), retrySettings()).join())
+                .<WebResponse>expectResult(response -> response.getStatus() == 200);
+
+        assertEquals(2, endpoint.attempts.get());
+    }
+
+    @Test
+    void asynchronousFixtureRoutesNativeBlockingRequestToMockAndRetriesImmediately() {
+        RetryingEndpoint endpoint = new RetryingEndpoint();
+
+        TestFixture.createAsync(endpoint)
+                .whenApplying(fluxzero -> fluxzero.webRequestGateway().sendAndWait(
+                        WebRequest.get(ENDPOINT).build(), retrySettings()))
+                .<WebResponse>expectResult(response -> response.getStatus() == 200);
+
+        assertEquals(2, endpoint.attempts.get());
+    }
+
+    @Test
+    void asynchronousWorkflowUsesFixtureGatewayFromHandlerContext() {
+        RetryingEndpoint endpoint = new RetryingEndpoint();
+
+        TestFixture.createAsync(endpoint, new Workflow())
+                .whenCommand(new CallEndpoint())
+                .expectResult(200);
+
+        assertEquals(2, endpoint.attempts.get());
+    }
+
+    private static WebRequestSettings retrySettings() {
+        return WebRequestSettings.builder()
+                .useNativeHttpClient(true)
+                .maxRetries(1)
+                .retryableStatusCodes(Set.of(429))
+                .retryDelay(Duration.ofDays(1))
+                .build();
+    }
+
+    private static class RetryingEndpoint {
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        @HandleGet(ENDPOINT)
+        WebResponse handle() {
+            return attempts.getAndIncrement() == 0
+                    ? WebResponse.builder().status(429).build()
+                    : WebResponse.builder().status(200).build();
+        }
+    }
+
+    private static class Workflow {
+        @HandleCommand
+        int handle(CallEndpoint ignored) {
+            return Fluxzero.get().webRequestGateway().sendAndWait(
+                    WebRequest.get(ENDPOINT).build(), retrySettings()).getStatus();
+        }
+    }
+
+    private record CallEndpoint() {
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
@@ -361,6 +361,7 @@ public class TestFixture implements Given<TestFixture>, When {
 
     @Getter
     private final Fluxzero fluxzero;
+    private final FixtureFluxzero handlerFluxzero;
     private final FluxzeroBuilder fluxzeroBuilder;
     private final GivenWhenThenInterceptor interceptor;
     private Duration resultTimeout = defaultResultTimeout;
@@ -432,7 +433,8 @@ public class TestFixture implements Given<TestFixture>, When {
                 .addBatchInterceptor(new HighPriorityBatchInterceptor(interceptor))
                 .addHandlerInterceptor(new HighPriorityHandlerInterceptor(interceptor));
         this.fluxzeroBuilder = fluxzeroBuilder;
-        this.fluxzero = new FixtureFluxzero(fluxzeroBuilder.build(client));
+        this.handlerFluxzero = new FixtureFluxzero(fluxzeroBuilder.build(client));
+        this.fluxzero = handlerFluxzero;
         Fluxzero.instance.set(this.fluxzero);
         if (synchronous) {
             localHandlerRegistries(fluxzero).forEach(r -> r.setSelfHandlerFilter(HandlerFilter.ALWAYS_HANDLE));
@@ -478,9 +480,9 @@ public class TestFixture implements Given<TestFixture>, When {
                 ? LocalClient.newInstance(null) : currentClient;
         newClient = trackRemoteDocumentUpdates(newClient);
         newClient.monitorDispatch(dispatchInterceptor::interceptClientDispatch);
-        Fluxzero fixtureFluxzero = new FixtureFluxzero(fluxzeroBuilder.build(
+        this.handlerFluxzero = new FixtureFluxzero(fluxzeroBuilder.build(
                 spying ? new SpyingClient(newClient) : newClient));
-        this.fluxzero = spying ? new SpyingFluxzero(fixtureFluxzero) : fixtureFluxzero;
+        this.fluxzero = spying ? new SpyingFluxzero(handlerFluxzero) : handlerFluxzero;
         Fluxzero.instance.set(this.fluxzero);
         localHandlerRegistries(this.fluxzero).forEach(r -> r.setSelfHandlerFilter(
                 synchronous ? HandlerFilter.ALWAYS_HANDLE : (t, m) -> !ClientUtils.isSelfTracking(t, m)));
@@ -2224,7 +2226,7 @@ public class TestFixture implements Given<TestFixture>, When {
 
         public Function<DeserializingMessage, Object> interceptHandling(
                 Function<DeserializingMessage, Object> function, HandlerInvoker invoker) {
-            return m -> testFixture.fluxzero.apply(ignored -> {
+            return m -> testFixture.handlerFluxzero.apply(ignored -> {
                 ActiveHandler activeHandler = testFixture.synchronous ? testFixture.activeHandler(m, invoker) : null;
                 Deque<ActiveHandler> activeHandlers = null;
                 if (activeHandler != null) {

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
@@ -165,6 +165,10 @@ import static java.util.stream.Stream.empty;
  *   <li>Non-local handlers are scheduled and dispatched asynchronously</li>
  *   <li>Handlers annotated with {@code @LocalHandler} still execute locally (on the calling thread)</li>
  * </ul>
+ * Outbound web requests always use the fixture's in-memory request route, even when their
+ * {@link io.fluxzero.sdk.web.WebRequestSettings} select native HTTP execution. This keeps registered mock endpoints
+ * active. Configured retry counts and retryable response statuses still apply, without waiting for the configured
+ * retry delay between fixture attempts.
  *
  * <p>
  * Handlers may be registered by class or by instance. In general:
@@ -428,7 +432,7 @@ public class TestFixture implements Given<TestFixture>, When {
                 .addBatchInterceptor(new HighPriorityBatchInterceptor(interceptor))
                 .addHandlerInterceptor(new HighPriorityHandlerInterceptor(interceptor));
         this.fluxzeroBuilder = fluxzeroBuilder;
-        this.fluxzero = fluxzeroBuilder.build(client);
+        this.fluxzero = new FixtureFluxzero(fluxzeroBuilder.build(client));
         Fluxzero.instance.set(this.fluxzero);
         if (synchronous) {
             localHandlerRegistries(fluxzero).forEach(r -> r.setSelfHandlerFilter(HandlerFilter.ALWAYS_HANDLE));
@@ -474,9 +478,9 @@ public class TestFixture implements Given<TestFixture>, When {
                 ? LocalClient.newInstance(null) : currentClient;
         newClient = trackRemoteDocumentUpdates(newClient);
         newClient.monitorDispatch(dispatchInterceptor::interceptClientDispatch);
-        this.fluxzero = spying
-                ? new SpyingFluxzero(fluxzeroBuilder.build(new SpyingClient(newClient)))
-                : fluxzeroBuilder.build(newClient);
+        Fluxzero fixtureFluxzero = new FixtureFluxzero(fluxzeroBuilder.build(
+                spying ? new SpyingClient(newClient) : newClient));
+        this.fluxzero = spying ? new SpyingFluxzero(fixtureFluxzero) : fixtureFluxzero;
         Fluxzero.instance.set(this.fluxzero);
         localHandlerRegistries(this.fluxzero).forEach(r -> r.setSelfHandlerFilter(
                 synchronous ? HandlerFilter.ALWAYS_HANDLE : (t, m) -> !ClientUtils.isSelfTracking(t, m)));
@@ -2220,7 +2224,7 @@ public class TestFixture implements Given<TestFixture>, When {
 
         public Function<DeserializingMessage, Object> interceptHandling(
                 Function<DeserializingMessage, Object> function, HandlerInvoker invoker) {
-            return m -> {
+            return m -> testFixture.fluxzero.apply(ignored -> {
                 ActiveHandler activeHandler = testFixture.synchronous ? testFixture.activeHandler(m, invoker) : null;
                 Deque<ActiveHandler> activeHandlers = null;
                 if (activeHandler != null) {
@@ -2269,7 +2273,7 @@ public class TestFixture implements Given<TestFixture>, When {
                         }
                     }
                 }
-            };
+            });
         }
 
         public void shutdown(Tracker tracker) {

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureLifecycleTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureLifecycleTest.java
@@ -120,9 +120,13 @@ class TestFixtureLifecycleTest {
 
     private static boolean closed(TestFixture fixture) {
         try {
-            var closed = fixture.getFluxzero().getClass().getDeclaredField("closed");
+            Fluxzero fluxzero = fixture.getFluxzero();
+            if (fluxzero instanceof FixtureFluxzero fixtureFluxzero) {
+                fluxzero = fixtureFluxzero.delegate();
+            }
+            var closed = fluxzero.getClass().getDeclaredField("closed");
             closed.setAccessible(true);
-            return ((AtomicBoolean) closed.get(fixture.getFluxzero())).get();
+            return ((AtomicBoolean) closed.get(fluxzero)).get();
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
@@ -31,12 +31,16 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -106,14 +110,107 @@ class DefaultWebRequestGatewayTest {
 
         WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
                                                  WebRequestSettings.builder().useNativeHttpClient(true)
-                                                         .maxRetries(2).timeout(Duration.ofSeconds(5)).build());
+                                                         .maxRetries(2).retryDelay(Duration.ZERO)
+                                                         .timeout(Duration.ofSeconds(5)).build());
 
         assertEquals(200, result.getStatus());
         verify(httpClient, org.mockito.Mockito.times(3)).sendAsync(any(), anyByteArrayBodyHandler());
     }
 
     @Test
-    void doesNotRetryCompletedHttpErrorResponse() {
+    void retriesDefaultTransientServerErrorResponse() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> errorResponse = response(503, "unavailable");
+        HttpResponse<byte[]> successResponse = response(200, "ok");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse),
+                            CompletableFuture.completedFuture(successResponse));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
+                                                 WebRequestSettings.builder().useNativeHttpClient(true)
+                                                         .maxRetries(1).retryDelay(Duration.ZERO)
+                                                         .timeout(Duration.ofSeconds(5)).build());
+
+        assertEquals(200, result.getStatus());
+        verify(httpClient, org.mockito.Mockito.times(2)).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void doesNotRetryResponseStatusWhenRetriesAreDisabled() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> errorResponse = response(503, "unavailable");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
+                                                 WebRequestSettings.builder().useNativeHttpClient(true).build());
+
+        assertEquals(503, result.getStatus());
+        verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void waitsAsynchronouslyBeforeNativeRetry() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> errorResponse = response(503, "unavailable");
+        HttpResponse<byte[]> successResponse = response(200, "ok");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse),
+                            CompletableFuture.completedFuture(successResponse));
+        CompletableFuture<Void> retryPermit = new CompletableFuture<>();
+        AtomicReference<Duration> scheduledDelay = new AtomicReference<>();
+        DefaultWebRequestGateway gateway = gateway(
+                delegate, httpClient, delay -> {
+                    scheduledDelay.set(delay);
+                    return retryPermit;
+                });
+
+        CompletableFuture<WebResponse> result = gateway.send(
+                WebRequest.get("https://example.com").build(),
+                WebRequestSettings.builder().useNativeHttpClient(true).maxRetries(1)
+                        .retryDelay(Duration.ofMillis(250)).timeout(Duration.ofSeconds(5)).build());
+
+        assertEquals(Duration.ofMillis(250), scheduledDelay.get());
+        assertFalse(result.isDone());
+        verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
+
+        retryPermit.complete(null);
+
+        assertEquals(200, result.join().getStatus());
+        verify(httpClient, org.mockito.Mockito.times(2)).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void skipsNativeRetryWhoseDelayDoesNotFitDeadline() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> errorResponse = response(503, "unavailable");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+        AtomicReference<Duration> scheduledDelay = new AtomicReference<>();
+        DefaultWebRequestGateway gateway = gateway(
+                delegate, httpClient, delay -> {
+                    scheduledDelay.set(delay);
+                    return CompletableFuture.completedFuture(null);
+                });
+
+        WebResponse result = gateway.sendAndWait(
+                WebRequest.get("https://example.com").build(),
+                WebRequestSettings.builder().useNativeHttpClient(true).maxRetries(1)
+                        .retryDelay(Duration.ofSeconds(2)).timeout(Duration.ofSeconds(1)).build());
+
+        assertEquals(503, result.getStatus());
+        assertNull(scheduledDelay.get());
+        verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void doesNotRetryResponseStatusExcludedBySettings() {
         GenericGateway delegate = mock(GenericGateway.class);
         HttpClient httpClient = mock(HttpClient.class);
         HttpResponse<byte[]> errorResponse = response(503, "unavailable");
@@ -123,7 +220,8 @@ class DefaultWebRequestGatewayTest {
 
         WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
                                                  WebRequestSettings.builder().useNativeHttpClient(true)
-                                                         .maxRetries(3).timeout(Duration.ofSeconds(5)).build());
+                                                         .maxRetries(3).retryableStatusCodes(Set.of())
+                                                         .timeout(Duration.ofSeconds(5)).build());
 
         assertEquals(503, result.getStatus());
         verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
@@ -134,17 +232,27 @@ class DefaultWebRequestGatewayTest {
         ObjectNode oldSettings = Metadata.objectMapper.valueToTree(WebRequestSettings.builder().build());
         oldSettings.remove("useNativeHttpClient");
         oldSettings.remove("maxRetries");
+        oldSettings.remove("retryDelay");
+        oldSettings.remove("retryableStatusCodes");
 
         WebRequestSettings result = Metadata.of("settings", oldSettings.toString())
                 .get("settings", WebRequestSettings.class);
 
         assertFalse(result.isUseNativeHttpClient());
         assertEquals(0, result.getMaxRetries());
+        assertEquals(Duration.ofSeconds(1), result.getRetryDelay());
+        assertEquals(Set.of(500, 502, 503, 504), result.getRetryableStatusCodes());
     }
 
     private DefaultWebRequestGateway gateway(GenericGateway delegate, HttpClient httpClient) {
         return new DefaultWebRequestGateway(delegate,
                                             new NativeWebRequestClient(httpClient, new JacksonSerializer()));
+    }
+
+    private DefaultWebRequestGateway gateway(GenericGateway delegate, HttpClient httpClient,
+                                             Function<Duration, CompletableFuture<Void>> retryDelay) {
+        return new DefaultWebRequestGateway(
+                delegate, new NativeWebRequestClient(httpClient, new JacksonSerializer(), retryDelay));
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
@@ -18,6 +18,7 @@ package io.fluxzero.sdk.web;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fluxzero.common.api.Metadata;
+import io.fluxzero.sdk.common.Message;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import io.fluxzero.sdk.publishing.GenericGateway;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -41,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -93,6 +96,91 @@ class DefaultWebRequestGatewayTest {
                         && request.headers().allValues("X-Test").equals(List.of("value"))),
                 anyByteArrayBodyHandler());
         verify(httpClient).close();
+    }
+
+    @Test
+    void withDelegateUsesIndependentlyOwnedNativeHttpClient() {
+        GenericGateway firstDelegate = mock(GenericGateway.class);
+        GenericGateway secondDelegate = mock(GenericGateway.class);
+        HttpClient firstHttpClient = mock(HttpClient.class);
+        HttpClient secondHttpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> firstResponse = response(200, "first");
+        HttpResponse<byte[]> secondResponse = response(200, "second");
+        when(firstHttpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(firstResponse));
+        when(secondHttpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(secondResponse));
+        AtomicInteger clientIndex = new AtomicInteger();
+        List<NativeWebRequestClient> clients = List.of(
+                new NativeWebRequestClient(firstHttpClient, new JacksonSerializer()),
+                new NativeWebRequestClient(secondHttpClient, new JacksonSerializer()));
+        DefaultWebRequestGateway firstGateway = new DefaultWebRequestGateway(
+                firstDelegate, () -> clients.get(clientIndex.getAndIncrement()));
+        DefaultWebRequestGateway secondGateway = firstGateway.withDelegate(secondDelegate);
+        WebRequestSettings settings = WebRequestSettings.builder().useNativeHttpClient(true).build();
+
+        WebResponse first = firstGateway.sendAndWait(WebRequest.get("https://example.com/first").build(), settings);
+        WebResponse second = secondGateway.sendAndWait(WebRequest.get("https://example.com/second").build(), settings);
+        firstGateway.close();
+        secondGateway.close();
+
+        assertArrayEquals("first".getBytes(UTF_8), first.getPayload());
+        assertArrayEquals("second".getBytes(UTF_8), second.getPayload());
+        assertEquals(2, clientIndex.get());
+        verify(firstHttpClient).close();
+        verify(secondHttpClient).close();
+    }
+
+    @Test
+    void cancellingNativeSendCancelsActiveHttpRequest() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<HttpResponse<byte[]>> httpRequest = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler())).thenReturn(httpRequest);
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        CompletableFuture<WebResponse> result = gateway.send(
+                WebRequest.get("https://example.com").build(),
+                WebRequestSettings.builder().useNativeHttpClient(true).build());
+
+        assertTrue(result.cancel(true));
+        assertTrue(httpRequest.isCancelled());
+        gateway.close();
+    }
+
+    @Test
+    void cancellingProxySendDoesNotCancelDelegateRequest() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        CompletableFuture<Message> delegateRequest = new CompletableFuture<>();
+        when(delegate.sendForMessage(any(WebRequest.class), any(Duration.class))).thenReturn(delegateRequest);
+        DefaultWebRequestGateway gateway = new DefaultWebRequestGateway(delegate);
+
+        CompletableFuture<WebResponse> result = gateway.send(
+                WebRequest.get("https://example.com").build(), WebRequestSettings.builder().build());
+
+        assertTrue(result.cancel(true));
+        assertFalse(delegateRequest.isCancelled());
+        gateway.close();
+    }
+
+    @Test
+    void cancellingNativeSendDuringRetryDelayPreventsNextAttempt() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> unavailable = response(503, "unavailable");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(unavailable));
+        CompletableFuture<Void> retryDelay = new CompletableFuture<>();
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient, ignored -> retryDelay);
+
+        CompletableFuture<WebResponse> result = gateway.send(
+                WebRequest.get("https://example.com").build(),
+                WebRequestSettings.builder().useNativeHttpClient(true).maxRetries(1).build());
+
+        assertTrue(result.cancel(true));
+        assertTrue(retryDelay.isCancelled());
+        verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
+        gateway.close();
     }
 
     @Test

--- a/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/DefaultWebRequestGatewayTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.web;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
+import io.fluxzero.sdk.publishing.GenericGateway;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DefaultWebRequestGatewayTest {
+
+    @Test
+    void usesProxyByDefault() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        WebResponse expected = WebResponse.builder().status(200).payload("proxy").build();
+        when(delegate.sendForMessage(any(WebRequest.class), any(Duration.class)))
+                .thenReturn(CompletableFuture.completedFuture(expected));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
+                                                 WebRequestSettings.builder().build());
+        gateway.close();
+
+        assertEquals(expected, result);
+        verify(delegate).sendForMessage(any(WebRequest.class), any(Duration.class));
+        verify(delegate).close();
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void nativeHttpClientBypassesProxy() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> nativeResponse = response(201, "native");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(nativeResponse));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.send(
+                        WebRequest.post("https://example.com/resource").header("X-Test", "value").body("request").build(),
+                        WebRequestSettings.builder().useNativeHttpClient(true).timeout(Duration.ofSeconds(5)).build())
+                .join();
+        gateway.close();
+
+        assertEquals(201, result.getStatus());
+        assertArrayEquals("native".getBytes(UTF_8), result.getPayload());
+        verify(delegate, never()).sendForMessage(any(WebRequest.class), any(Duration.class));
+        verify(httpClient).sendAsync(
+                org.mockito.ArgumentMatchers.argThat(request -> request.uri().equals(
+                        URI.create("https://example.com/resource")) && "POST".equals(request.method())
+                        && request.headers().allValues("X-Test").equals(List.of("value"))),
+                anyByteArrayBodyHandler());
+        verify(httpClient).close();
+    }
+
+    @Test
+    void retriesNativeTransportFailures() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<HttpResponse<byte[]>> firstFailure = CompletableFuture.failedFuture(
+                new IOException("first"));
+        CompletableFuture<HttpResponse<byte[]>> secondFailure = CompletableFuture.failedFuture(
+                new IOException("second"));
+        HttpResponse<byte[]> successfulResponse = response(200, "ok");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(firstFailure, secondFailure, CompletableFuture.completedFuture(successfulResponse));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
+                                                 WebRequestSettings.builder().useNativeHttpClient(true)
+                                                         .maxRetries(2).timeout(Duration.ofSeconds(5)).build());
+
+        assertEquals(200, result.getStatus());
+        verify(httpClient, org.mockito.Mockito.times(3)).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void doesNotRetryCompletedHttpErrorResponse() {
+        GenericGateway delegate = mock(GenericGateway.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> errorResponse = response(503, "unavailable");
+        when(httpClient.sendAsync(any(), anyByteArrayBodyHandler()))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+        DefaultWebRequestGateway gateway = gateway(delegate, httpClient);
+
+        WebResponse result = gateway.sendAndWait(WebRequest.get("https://example.com").build(),
+                                                 WebRequestSettings.builder().useNativeHttpClient(true)
+                                                         .maxRetries(3).timeout(Duration.ofSeconds(5)).build());
+
+        assertEquals(503, result.getStatus());
+        verify(httpClient).sendAsync(any(), anyByteArrayBodyHandler());
+    }
+
+    @Test
+    void readsCompatibilityDefaultsWhenNewSettingsAreAbsent() {
+        ObjectNode oldSettings = Metadata.objectMapper.valueToTree(WebRequestSettings.builder().build());
+        oldSettings.remove("useNativeHttpClient");
+        oldSettings.remove("maxRetries");
+
+        WebRequestSettings result = Metadata.of("settings", oldSettings.toString())
+                .get("settings", WebRequestSettings.class);
+
+        assertFalse(result.isUseNativeHttpClient());
+        assertEquals(0, result.getMaxRetries());
+    }
+
+    private DefaultWebRequestGateway gateway(GenericGateway delegate, HttpClient httpClient) {
+        return new DefaultWebRequestGateway(delegate,
+                                            new NativeWebRequestClient(httpClient, new JacksonSerializer()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse.BodyHandler<byte[]> anyByteArrayBodyHandler() {
+        return any(HttpResponse.BodyHandler.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse<byte[]> response(int status, String body) {
+        HttpResponse<byte[]> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.body()).thenReturn(body.getBytes(UTF_8));
+        when(response.headers()).thenReturn(HttpHeaders.of(Map.of("Content-Type", List.of("text/plain")),
+                                                           (name, value) -> true));
+        return response;
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestForwardingTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestForwardingTest.java
@@ -19,6 +19,7 @@ import io.fluxzero.common.TestUtils;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import io.fluxzero.sdk.configuration.DefaultFluxzero;
+import io.fluxzero.sdk.publishing.GenericGateway;
 import io.fluxzero.sdk.test.TestFixture;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
@@ -33,8 +34,9 @@ import java.net.InetSocketAddress;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class WebRequestForwardingTest {
@@ -99,13 +101,18 @@ public class WebRequestForwardingTest {
 
     @Test
     void sendsAbsoluteRequestUsingNativeHttpClient() {
-        testFixture.whenApplying(fc -> fc.webRequestGateway().sendAndWait(
-                        WebRequest.post("http://localhost:%d/object".formatted(port)).body(new Foo("bar")).build(),
-                        WebRequestSettings.builder().useNativeHttpClient(true).build()))
-                .<WebResponse>expectResult(response -> response.getStatus() == 200
-                        && "object".equals(new String(response.<byte[]>getPayload(), UTF_8)))
-                .expectThat(fc -> verify(fc.client().getGatewayClient(MessageType.WEBREQUEST), never())
-                        .append(any(), any()));
+        DefaultWebRequestGateway gateway = new DefaultWebRequestGateway(
+                mock(GenericGateway.class), new JacksonSerializer());
+        try {
+            WebResponse response = gateway.sendAndWait(
+                    WebRequest.post("http://localhost:%d/object".formatted(port)).body(new Foo("bar")).build(),
+                    WebRequestSettings.builder().useNativeHttpClient(true).build());
+
+            assertEquals(200, response.getStatus());
+            assertEquals("object", new String(response.<byte[]>getPayload(), UTF_8));
+        } finally {
+            gateway.close();
+        }
     }
 
     private static void handleGet(HttpExchange exchange) throws IOException {

--- a/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestForwardingTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/web/WebRequestForwardingTest.java
@@ -34,6 +34,7 @@ import java.net.InetSocketAddress;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class WebRequestForwardingTest {
@@ -94,6 +95,17 @@ public class WebRequestForwardingTest {
                     assertArrayEquals("get".getBytes(UTF_8), ((WebResponse) response).getPayload());
                     return true;
                 });
+    }
+
+    @Test
+    void sendsAbsoluteRequestUsingNativeHttpClient() {
+        testFixture.whenApplying(fc -> fc.webRequestGateway().sendAndWait(
+                        WebRequest.post("http://localhost:%d/object".formatted(port)).body(new Foo("bar")).build(),
+                        WebRequestSettings.builder().useNativeHttpClient(true).build()))
+                .<WebResponse>expectResult(response -> response.getStatus() == 200
+                        && "object".equals(new String(response.<byte[]>getPayload(), UTF_8)))
+                .expectThat(fc -> verify(fc.client().getGatewayClient(MessageType.WEBREQUEST), never())
+                        .append(any(), any()));
     }
 
     private static void handleGet(HttpExchange exchange) throws IOException {


### PR DESCRIPTION
## Summary

- let WebRequestSettings select the lifecycle-managed native HTTP client instead of proxy routing per request
- configure bounded retries, retryable response statuses, and a fixed delay within one total timeout
- keep native-configured requests mockable in TestFixture, retaining retries without real retry waits
- propagate async cancellation to the active native HTTP call or retry delay while preserving proxy cancellation behavior

## Verification

- ./mvnw -B install
- ./mvnw -B site -Pjavadoc