### PR TITLE
feat(proxy): schedule asynchronous forwards by segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2952,11 +2952,26 @@ When set, the Flux Web Proxy will isolate this request in its own internal proce
 - Need different retry or error handling strategies per destination
 - Want fault isolation between outgoing endpoints
 
-The proxy executes outgoing HTTP calls asynchronously and admits at most four active logical requests per consumer by
-default. A logical request keeps its capacity slot throughout its retry attempts and retry delays. Once a consumer
-reaches its limit, its tracker stops fetching further requests until capacity becomes available; a slow consumer does
-not consume another consumer's slots. Set `FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS` to a positive integer to
-change this per-consumer limit. Higher values may increase outbound connection, memory, and destination load.
+The proxy keeps one tracker per named consumer, while all trackers feed one bounded asynchronous request scheduler.
+Requests with the exact same message segment are always handled serially, including response storage; ready requests
+from other segments share up to eight active logical-request slots by default. A logical request keeps its slot through
+all HTTP attempts, retry delays, and durable response publication.
+
+Each tracking batch gets a 250 ms best-case completion window. When that window expires, the tracker may checkpoint the
+batch and fetch the next default-sized batch while late requests continue in memory. The scheduler admits at most 1024
+outstanding requests in total by default, including active and segment-queued requests. Reaching that bound blocks
+further batch admission and therefore provides durable-log backpressure. These limits can be tuned with:
+
+- `FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS` (default `8`)
+- `FLUXZERO_PROXY_FORWARD_MAX_OUTSTANDING_REQUESTS` (default `1024`, at least the concurrent limit)
+- `FLUXZERO_PROXY_FORWARD_BATCH_COMPLETION_GRACE_MILLIS` (default `250`, non-negative)
+
+Higher values can increase outbound connection, memory, and destination load. During normal shutdown, the proxy first
+waits for outstanding requests and stored responses. If the configured proxy shutdown deadline expires, requests that
+are still queued or executing HTTP are cancelled best effort and appended at the end of the durable WebRequest log in
+their original log order. Requests whose response is already being stored are not re-executed. A hard process crash can
+still leave the outcome of already checkpointed in-memory work ambiguous, so request senders remain responsible for
+their own timeout and retry policy.
 
 ### Native HTTP execution and retries
 

--- a/README.md
+++ b/README.md
@@ -2952,6 +2952,12 @@ When set, the Flux Web Proxy will isolate this request in its own internal proce
 - Need different retry or error handling strategies per destination
 - Want fault isolation between outgoing endpoints
 
+The proxy executes outgoing HTTP calls asynchronously and admits at most four active logical requests per consumer by
+default. A logical request keeps its capacity slot throughout its retry attempts and retry delays. Once a consumer
+reaches its limit, its tracker stops fetching further requests until capacity becomes available; a slow consumer does
+not consume another consumer's slots. Set `FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS` to a positive integer to
+change this per-consumer limit. Higher values may increase outbound connection, memory, and destination load.
+
 ### Native HTTP execution and retries
 
 For calls that should leave the application directly instead of passing through the Fluxzero proxy, opt into the SDK's

--- a/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
@@ -48,23 +48,34 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getBooleanProperty;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
 import static io.fluxzero.sdk.web.WebRequest.getHeaders;
 import static java.time.temporal.ChronoUnit.NANOS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.Optional.ofNullable;
 
 @Slf4j
 public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     static final String METRICS_ENABLED_PROPERTY = "FLUXZERO_PROXY_METRICS_ENABLED";
+    static final String MAX_CONCURRENT_REQUESTS_PROPERTY = "FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS";
+    static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 4;
 
     private static final HttpClient sharedHttpClient = newHttpClient();
     protected static final WebRequestSettings defaultSettings = WebRequestSettings.builder().build();
@@ -83,22 +94,47 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     private final boolean publishMetrics;
     private final HttpClient httpClient;
     private final AtomicBoolean forceStopping;
+    private final AtomicBoolean stopping;
     private final Set<CompletableFuture<Void>> pendingResponses;
+    private final Set<ActiveRequest> activeRequests;
+    private final Object lifecycleMonitor;
+    private final Semaphore requestCapacity;
+    private final int maxConcurrentRequests;
+    private final Function<Duration, CompletableFuture<Void>> retryDelay;
 
     protected ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                                    boolean publishMetrics) {
-        this(client, consumerName, minIndex, mainConsumer, publishMetrics, sharedHttpClient, new AtomicBoolean());
+        this(client, consumerName, minIndex, mainConsumer, publishMetrics, sharedHttpClient, new AtomicBoolean(),
+             DEFAULT_MAX_CONCURRENT_REQUESTS);
     }
 
     ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                          boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping) {
         this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
-             ConcurrentHashMap.newKeySet());
+             DEFAULT_MAX_CONCURRENT_REQUESTS);
+    }
+
+    ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
+                         boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
+                         int maxConcurrentRequests) {
+        this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
+             maxConcurrentRequests, ForwardProxyConsumer::delay);
+    }
+
+    ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
+                         boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
+                         int maxConcurrentRequests, Function<Duration, CompletableFuture<Void>> retryDelay) {
+        this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
+             new AtomicBoolean(), ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet(), new Object(),
+             maxConcurrentRequests, retryDelay);
     }
 
     private ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                                  boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
-                                 Set<CompletableFuture<Void>> pendingResponses) {
+                                 AtomicBoolean stopping, Set<CompletableFuture<Void>> pendingResponses,
+                                 Set<ActiveRequest> activeRequests, Object lifecycleMonitor,
+                                 int maxConcurrentRequests,
+                                 Function<Duration, CompletableFuture<Void>> retryDelay) {
         this.client = client;
         this.consumerName = consumerName;
         this.minIndex = minIndex;
@@ -106,7 +142,13 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         this.publishMetrics = publishMetrics;
         this.httpClient = httpClient;
         this.forceStopping = forceStopping;
+        this.stopping = stopping;
         this.pendingResponses = pendingResponses;
+        this.activeRequests = activeRequests;
+        this.lifecycleMonitor = lifecycleMonitor;
+        this.maxConcurrentRequests = requirePositiveMaxConcurrentRequests(maxConcurrentRequests);
+        this.requestCapacity = new Semaphore(maxConcurrentRequests, true);
+        this.retryDelay = Objects.requireNonNull(retryDelay);
     }
 
     public static Registration start(Client client) {
@@ -118,7 +160,8 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         var consumer = new ForwardProxyConsumer(
                 client, defaultSettings.getConsumer(),
                 IndexUtils.indexFromTimestamp(Fluxzero.currentTime().minusSeconds(2)), true,
-                getBooleanProperty(METRICS_ENABLED_PROPERTY, true), httpClient, new AtomicBoolean());
+                getBooleanProperty(METRICS_ENABLED_PROPERTY, true), httpClient, new AtomicBoolean(),
+                configuredMaxConcurrentRequests());
         try {
             consumer.runningConsumers.computeIfAbsent(defaultSettings.getConsumer(), c -> consumer.start());
             return new Lifecycle(consumer);
@@ -133,35 +176,52 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 .followRedirects(HttpClient.Redirect.NORMAL).connectTimeout(Duration.ofSeconds(5)).build();
     }
 
+    static int configuredMaxConcurrentRequests() {
+        return requirePositiveMaxConcurrentRequests(getIntegerProperty(
+                MAX_CONCURRENT_REQUESTS_PROPERTY, DEFAULT_MAX_CONCURRENT_REQUESTS));
+    }
+
+    private static int requirePositiveMaxConcurrentRequests(int value) {
+        if (value < 1) {
+            throw new IllegalArgumentException(MAX_CONCURRENT_REQUESTS_PROPERTY + " must be >= 1");
+        }
+        return value;
+    }
+
     protected Registration start() {
         log.info(isMainConsumer() ? "Starting consumer {}" : "Starting consumer {} at {}", consumerName, minIndex);
-        return DefaultTracker.start(this, MessageType.WEBREQUEST,
-                                    ConsumerConfiguration.builder().name(consumerName).minIndex(minIndex).threads(4)
-                                            .build(), client);
+        return DefaultTracker.start(this, MessageType.WEBREQUEST, consumerConfiguration(), client);
+    }
+
+    ConsumerConfiguration consumerConfiguration() {
+        return ConsumerConfiguration.builder().name(consumerName).minIndex(minIndex)
+                .threads(maxConcurrentRequests).maxFetchSize(1).build();
     }
 
     @Override
     public void accept(List<SerializedMessage> serializedMessages) {
         Instant start = Instant.now();
+        List<CompletableFuture<Void>> activeBatch = new ArrayList<>(serializedMessages.size());
+        BatchProcessingException stoppingFailure = null;
         try {
             for (SerializedMessage s : serializedMessages) {
-                if (forceStopping.get()) {
-                    throw new BatchProcessingException(
-                            "Forward proxy stopped before the remaining request could start", s.getIndex());
+                if (stopping.get() || forceStopping.get()) {
+                    stoppingFailure = stoppedBeforeStart(s);
+                    break;
                 }
                 try {
                     var settings = getSettings(s);
                     if (consumerName.equals(settings.getConsumer())) {
                         URI uri = URI.create(WebRequest.getUrl(s.getMetadata()));
                         if (uri.isAbsolute()) {
-                            handle(s, uri, settings);
+                            activeBatch.add(startRequest(s, uri, settings));
                         }
                     } else if (isMainConsumer()) {
-                        runningConsumers.computeIfAbsent(
-                                settings.getConsumer(), c -> new ForwardProxyConsumer(
-                                        client, c, s.getIndex(), false, publishMetrics,
-                                        httpClient, forceStopping, pendingResponses).start());
+                        startConsumer(settings.getConsumer(), s);
                     }
+                } catch (BatchProcessingException e) {
+                    stoppingFailure = e;
+                    break;
                 } catch (Throwable e) {
                     log.error("Failed to handle external request {}. Continuing..", s.getMessageId(), e);
                     try {
@@ -172,32 +232,117 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                     }
                 }
             }
+            await(activeBatch);
+            if (stoppingFailure != null) {
+                throw stoppingFailure;
+            }
         } finally {
             publishProcessBatchMetrics(start);
         }
     }
 
+    private CompletableFuture<Void> startRequest(SerializedMessage request, URI uri, WebRequestSettings settings) {
+        try {
+            requestCapacity.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BatchProcessingException(
+                    "Forward proxy interrupted before the request could start", e, request.getIndex());
+        }
+        boolean releaseCapacity = true;
+        try {
+            synchronized (lifecycleMonitor) {
+                if (stopping.get() || forceStopping.get()) {
+                    throw stoppedBeforeStart(request);
+                }
+                ActiveRequest activeRequest = handleAsync(request, uri, settings);
+                activeRequests.add(activeRequest);
+                activeRequest.completion().whenComplete((ignored, error) -> {
+                    activeRequests.remove(activeRequest);
+                    requestCapacity.release();
+                });
+                releaseCapacity = false;
+                return activeRequest.completion();
+            }
+        } finally {
+            if (releaseCapacity) {
+                requestCapacity.release();
+            }
+        }
+    }
+
+    private void startConsumer(String name, SerializedMessage request) {
+        synchronized (lifecycleMonitor) {
+            if (stopping.get() || forceStopping.get()) {
+                throw stoppedBeforeStart(request);
+            }
+            runningConsumers.computeIfAbsent(
+                    name, c -> new ForwardProxyConsumer(
+                            client, c, request.getIndex(), false, publishMetrics, httpClient, forceStopping, stopping,
+                            pendingResponses, activeRequests, lifecycleMonitor, maxConcurrentRequests,
+                            retryDelay).start());
+        }
+    }
+
+    private BatchProcessingException stoppedBeforeStart(SerializedMessage request) {
+        return new BatchProcessingException(
+                "Forward proxy stopped before the remaining request could start", request.getIndex());
+    }
+
+    private void await(List<CompletableFuture<Void>> futures) {
+        if (!futures.isEmpty()) {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+        }
+    }
+
     protected void handle(SerializedMessage request, URI uri, WebRequestSettings settings) {
+        handleAsync(request, uri, settings).completion().join();
+    }
+
+    private ActiveRequest handleAsync(SerializedMessage request, URI uri, WebRequestSettings settings) {
         Instant start = Instant.now();
+        Map<String, String> correlationData = DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
+                client, request, MessageType.WEBREQUEST);
         Instant deadline = IndexUtils.timestampFromIndex(request.getIndex())
                 .plus(Optional.ofNullable(settings.getTimeout()).orElse(MAX_TIMEOUT));
+        CancellableResponseFuture execution = new CancellableResponseFuture();
         if (deadline.isBefore(start)) {
             //the deadline of this request is in the past. Skipping the request to prevent handling 'old' requests.
-            sendResponse(WebResponse.builder().status(504).payload("Timeout in forward proxy".getBytes())
-                            .build(), request);
-            return;
+            execution.complete(WebResponse.builder().status(504).payload("Timeout in forward proxy".getBytes())
+                                       .build());
+        } else if (settings.getMaxRetries() > 0) {
+            executeRequestWithRetries(request, uri, settings, deadline, execution)
+                    .whenComplete((response, error) -> complete(execution, response, error));
+        } else {
+            try {
+                executeRequestAsync(asHttpRequest(request, uri, settings), execution)
+                        .whenComplete((response, error) -> complete(execution, response, error));
+            } catch (Throwable e) {
+                execution.complete(asWebResponse(e));
+            }
         }
-        WebResponse webResponse;
-        try {
-            webResponse = settings.getMaxRetries() > 0
-                    ? executeRequestWithRetries(request, uri, settings, deadline)
-                    : executeRequest(asHttpRequest(request, uri, settings));
-        } catch (Throwable e) {
-            publishHandleMessageMetrics(request, true, start);
-            throw e;
-        }
-        publishHandleMessageMetrics(request, false, start);
-        sendResponse(webResponse, request);
+        CompletableFuture<Void> completion = execution.handle((response, error) -> {
+            WebResponse result = response;
+            if (error != null) {
+                Throwable failure = unwrap(error);
+                log.error("Failed to handle external request. Returning error.. ", failure);
+                result = asWebResponse(failure);
+            }
+            publishHandleMessageMetrics(request, false, start, correlationData);
+            sendResponse(result, request, correlationData);
+            return (Void) null;
+        }).exceptionally(error -> {
+            Throwable failure = unwrap(error);
+            log.error("Failed to handle external request {}. Continuing..", request.getMessageId(), failure);
+            try {
+                sendResponse(asWebResponse(failure), request, correlationData);
+            } catch (Throwable responseError) {
+                responseError.addSuppressed(failure);
+                log.error("Failed to send error response. Continuing..", responseError);
+            }
+            return null;
+        });
+        return new ActiveRequest(execution, completion);
     }
 
     protected HttpRequest asHttpRequest(SerializedMessage request, URI uri, WebRequestSettings settings) {
@@ -215,75 +360,135 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     protected WebResponse executeRequest(HttpRequest httpRequest) {
+        CancellableResponseFuture requestFuture = new CancellableResponseFuture();
+        executeRequestAsync(httpRequest, requestFuture)
+                .whenComplete((response, error) -> complete(requestFuture, response, error));
+        return requestFuture.join();
+    }
+
+    private CompletableFuture<WebResponse> executeRequestAsync(HttpRequest httpRequest,
+                                                               CancellableResponseFuture requestFuture) {
+        CompletableFuture<HttpResponse<byte[]>> attempt;
         try {
-            var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
-            return asWebResponse(response);
+            attempt = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
         } catch (Throwable e) {
             log.error("Failed to handle external request. Returning error.. ", e);
-            return asWebResponse(e);
+            return CompletableFuture.completedFuture(asWebResponse(e));
         }
-    }
-
-    private WebResponse executeRequestWithRetries(SerializedMessage request, URI uri, WebRequestSettings settings,
-                                                  Instant deadline) {
-        int retriesRemaining = Math.max(0, settings.getMaxRetries());
-        while (true) {
-            Duration remaining = Duration.between(Instant.now(), deadline);
-            if (remaining.isNegative() || remaining.isZero()) {
-                return asWebResponse(new java.net.http.HttpTimeoutException("Timeout in forward proxy"));
-            }
-            try {
-                HttpRequest httpRequest = asHttpRequest(
-                        request, uri, settings.toBuilder().timeout(remaining).build());
-                HttpResponse<byte[]> response = httpClient.send(
-                        httpRequest, HttpResponse.BodyHandlers.ofByteArray());
-                if (retriesRemaining > 0 && settings.getRetryableStatusCodes().contains(response.statusCode())
-                        && awaitRetryDelay(settings, deadline)) {
-                    retriesRemaining--;
-                    continue;
-                }
+        requestFuture.track(attempt);
+        return attempt.handle((response, error) -> {
+            if (error == null) {
                 return asWebResponse(response);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.error("Interrupted while handling external request. Returning error.. ", e);
-                return asWebResponse(e);
-            } catch (IOException e) {
-                if (retriesRemaining > 0) {
-                    try {
-                        if (awaitRetryDelay(settings, deadline)) {
-                            retriesRemaining--;
-                            continue;
-                        }
-                    } catch (InterruptedException interrupted) {
-                        Thread.currentThread().interrupt();
-                        log.error("Interrupted before retrying external request. Returning error.. ", interrupted);
-                        return asWebResponse(interrupted);
-                    }
-                }
-                log.error("Failed to handle external request after retries. Returning error.. ", e);
-                return asWebResponse(e);
-            } catch (Throwable e) {
-                log.error("Failed to handle external request. Returning error.. ", e);
-                return asWebResponse(e);
             }
-        }
+            Throwable failure = unwrap(error);
+            log.error("Failed to handle external request. Returning error.. ", failure);
+            return asWebResponse(failure);
+        });
     }
 
-    private boolean awaitRetryDelay(WebRequestSettings settings, Instant deadline) throws InterruptedException {
-        Duration delay = settings.getRetryDelay().isNegative() ? Duration.ZERO : settings.getRetryDelay();
+    private CompletableFuture<WebResponse> executeRequestWithRetries(
+            SerializedMessage request, URI uri, WebRequestSettings settings, Instant deadline,
+            CancellableResponseFuture requestFuture) {
+        return executeRequestWithRetries(
+                request, uri, settings, Math.max(0, settings.getMaxRetries()), deadline, requestFuture);
+    }
+
+    private CompletableFuture<WebResponse> executeRequestWithRetries(
+            SerializedMessage request, URI uri, WebRequestSettings settings, int retriesRemaining, Instant deadline,
+            CancellableResponseFuture requestFuture) {
+        if (requestFuture.isCancelled()) {
+            return CompletableFuture.failedFuture(new CancellationException());
+        }
+        Duration remaining = Duration.between(Instant.now(), deadline);
+        if (remaining.isNegative() || remaining.isZero()) {
+            return CompletableFuture.completedFuture(
+                    asWebResponse(new java.net.http.HttpTimeoutException("Timeout in forward proxy")));
+        }
+
+        HttpRequest httpRequest;
+        try {
+            httpRequest = asHttpRequest(request, uri, settings.toBuilder().timeout(remaining).build());
+        } catch (Throwable e) {
+            return CompletableFuture.completedFuture(asWebResponse(e));
+        }
+
+        CompletableFuture<HttpResponse<byte[]>> attempt;
+        try {
+            attempt = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+        } catch (Throwable e) {
+            return CompletableFuture.completedFuture(asWebResponse(e));
+        }
+        requestFuture.track(attempt);
+        return attempt.handle((response, error) -> {
+            if (error == null) {
+                WebResponse mappedResponse = asWebResponse(response);
+                if (retriesRemaining > 0 && settings.getRetryableStatusCodes().contains(response.statusCode())) {
+                    return retry(request, uri, settings, retriesRemaining, deadline, mappedResponse, requestFuture);
+                }
+                return CompletableFuture.completedFuture(mappedResponse);
+            }
+            Throwable failure = unwrap(error);
+            WebResponse mappedFailure = asWebResponse(failure);
+            if (retriesRemaining > 0 && failure instanceof IOException && Instant.now().isBefore(deadline)) {
+                return retry(request, uri, settings, retriesRemaining, deadline, mappedFailure, requestFuture);
+            }
+            log.error("Failed to handle external request after retries. Returning error.. ", failure);
+            return CompletableFuture.completedFuture(mappedFailure);
+        }).thenCompose(Function.identity());
+    }
+
+    private CompletableFuture<WebResponse> retry(
+            SerializedMessage request, URI uri, WebRequestSettings settings, int retriesRemaining, Instant deadline,
+            WebResponse exhaustedResult, CancellableResponseFuture requestFuture) {
+        Duration delay = normalizedRetryDelay(settings);
         Duration remaining = Duration.between(Instant.now(), deadline);
         if (remaining.isNegative() || remaining.isZero() || delay.compareTo(remaining) >= 0) {
-            return false;
+            return CompletableFuture.completedFuture(exhaustedResult);
         }
-        if (!delay.isZero()) {
-            Thread.sleep(delay);
+        CompletableFuture<Void> delayFuture = retryDelay.apply(delay);
+        requestFuture.track(delayFuture);
+        return delayFuture.thenCompose(ignored -> Instant.now().isBefore(deadline)
+                ? executeRequestWithRetries(
+                        request, uri, settings, retriesRemaining - 1, deadline, requestFuture)
+                : CompletableFuture.completedFuture(exhaustedResult));
+    }
+
+    private Duration normalizedRetryDelay(WebRequestSettings settings) {
+        Duration delay = settings.getRetryDelay();
+        return delay.isNegative() ? Duration.ZERO : delay;
+    }
+
+    private static CompletableFuture<Void> delay(Duration duration) {
+        if (duration.isZero()) {
+            return CompletableFuture.completedFuture(null);
         }
-        return Instant.now().isBefore(deadline);
+        return CompletableFuture.runAsync(
+                () -> {}, CompletableFuture.delayedExecutor(duration.toNanos(), NANOSECONDS));
+    }
+
+    private static void complete(CancellableResponseFuture target, WebResponse response, Throwable error) {
+        if (error == null) {
+            target.complete(response);
+        } else {
+            target.completeExceptionally(error);
+        }
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        Throwable result = error;
+        while (result instanceof CompletionException && result.getCause() != null) {
+            result = result.getCause();
+        }
+        return result;
     }
 
     protected void sendResponse(WebResponse response, SerializedMessage request) {
-        Metadata responseMetadata = response.getMetadata().addIfAbsent(
-                DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(client, request, MessageType.WEBREQUEST));
+        sendResponse(response, request, DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
+                client, request, MessageType.WEBREQUEST));
+    }
+
+    private void sendResponse(WebResponse response, SerializedMessage request, Map<String, String> correlationData) {
+        Metadata responseMetadata = response.getMetadata().addIfAbsent(correlationData);
         SerializedMessage serializedResponse = new SerializedMessage(
                 serializer.serialize(response.getPayload()).withFormat("application/octet-stream"),
                 responseMetadata, response.getMessageId(), response.getTimestamp().toEpochMilli());
@@ -308,6 +513,34 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         }
     }
 
+    void awaitActiveRequests() {
+        while (!activeRequests.isEmpty()) {
+            CompletableFuture<?>[] snapshot = activeRequests.stream()
+                    .map(ActiveRequest::completion).toArray(CompletableFuture[]::new);
+            if (snapshot.length > 0) {
+                CompletableFuture.allOf(snapshot).join();
+            }
+        }
+    }
+
+    private void stopAccepting() {
+        synchronized (lifecycleMonitor) {
+            stopping.set(true);
+        }
+    }
+
+    void forceActiveRequests() {
+        List<ActiveRequest> snapshot;
+        synchronized (lifecycleMonitor) {
+            stopping.set(true);
+            forceStopping.set(true);
+            snapshot = List.copyOf(activeRequests);
+        }
+        snapshot.forEach(request -> request.execution().cancel(true));
+        httpClient.shutdownNow();
+        pendingResponses.forEach(response -> response.cancel(false));
+    }
+
     protected WebResponse asWebResponse(HttpResponse<byte[]> response) {
         WebResponse.Builder builder = WebResponse.builder();
         response.headers().map().forEach((name, values) -> values.forEach(v -> builder.header(name, v)));
@@ -329,12 +562,18 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     protected void publishHandleMessageMetrics(SerializedMessage request, boolean exceptionalResult, Instant start) {
+        publishHandleMessageMetrics(request, exceptionalResult, start,
+                                    DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
+                                            client, request, MessageType.WEBREQUEST));
+    }
+
+    private void publishHandleMessageMetrics(SerializedMessage request, boolean exceptionalResult, Instant start,
+                                             Map<String, String> correlationData) {
         if (!publishMetrics) {
             return;
         }
         try {
-            var metadata = Metadata.of(DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
-                    client, request, MessageType.WEBREQUEST));
+            var metadata = Metadata.of(correlationData);
             var metricsMessage = new Message(new HandleMessageEvent(
                     consumerName, ForwardProxyConsumer.class.getSimpleName(),
                     request.getIndex(), MessageType.WEBREQUEST, null, formatType(request), exceptionalResult,
@@ -375,6 +614,32 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         }
     }
 
+    private record ActiveRequest(CancellableResponseFuture execution, CompletableFuture<Void> completion) {
+    }
+
+    private static final class CancellableResponseFuture extends CompletableFuture<WebResponse> {
+        private final AtomicReference<CompletableFuture<?>> activeOperation = new AtomicReference<>();
+
+        private void track(CompletableFuture<?> operation) {
+            activeOperation.set(operation);
+            if (isCancelled()) {
+                operation.cancel(true);
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (!super.cancel(mayInterruptIfRunning)) {
+                return false;
+            }
+            CompletableFuture<?> operation = activeOperation.get();
+            if (operation != null) {
+                operation.cancel(mayInterruptIfRunning);
+            }
+            return true;
+        }
+    }
+
     static final class Lifecycle implements Registration {
         private final ForwardProxyConsumer consumer;
         private final AtomicBoolean cancelled = new AtomicBoolean();
@@ -386,12 +651,14 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         @Override
         public void cancel() {
             if (cancelled.compareAndSet(false, true)) {
+                consumer.stopAccepting();
                 try {
                     while (!consumer.runningConsumers.isEmpty()) {
                         var snapshot = List.copyOf(consumer.runningConsumers.entrySet());
                         snapshot.forEach(entry -> entry.getValue().cancel());
                         snapshot.forEach(entry -> consumer.runningConsumers.remove(entry.getKey(), entry.getValue()));
                     }
+                    consumer.awaitActiveRequests();
                     consumer.awaitPendingResponses();
                 } finally {
                     consumer.httpClient.close();
@@ -400,9 +667,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         }
 
         void force() {
-            consumer.forceStopping.set(true);
-            consumer.httpClient.shutdownNow();
-            consumer.pendingResponses.forEach(response -> response.cancel(false));
+            consumer.forceActiveRequests();
         }
     }
 }

--- a/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
@@ -15,6 +15,7 @@
 
 package io.fluxzero.proxy;
 
+import io.fluxzero.common.ConsistentHashing;
 import io.fluxzero.common.Guarantee;
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.Registration;
@@ -49,6 +50,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,7 +60,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -66,6 +67,7 @@ import java.util.function.Function;
 
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getBooleanProperty;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getLongProperty;
 import static io.fluxzero.sdk.web.WebRequest.getHeaders;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -75,7 +77,12 @@ import static java.util.Optional.ofNullable;
 public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     static final String METRICS_ENABLED_PROPERTY = "FLUXZERO_PROXY_METRICS_ENABLED";
     static final String MAX_CONCURRENT_REQUESTS_PROPERTY = "FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS";
-    static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 4;
+    static final String MAX_OUTSTANDING_REQUESTS_PROPERTY = "FLUXZERO_PROXY_FORWARD_MAX_OUTSTANDING_REQUESTS";
+    static final String BATCH_COMPLETION_GRACE_MILLIS_PROPERTY =
+            "FLUXZERO_PROXY_FORWARD_BATCH_COMPLETION_GRACE_MILLIS";
+    static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 8;
+    static final int DEFAULT_MAX_OUTSTANDING_REQUESTS = 1024;
+    static final Duration DEFAULT_BATCH_COMPLETION_GRACE = Duration.ofMillis(250);
 
     private static final HttpClient sharedHttpClient = newHttpClient();
     protected static final WebRequestSettings defaultSettings = WebRequestSettings.builder().build();
@@ -96,45 +103,58 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     private final AtomicBoolean forceStopping;
     private final AtomicBoolean stopping;
     private final Set<CompletableFuture<Void>> pendingResponses;
-    private final Set<ActiveRequest> activeRequests;
+    private final Set<ScheduledRequest> outstandingRequests;
     private final Object lifecycleMonitor;
-    private final Semaphore requestCapacity;
     private final int maxConcurrentRequests;
+    private final int maxOutstandingRequests;
+    private final Duration batchCompletionGrace;
     private final Function<Duration, CompletableFuture<Void>> retryDelay;
+    private final SegmentSerialScheduler<ScheduledRequest> scheduler;
 
     protected ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                                    boolean publishMetrics) {
         this(client, consumerName, minIndex, mainConsumer, publishMetrics, sharedHttpClient, new AtomicBoolean(),
-             DEFAULT_MAX_CONCURRENT_REQUESTS);
+             DEFAULT_MAX_CONCURRENT_REQUESTS, DEFAULT_MAX_OUTSTANDING_REQUESTS, DEFAULT_BATCH_COMPLETION_GRACE);
     }
 
     ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                          boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping) {
         this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
-             DEFAULT_MAX_CONCURRENT_REQUESTS);
+             DEFAULT_MAX_CONCURRENT_REQUESTS, DEFAULT_MAX_OUTSTANDING_REQUESTS, DEFAULT_BATCH_COMPLETION_GRACE);
     }
 
     ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                          boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
                          int maxConcurrentRequests) {
         this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
-             maxConcurrentRequests, ForwardProxyConsumer::delay);
+             maxConcurrentRequests, DEFAULT_MAX_OUTSTANDING_REQUESTS, DEFAULT_BATCH_COMPLETION_GRACE);
     }
 
     ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                          boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
                          int maxConcurrentRequests, Function<Duration, CompletableFuture<Void>> retryDelay) {
         this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
-             new AtomicBoolean(), ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet(), new Object(),
-             maxConcurrentRequests, retryDelay);
+             new AtomicBoolean(), ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet(),
+             new Object(), maxConcurrentRequests, DEFAULT_MAX_OUTSTANDING_REQUESTS,
+             DEFAULT_BATCH_COMPLETION_GRACE, retryDelay, null);
+    }
+
+    ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
+                         boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
+                         int maxConcurrentRequests, int maxOutstandingRequests, Duration batchCompletionGrace) {
+        this(client, consumerName, minIndex, mainConsumer, publishMetrics, httpClient, forceStopping,
+             new AtomicBoolean(), ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet(),
+             new Object(), maxConcurrentRequests, maxOutstandingRequests,
+             batchCompletionGrace, ForwardProxyConsumer::delay, null);
     }
 
     private ForwardProxyConsumer(Client client, String consumerName, Long minIndex, boolean mainConsumer,
                                  boolean publishMetrics, HttpClient httpClient, AtomicBoolean forceStopping,
                                  AtomicBoolean stopping, Set<CompletableFuture<Void>> pendingResponses,
-                                 Set<ActiveRequest> activeRequests, Object lifecycleMonitor,
-                                 int maxConcurrentRequests,
-                                 Function<Duration, CompletableFuture<Void>> retryDelay) {
+                                 Set<ScheduledRequest> outstandingRequests, Object lifecycleMonitor,
+                                 int maxConcurrentRequests, int maxOutstandingRequests, Duration batchCompletionGrace,
+                                 Function<Duration, CompletableFuture<Void>> retryDelay,
+                                 SegmentSerialScheduler<ScheduledRequest> scheduler) {
         this.client = client;
         this.consumerName = consumerName;
         this.minIndex = minIndex;
@@ -144,11 +164,15 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         this.forceStopping = forceStopping;
         this.stopping = stopping;
         this.pendingResponses = pendingResponses;
-        this.activeRequests = activeRequests;
+        this.outstandingRequests = outstandingRequests;
         this.lifecycleMonitor = lifecycleMonitor;
         this.maxConcurrentRequests = requirePositiveMaxConcurrentRequests(maxConcurrentRequests);
-        this.requestCapacity = new Semaphore(maxConcurrentRequests, true);
+        this.maxOutstandingRequests = requireValidMaxOutstandingRequests(
+                maxOutstandingRequests, this.maxConcurrentRequests);
+        this.batchCompletionGrace = requireNonNegativeBatchCompletionGrace(batchCompletionGrace);
         this.retryDelay = Objects.requireNonNull(retryDelay);
+        this.scheduler = scheduler == null
+                ? new SegmentSerialScheduler<>(this.maxConcurrentRequests, this.maxOutstandingRequests) : scheduler;
     }
 
     public static Registration start(Client client) {
@@ -157,11 +181,13 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
 
     static Lifecycle startManaged(Client client) {
         HttpClient httpClient = newHttpClient();
+        int maxConcurrentRequests = configuredMaxConcurrentRequests();
         var consumer = new ForwardProxyConsumer(
                 client, defaultSettings.getConsumer(),
                 IndexUtils.indexFromTimestamp(Fluxzero.currentTime().minusSeconds(2)), true,
                 getBooleanProperty(METRICS_ENABLED_PROPERTY, true), httpClient, new AtomicBoolean(),
-                configuredMaxConcurrentRequests());
+                maxConcurrentRequests, configuredMaxOutstandingRequests(maxConcurrentRequests),
+                configuredBatchCompletionGrace());
         try {
             consumer.runningConsumers.computeIfAbsent(defaultSettings.getConsumer(), c -> consumer.start());
             return new Lifecycle(consumer);
@@ -181,9 +207,40 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 MAX_CONCURRENT_REQUESTS_PROPERTY, DEFAULT_MAX_CONCURRENT_REQUESTS));
     }
 
+    static int configuredMaxOutstandingRequests() {
+        return configuredMaxOutstandingRequests(configuredMaxConcurrentRequests());
+    }
+
+    private static int configuredMaxOutstandingRequests(int maxConcurrentRequests) {
+        return requireValidMaxOutstandingRequests(
+                getIntegerProperty(MAX_OUTSTANDING_REQUESTS_PROPERTY, DEFAULT_MAX_OUTSTANDING_REQUESTS),
+                maxConcurrentRequests);
+    }
+
+    static Duration configuredBatchCompletionGrace() {
+        return requireNonNegativeBatchCompletionGrace(Duration.ofMillis(getLongProperty(
+                BATCH_COMPLETION_GRACE_MILLIS_PROPERTY, DEFAULT_BATCH_COMPLETION_GRACE.toMillis())));
+    }
+
     private static int requirePositiveMaxConcurrentRequests(int value) {
         if (value < 1) {
             throw new IllegalArgumentException(MAX_CONCURRENT_REQUESTS_PROPERTY + " must be >= 1");
+        }
+        return value;
+    }
+
+    private static int requireValidMaxOutstandingRequests(int value, int maxConcurrentRequests) {
+        if (value < maxConcurrentRequests) {
+            throw new IllegalArgumentException(
+                    MAX_OUTSTANDING_REQUESTS_PROPERTY + " must be >= " + MAX_CONCURRENT_REQUESTS_PROPERTY);
+        }
+        return value;
+    }
+
+    private static Duration requireNonNegativeBatchCompletionGrace(Duration value) {
+        Objects.requireNonNull(value);
+        if (value.isNegative()) {
+            throw new IllegalArgumentException(BATCH_COMPLETION_GRACE_MILLIS_PROPERTY + " must be >= 0");
         }
         return value;
     }
@@ -194,8 +251,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     ConsumerConfiguration consumerConfiguration() {
-        return ConsumerConfiguration.builder().name(consumerName).minIndex(minIndex)
-                .threads(maxConcurrentRequests).maxFetchSize(1).build();
+        return ConsumerConfiguration.builder().name(consumerName).minIndex(minIndex).threads(1).build();
     }
 
     @Override
@@ -214,7 +270,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                     if (consumerName.equals(settings.getConsumer())) {
                         URI uri = URI.create(WebRequest.getUrl(s.getMetadata()));
                         if (uri.isAbsolute()) {
-                            activeBatch.add(startRequest(s, uri, settings));
+                            activeBatch.add(scheduleRequest(s, uri, settings));
                         }
                     } else if (isMainConsumer()) {
                         startConsumer(settings.getConsumer(), s);
@@ -225,14 +281,17 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 } catch (Throwable e) {
                     log.error("Failed to handle external request {}. Continuing..", s.getMessageId(), e);
                     try {
-                        sendResponse(asWebResponse(e), s);
+                        activeBatch.add(scheduleFailedRequest(s, e));
+                    } catch (BatchProcessingException stoppingException) {
+                        stoppingFailure = stoppingException;
+                        break;
                     } catch (Throwable e2) {
                         e2.addSuppressed(e);
                         log.error("Failed to send error response. Continuing..", e2);
                     }
                 }
             }
-            await(activeBatch);
+            awaitBestEffort(activeBatch);
             if (stoppingFailure != null) {
                 throw stoppingFailure;
             }
@@ -241,34 +300,34 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         }
     }
 
-    private CompletableFuture<Void> startRequest(SerializedMessage request, URI uri, WebRequestSettings settings) {
+    private CompletableFuture<Void> scheduleRequest(SerializedMessage request, URI uri, WebRequestSettings settings) {
+        return scheduleRequest(new ScheduledRequest(request, uri, settings));
+    }
+
+    private CompletableFuture<Void> scheduleFailedRequest(SerializedMessage request, Throwable failure) {
+        return scheduleRequest(new ScheduledRequest(request, failure));
+    }
+
+    private CompletableFuture<Void> scheduleRequest(ScheduledRequest scheduledRequest) {
+        SerializedMessage request = scheduledRequest.request();
+        synchronized (lifecycleMonitor) {
+            if (stopping.get() || forceStopping.get()) {
+                throw stoppedBeforeStart(request);
+            }
+        }
         try {
-            requestCapacity.acquire();
+            if (!scheduler.schedule(scheduledRequest)) {
+                BatchProcessingException failure = stoppedBeforeStart(request);
+                scheduledRequest.fail(failure);
+                throw failure;
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            scheduledRequest.fail(e);
             throw new BatchProcessingException(
                     "Forward proxy interrupted before the request could start", e, request.getIndex());
         }
-        boolean releaseCapacity = true;
-        try {
-            synchronized (lifecycleMonitor) {
-                if (stopping.get() || forceStopping.get()) {
-                    throw stoppedBeforeStart(request);
-                }
-                ActiveRequest activeRequest = handleAsync(request, uri, settings);
-                activeRequests.add(activeRequest);
-                activeRequest.completion().whenComplete((ignored, error) -> {
-                    activeRequests.remove(activeRequest);
-                    requestCapacity.release();
-                });
-                releaseCapacity = false;
-                return activeRequest.completion();
-            }
-        } finally {
-            if (releaseCapacity) {
-                requestCapacity.release();
-            }
-        }
+        return scheduledRequest.completion();
     }
 
     private void startConsumer(String name, SerializedMessage request) {
@@ -279,8 +338,9 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             runningConsumers.computeIfAbsent(
                     name, c -> new ForwardProxyConsumer(
                             client, c, request.getIndex(), false, publishMetrics, httpClient, forceStopping, stopping,
-                            pendingResponses, activeRequests, lifecycleMonitor, maxConcurrentRequests,
-                            retryDelay).start());
+                            pendingResponses, outstandingRequests, lifecycleMonitor,
+                            maxConcurrentRequests, maxOutstandingRequests, batchCompletionGrace, retryDelay,
+                            scheduler).start());
         }
     }
 
@@ -289,17 +349,19 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 "Forward proxy stopped before the remaining request could start", request.getIndex());
     }
 
-    private void await(List<CompletableFuture<Void>> futures) {
+    private void awaitBestEffort(List<CompletableFuture<Void>> futures) {
         if (!futures.isEmpty()) {
-            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).handle((ignored, error) -> null)
+                    .completeOnTimeout(null, batchCompletionGrace.toNanos(), NANOSECONDS).join();
         }
     }
 
     protected void handle(SerializedMessage request, URI uri, WebRequestSettings settings) {
-        handleAsync(request, uri, settings).completion().join();
+        handleAsync(request, uri, settings, null).completion().join();
     }
 
-    private ActiveRequest handleAsync(SerializedMessage request, URI uri, WebRequestSettings settings) {
+    private ActiveRequest handleAsync(SerializedMessage request, URI uri, WebRequestSettings settings,
+                                      ScheduledRequest scheduledRequest) {
         Instant start = Instant.now();
         Map<String, String> correlationData = DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
                 client, request, MessageType.WEBREQUEST);
@@ -325,20 +387,22 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             WebResponse result = response;
             if (error != null) {
                 Throwable failure = unwrap(error);
-                log.error("Failed to handle external request. Returning error.. ", failure);
+                if (scheduledRequest == null || !scheduledRequest.isRequeuing()) {
+                    log.error("Failed to handle external request. Returning error.. ", failure);
+                }
                 result = asWebResponse(failure);
             }
+            return result;
+        }).thenCompose(result -> {
+            if (scheduledRequest != null && !scheduledRequest.beginResponsePublication()) {
+                return CompletableFuture.completedFuture(null);
+            }
             publishHandleMessageMetrics(request, false, start, correlationData);
-            sendResponse(result, request, correlationData);
-            return (Void) null;
-        }).exceptionally(error -> {
-            Throwable failure = unwrap(error);
-            log.error("Failed to handle external request {}. Continuing..", request.getMessageId(), failure);
-            try {
-                sendResponse(asWebResponse(failure), request, correlationData);
-            } catch (Throwable responseError) {
-                responseError.addSuppressed(failure);
-                log.error("Failed to send error response. Continuing..", responseError);
+            return sendResponseAsync(result, request, correlationData);
+        }).handle((ignored, error) -> {
+            if (error != null && !forceStopping.get()) {
+                log.error("Failed to publish response for external request {}. Continuing..",
+                          request.getMessageId(), unwrap(error));
             }
             return null;
         });
@@ -381,7 +445,9 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 return asWebResponse(response);
             }
             Throwable failure = unwrap(error);
-            log.error("Failed to handle external request. Returning error.. ", failure);
+            if (!(failure instanceof CancellationException && requestFuture.isCancelled())) {
+                log.error("Failed to handle external request. Returning error.. ", failure);
+            }
             return asWebResponse(failure);
         });
     }
@@ -432,7 +498,9 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             if (retriesRemaining > 0 && failure instanceof IOException && Instant.now().isBefore(deadline)) {
                 return retry(request, uri, settings, retriesRemaining, deadline, mappedFailure, requestFuture);
             }
-            log.error("Failed to handle external request after retries. Returning error.. ", failure);
+            if (!(failure instanceof CancellationException && requestFuture.isCancelled())) {
+                log.error("Failed to handle external request after retries. Returning error.. ", failure);
+            }
             return CompletableFuture.completedFuture(mappedFailure);
         }).thenCompose(Function.identity());
     }
@@ -483,11 +551,12 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     protected void sendResponse(WebResponse response, SerializedMessage request) {
-        sendResponse(response, request, DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
+        sendResponseAsync(response, request, DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
                 client, request, MessageType.WEBREQUEST));
     }
 
-    private void sendResponse(WebResponse response, SerializedMessage request, Map<String, String> correlationData) {
+    private CompletableFuture<Void> sendResponseAsync(WebResponse response, SerializedMessage request,
+                                                      Map<String, String> correlationData) {
         Metadata responseMetadata = response.getMetadata().addIfAbsent(correlationData);
         SerializedMessage serializedResponse = new SerializedMessage(
                 serializer.serialize(response.getPayload()).withFormat("application/octet-stream"),
@@ -504,6 +573,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
                 log.warn("Failed to store forwarded response for request {}", request.getRequestId(), error);
             }
         });
+        return publication;
     }
 
     void awaitPendingResponses() {
@@ -514,9 +584,9 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     void awaitActiveRequests() {
-        while (!activeRequests.isEmpty()) {
-            CompletableFuture<?>[] snapshot = activeRequests.stream()
-                    .map(ActiveRequest::completion).toArray(CompletableFuture[]::new);
+        while (!outstandingRequests.isEmpty()) {
+            CompletableFuture<?>[] snapshot = outstandingRequests.stream()
+                    .map(ScheduledRequest::completion).toArray(CompletableFuture[]::new);
             if (snapshot.length > 0) {
                 CompletableFuture.allOf(snapshot).join();
             }
@@ -530,15 +600,41 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     void forceActiveRequests() {
-        List<ActiveRequest> snapshot;
+        List<ScheduledRequest> requeued;
         synchronized (lifecycleMonitor) {
             stopping.set(true);
             forceStopping.set(true);
-            snapshot = List.copyOf(activeRequests);
+            scheduler.stopDispatching();
+            requeued = outstandingRequests.stream().filter(ScheduledRequest::beginRequeue)
+                    .sorted(Comparator.comparingLong(r -> ofNullable(r.request().getIndex()).orElse(Long.MAX_VALUE)))
+                    .toList();
         }
-        snapshot.forEach(request -> request.execution().cancel(true));
+        requeued.forEach(ScheduledRequest::cancelExecution);
+        if (!requeued.isEmpty()) {
+            SerializedMessage[] requests = requeued.stream().map(ScheduledRequest::copyForRequeue)
+                    .toArray(SerializedMessage[]::new);
+            CompletableFuture<Void> handoff;
+            try {
+                handoff = client.getGatewayClient(MessageType.WEBREQUEST).append(Guarantee.STORED, requests);
+            } catch (Throwable e) {
+                requeued.forEach(request -> request.fail(e));
+                log.error("Failed to return {} unfinished forward requests to the WebRequest log", requeued.size(), e);
+                httpClient.shutdownNow();
+                return;
+            }
+            pendingResponses.add(handoff);
+            handoff.whenComplete((ignored, error) -> {
+                pendingResponses.remove(handoff);
+                if (error == null) {
+                    requeued.forEach(ScheduledRequest::completeRequeue);
+                } else {
+                    requeued.forEach(request -> request.fail(error));
+                    log.error("Failed to return {} unfinished forward requests to the WebRequest log",
+                              requeued.size(), error);
+                }
+            });
+        }
         httpClient.shutdownNow();
-        pendingResponses.forEach(response -> response.cancel(false));
     }
 
     protected WebResponse asWebResponse(HttpResponse<byte[]> response) {
@@ -612,6 +708,159 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         } catch (Throwable e) {
             log.error("Failed to publish HandleMessage metrics", e);
         }
+    }
+
+    private final class ScheduledRequest implements SegmentSerialScheduler.Task {
+        private final SerializedMessage request;
+        private final URI uri;
+        private final WebRequestSettings settings;
+        private final Throwable initialFailure;
+        private final int segment;
+        private final AtomicReference<RequestState> state = new AtomicReference<>(RequestState.QUEUED);
+        private final AtomicReference<CancellableResponseFuture> execution = new AtomicReference<>();
+        private final CompletableFuture<Void> completion = new CompletableFuture<>();
+
+        private ScheduledRequest(SerializedMessage request, URI uri, WebRequestSettings settings) {
+            this.request = request;
+            this.uri = uri;
+            this.settings = settings;
+            this.initialFailure = null;
+            this.segment = requestSegment(request);
+        }
+
+        private ScheduledRequest(SerializedMessage request, Throwable initialFailure) {
+            this.request = request;
+            this.uri = null;
+            this.settings = null;
+            this.initialFailure = initialFailure;
+            this.segment = requestSegment(request);
+        }
+
+        private int requestSegment(SerializedMessage request) {
+            return ofNullable(request.getSegment()).orElseGet(() -> ConsistentHashing.computeSegment(
+                    Objects.toString(request.getMessageId(), Objects.toString(request.getIndex(), "unsegmented"))));
+        }
+
+        @Override
+        public int segment() {
+            return segment;
+        }
+
+        @Override
+        public CompletableFuture<Void> completion() {
+            return completion;
+        }
+
+        @Override
+        public void admitted() {
+            outstandingRequests.add(this);
+            completion.whenComplete((ignored, error) -> outstandingRequests.remove(this));
+        }
+
+        @Override
+        public void start() {
+            if (initialFailure != null) {
+                publishInitialFailure();
+                return;
+            }
+            if (!state.compareAndSet(RequestState.QUEUED, RequestState.HTTP_ACTIVE)) {
+                return;
+            }
+            ActiveRequest activeRequest = handleAsync(request, uri, settings, this);
+            execution.set(activeRequest.execution());
+            if (state.get() == RequestState.REQUEUING) {
+                activeRequest.execution().cancel(true);
+            }
+            activeRequest.completion().whenComplete((ignored, error) -> finishNormally(error));
+        }
+
+        private void publishInitialFailure() {
+            if (!state.compareAndSet(RequestState.QUEUED, RequestState.RESPONSE_PUBLISHING)) {
+                return;
+            }
+            CompletableFuture<Void> publication;
+            try {
+                publication = sendResponseAsync(
+                        asWebResponse(initialFailure), request,
+                        DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
+                                client, request, MessageType.WEBREQUEST));
+            } catch (Throwable e) {
+                publication = CompletableFuture.failedFuture(e);
+            }
+            publication.handle((ignored, error) -> {
+                        if (error != null && !forceStopping.get()) {
+                            log.error("Failed to publish error response for external request {}. Continuing..",
+                                      request.getMessageId(), unwrap(error));
+                        }
+                        return null;
+                    })
+                    .whenComplete((ignored, error) -> finishNormally(error));
+        }
+
+        @Override
+        public void fail(Throwable error) {
+            RequestState previous = state.getAndSet(RequestState.DONE);
+            if (previous != RequestState.DONE && previous != RequestState.REQUEUED) {
+                if (!forceStopping.get()) {
+                    log.error("Failed to schedule forward request {}", request.getMessageId(), unwrap(error));
+                }
+                completion.complete(null);
+            }
+        }
+
+        private boolean beginResponsePublication() {
+            return state.compareAndSet(RequestState.HTTP_ACTIVE, RequestState.RESPONSE_PUBLISHING);
+        }
+
+        private void finishNormally(Throwable error) {
+            if (state.compareAndSet(RequestState.RESPONSE_PUBLISHING, RequestState.DONE)) {
+                if (error != null && !forceStopping.get()) {
+                    log.error("Failed to complete forward request {}", request.getMessageId(), unwrap(error));
+                }
+                completion.complete(null);
+            }
+        }
+
+        private boolean beginRequeue() {
+            while (true) {
+                RequestState current = state.get();
+                if (current != RequestState.QUEUED && current != RequestState.HTTP_ACTIVE) {
+                    return false;
+                }
+                if (state.compareAndSet(current, RequestState.REQUEUING)) {
+                    return true;
+                }
+            }
+        }
+
+        private boolean isRequeuing() {
+            return state.get() == RequestState.REQUEUING;
+        }
+
+        private void cancelExecution() {
+            ofNullable(execution.get()).ifPresent(active -> active.cancel(true));
+        }
+
+        private void completeRequeue() {
+            if (state.compareAndSet(RequestState.REQUEUING, RequestState.REQUEUED)) {
+                completion.complete(null);
+            }
+        }
+
+        private SerializedMessage copyForRequeue() {
+            return new SerializedMessage(
+                    request.getData(), request.getMetadata(), request.getSegment(), null, request.getSource(),
+                    request.getTarget(), request.getRequestId(), request.getTimestamp(), request.getMessageId(),
+                    request.getOriginalRevision());
+        }
+
+        private SerializedMessage request() {
+            return request;
+        }
+    }
+
+    private enum RequestState {
+        QUEUED, HTTP_ACTIVE, RESPONSE_PUBLISHING, REQUEUING, REQUEUED, DONE
     }
 
     private record ActiveRequest(CancellableResponseFuture execution, CompletableFuture<Void> completion) {

--- a/proxy/src/main/java/io/fluxzero/proxy/ProxyServer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ProxyServer.java
@@ -579,12 +579,12 @@ public class ProxyServer implements Registration {
                 log.warn("Failed to stop Fluxzero proxy server", e);
             } finally {
                 try {
-                    proxyHandler.close(gracefulShutdown);
-                } catch (RuntimeException e) {
-                    log.warn("Failed to close Fluxzero proxy request handling", e);
+                    awaitBackendShutdown(backendShutdown, deadline);
                 } finally {
                     try {
-                        awaitBackendShutdown(backendShutdown, deadline);
+                        proxyHandler.close(gracefulShutdown);
+                    } catch (RuntimeException e) {
+                        log.warn("Failed to close Fluxzero proxy request handling", e);
                     } finally {
                         try {
                             ownedClientShutdown.cancel();

--- a/proxy/src/main/java/io/fluxzero/proxy/SegmentSerialScheduler.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/SegmentSerialScheduler.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.proxy;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Bounded work-conserving scheduler that runs at most one task per exact message segment.
+ */
+final class SegmentSerialScheduler<T extends SegmentSerialScheduler.Task> {
+
+    interface Task {
+        int segment();
+
+        CompletableFuture<Void> completion();
+
+        void admitted();
+
+        void start();
+
+        void fail(Throwable error);
+    }
+
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition capacityAvailable = lock.newCondition();
+    private final int maxConcurrent;
+    private final int maxOutstanding;
+    private final Map<Integer, ArrayDeque<T>> segmentQueues = new HashMap<>();
+    private final ArrayDeque<Integer> readySegments = new ArrayDeque<>();
+    private final Set<Integer> readySegmentSet = new HashSet<>();
+    private final Map<Integer, T> activeTasks = new HashMap<>();
+    private final ConcurrentLinkedQueue<T> starts = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger startDrain = new AtomicInteger();
+
+    private int outstandingCount;
+    private boolean dispatching = true;
+
+    SegmentSerialScheduler(int maxConcurrent, int maxOutstanding) {
+        if (maxConcurrent < 1) {
+            throw new IllegalArgumentException("maxConcurrent must be >= 1");
+        }
+        if (maxOutstanding < maxConcurrent) {
+            throw new IllegalArgumentException("maxOutstanding must be >= maxConcurrent");
+        }
+        this.maxConcurrent = maxConcurrent;
+        this.maxOutstanding = maxOutstanding;
+    }
+
+    boolean schedule(T task) throws InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            while (dispatching && outstandingCount >= maxOutstanding) {
+                capacityAvailable.await();
+            }
+            if (!dispatching) {
+                return false;
+            }
+            outstandingCount++;
+            segmentQueues.computeIfAbsent(task.segment(), ignored -> new ArrayDeque<>()).addLast(task);
+            task.admitted();
+            markReady(task.segment());
+            task.completion().whenComplete((ignored, error) -> completed(task));
+            collectStarts();
+        } finally {
+            lock.unlock();
+        }
+        drainStarts();
+        return true;
+    }
+
+    void stopDispatching() {
+        lock.lock();
+        try {
+            dispatching = false;
+            readySegments.clear();
+            readySegmentSet.clear();
+            starts.clear();
+            capacityAvailable.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void completed(T task) {
+        lock.lock();
+        try {
+            ArrayDeque<T> queue = segmentQueues.get(task.segment());
+            if (queue == null || !queue.remove(task)) {
+                return;
+            }
+            activeTasks.remove(task.segment(), task);
+            outstandingCount--;
+            capacityAvailable.signal();
+            if (queue.isEmpty()) {
+                segmentQueues.remove(task.segment());
+                readySegmentSet.remove(task.segment());
+                readySegments.remove(task.segment());
+            } else {
+                markReady(task.segment());
+            }
+            collectStarts();
+        } finally {
+            lock.unlock();
+        }
+        drainStarts();
+    }
+
+    private void markReady(int segment) {
+        if (dispatching && !activeTasks.containsKey(segment) && readySegmentSet.add(segment)) {
+            readySegments.addLast(segment);
+        }
+    }
+
+    private void collectStarts() {
+        while (dispatching && activeTasks.size() < maxConcurrent && !readySegments.isEmpty()) {
+            int segment = readySegments.removeFirst();
+            readySegmentSet.remove(segment);
+            ArrayDeque<T> queue = segmentQueues.get(segment);
+            if (queue == null || queue.isEmpty() || activeTasks.containsKey(segment)) {
+                continue;
+            }
+            T task = queue.getFirst();
+            activeTasks.put(segment, task);
+            starts.add(task);
+        }
+    }
+
+    private void drainStarts() {
+        if (startDrain.getAndIncrement() != 0) {
+            return;
+        }
+        int missed = 1;
+        do {
+            T task;
+            while ((task = starts.poll()) != null) {
+                try {
+                    task.start();
+                } catch (Throwable e) {
+                    task.fail(e);
+                }
+            }
+            missed = startDrain.addAndGet(-missed);
+        } while (missed != 0);
+    }
+}

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
@@ -49,14 +49,17 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.fluxzero.common.Guarantee.STORED;
 import static io.fluxzero.sdk.web.HttpRequestMethod.GET;
@@ -349,6 +352,243 @@ class ForwardProxyConsumerTest {
     }
 
     @Test
+    void serializesExactSegmentAcrossBatchesWithoutBlockingOtherSegments() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        List<String> started = new ArrayList<>();
+        List<CompletableFuture<HttpResponse<byte[]>>> attempts = List.of(
+                new CompletableFuture<>(), new CompletableFuture<>(), new CompletableFuture<>());
+        AtomicInteger attempt = new AtomicInteger();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenAnswer(invocation -> {
+            synchronized (started) {
+                started.add(invocation.<HttpRequest>getArgument(0).uri().getPath());
+            }
+            return attempts.get(attempt.getAndIncrement());
+        });
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                2, 8, Duration.ZERO);
+        SerializedMessage first = serializedRequest("first", CONSUMER_NAME);
+        first.setSegment(17);
+        SerializedMessage sameSegment = serializedRequest("same-segment", CONSUMER_NAME);
+        sameSegment.setSegment(17);
+        SerializedMessage otherSegment = serializedRequest("other-segment", CONSUMER_NAME);
+        otherSegment.setSegment(23);
+
+        consumer.accept(List.of(first));
+        consumer.accept(List.of(sameSegment, otherSegment));
+
+        verify(httpClient, timeout(1_000).times(2))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        synchronized (started) {
+            assertEquals(List.of("/first", "/other-segment"), started);
+        }
+        attempts.get(1).complete(response);
+        verify(httpClient, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        attempts.getFirst().complete(response);
+        verify(httpClient, timeout(1_000).times(3))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        synchronized (started) {
+            assertEquals(List.of("/first", "/other-segment", "/same-segment"), started);
+        }
+        attempts.get(2).complete(response);
+        consumer.awaitActiveRequests();
+    }
+
+    @Test
+    void softBatchCompletionKeepsLateRequestInGlobalCapacity() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<HttpResponse<byte[]>> slow = new CompletableFuture<>();
+        CompletableFuture<HttpResponse<byte[]>> next = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(slow, next);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 4, Duration.ZERO);
+        SerializedMessage first = serializedRequest("slow", CONSUMER_NAME);
+        first.setSegment(1);
+        SerializedMessage second = serializedRequest("next", CONSUMER_NAME);
+        second.setSegment(2);
+
+        consumer.accept(List.of(first));
+        CompletableFuture<Void> nextBatch = runAsync(() -> consumer.accept(List.of(second)));
+
+        verify(httpClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        nextBatch.get(1, TimeUnit.SECONDS);
+        verify(httpClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        slow.complete(response);
+        verify(httpClient, timeout(1_000).times(2))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        next.complete(response);
+        consumer.awaitActiveRequests();
+    }
+
+    @Test
+    void outstandingLimitAppliesBackpressureAcrossBatches() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<HttpResponse<byte[]>> firstAttempt = new CompletableFuture<>();
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(firstAttempt, CompletableFuture.completedFuture(response),
+                            CompletableFuture.completedFuture(response));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 2, Duration.ZERO);
+        SerializedMessage first = serializedRequest("first", CONSUMER_NAME);
+        first.setSegment(1);
+        SerializedMessage queued = serializedRequest("queued", CONSUMER_NAME);
+        queued.setSegment(1);
+        SerializedMessage blocked = serializedRequest("blocked", CONSUMER_NAME);
+        blocked.setSegment(2);
+
+        consumer.accept(List.of(first, queued));
+        CompletableFuture<Void> blockedBatch = runAsync(() -> consumer.accept(List.of(blocked)));
+
+        verify(httpClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertFalse(blockedBatch.isDone(), "The outstanding limit should stop the tracker from checkpointing");
+        firstAttempt.complete(response);
+        blockedBatch.get(1, TimeUnit.SECONDS);
+        consumer.awaitActiveRequests();
+        verify(httpClient, times(3)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
+    void malformedRequestResponseRemainsInsideOutstandingBound() throws Exception {
+        Client client = mockForwardingClient();
+        GatewayClient responseGateway = client.getGatewayClient(MessageType.WEBRESPONSE);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<Void> storedError = new CompletableFuture<>();
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(storedError, CompletableFuture.completedFuture(null));
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 1, Duration.ZERO);
+        SerializedMessage malformed = serializedRequest("malformed", CONSUMER_NAME);
+        malformed.setMetadata(Metadata.of("settings", WebRequestSettings.builder()
+                .consumer(CONSUMER_NAME).timeout(Duration.ofSeconds(5)).build()));
+        SerializedMessage next = serializedRequest("next", CONSUMER_NAME);
+
+        consumer.accept(List.of(malformed));
+        CompletableFuture<Void> nextBatch = runAsync(() -> consumer.accept(List.of(next)));
+
+        assertFalse(nextBatch.isDone());
+        verifyNoInteractions(httpClient);
+        storedError.complete(null);
+        nextBatch.get(1, TimeUnit.SECONDS);
+        verify(httpClient).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        consumer.awaitActiveRequests();
+    }
+
+    @Test
+    void hardStopRequeuesUnfinishedRequestsInOriginalSegmentOrder() throws Exception {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        GatewayClient requestGateway = mock(GatewayClient.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<HttpResponse<byte[]>> activeAttempt = new CompletableFuture<>();
+        CompletableFuture<Void> handoff = new CompletableFuture<>();
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(client.getGatewayClient(MessageType.WEBREQUEST)).thenReturn(requestGateway);
+        when(requestGateway.append(eq(STORED), any(SerializedMessage[].class))).thenReturn(handoff);
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(activeAttempt);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                2, 8, Duration.ZERO);
+        SerializedMessage first = serializedRequest("first", CONSUMER_NAME);
+        first.setSegment(41);
+        SerializedMessage second = serializedRequest("second", CONSUMER_NAME);
+        second.setSegment(41);
+        second.setIndex(first.getIndex() + 1);
+
+        consumer.accept(List.of(first, second));
+        consumer.forceActiveRequests();
+
+        ArgumentCaptor<SerializedMessage[]> requeued = ArgumentCaptor.forClass(SerializedMessage[].class);
+        verify(requestGateway).append(eq(STORED), requeued.capture());
+        assertEquals(List.of(first.getMessageId(), second.getMessageId()),
+                     List.of(requeued.getValue()[0].getMessageId(), requeued.getValue()[1].getMessageId()));
+        for (SerializedMessage request : requeued.getValue()) {
+            assertEquals(41, request.getSegment());
+            assertEquals(null, request.getIndex());
+            assertEquals("requester", request.getSource());
+        }
+        assertTrue(activeAttempt.isCancelled());
+        verifyNoInteractions(responseGateway);
+        handoff.complete(null);
+        consumer.awaitActiveRequests();
+        verify(httpClient).shutdownNow();
+    }
+
+    @Test
+    void hardStopDoesNotRequeueARequestWhoseResponseIsBeingStored() throws Exception {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        GatewayClient requestGateway = mock(GatewayClient.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<Void> storedResponse = new CompletableFuture<>();
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(client.getGatewayClient(MessageType.WEBREQUEST)).thenReturn(requestGateway);
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class))).thenReturn(storedResponse);
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 4, Duration.ZERO);
+
+        consumer.accept(List.of(serializedRequest("publishing", CONSUMER_NAME)));
+        verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
+        consumer.forceActiveRequests();
+
+        verifyNoInteractions(requestGateway);
+        assertFalse(storedResponse.isCancelled());
+        storedResponse.complete(null);
+        consumer.awaitActiveRequests();
+    }
+
+    @Test
+    void hardStopRejectsCapacityBlockedAdmissionForTrackerRedelivery() throws Exception {
+        Client client = mockForwardingClient();
+        GatewayClient requestGateway = client.getGatewayClient(MessageType.WEBREQUEST);
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<HttpResponse<byte[]>> activeAttempt = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(activeAttempt);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 1, Duration.ZERO);
+        SerializedMessage admitted = serializedRequest("admitted", CONSUMER_NAME);
+        admitted.setSegment(7);
+        SerializedMessage capacityBlocked = serializedRequest("capacity-blocked", CONSUMER_NAME);
+        capacityBlocked.setSegment(8);
+
+        consumer.accept(List.of(admitted));
+        CompletableFuture<Void> blockedBatch = runAsync(() -> consumer.accept(List.of(capacityBlocked)));
+        assertFalse(blockedBatch.isDone());
+        consumer.forceActiveRequests();
+
+        CompletionException error = assertThrows(CompletionException.class, blockedBatch::join);
+        assertTrue(error.getCause() instanceof BatchProcessingException);
+        ArgumentCaptor<SerializedMessage[]> requeued = ArgumentCaptor.forClass(SerializedMessage[].class);
+        verify(requestGateway).append(eq(STORED), requeued.capture());
+        assertEquals(List.of(admitted.getMessageId()),
+                     List.of(requeued.getValue()[0].getMessageId()));
+        consumer.awaitActiveRequests();
+    }
+
+    @Test
     void consumersHaveIndependentConcurrentRequestCapacity() throws Exception {
         Client client = mockForwardingClient();
         HttpClient httpClient = mock(HttpClient.class);
@@ -377,7 +617,7 @@ class ForwardProxyConsumerTest {
     }
 
     @Test
-    void retryDelayRetainsCapacityWithoutBlockingAnotherHttpCall() throws Exception {
+    void retryDelayRetainsLogicalRequestCapacityUntilNextAttempt() throws Exception {
         Client client = mockForwardingClient();
         HttpClient httpClient = mock(HttpClient.class);
         HttpResponse<byte[]> response = httpResponse(200, "ok");
@@ -435,43 +675,73 @@ class ForwardProxyConsumerTest {
     }
 
     @Test
-    void trackerFetchMatchesPerConsumerCapacity() {
+    void trackerUsesOneDefaultSizedBatchIndependentlyOfHttpCapacity() {
         ForwardProxyConsumer consumer = new ForwardProxyConsumer(
                 testFixture.getFluxzero().client(), CONSUMER_NAME, 0L, false, false,
                 mock(HttpClient.class), new AtomicBoolean(), 3);
 
         ConsumerConfiguration configuration = consumer.consumerConfiguration();
 
-        assertEquals(3, configuration.getThreads());
-        assertEquals(1, configuration.getMaxFetchSize());
+        assertEquals(1, configuration.getThreads());
+        assertEquals(1024, configuration.getMaxFetchSize());
     }
 
     @Test
     @ResourceLock(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY)
-    void validatesConfiguredConcurrentRequestCapacity() {
-        String previous = System.getProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY);
+    @ResourceLock(ForwardProxyConsumer.MAX_OUTSTANDING_REQUESTS_PROPERTY)
+    @ResourceLock(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY)
+    void validatesConfiguredForwardRequestCapacityAndBatchGrace() {
+        String previousConcurrent = System.getProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY);
+        String previousOutstanding = System.getProperty(ForwardProxyConsumer.MAX_OUTSTANDING_REQUESTS_PROPERTY);
+        String previousGrace = System.getProperty(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY);
         try {
             System.clearProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY);
+            System.clearProperty(ForwardProxyConsumer.MAX_OUTSTANDING_REQUESTS_PROPERTY);
+            System.clearProperty(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY);
             assertEquals(ForwardProxyConsumer.DEFAULT_MAX_CONCURRENT_REQUESTS,
                          ForwardProxyConsumer.configuredMaxConcurrentRequests());
+            assertEquals(ForwardProxyConsumer.DEFAULT_MAX_OUTSTANDING_REQUESTS,
+                         ForwardProxyConsumer.configuredMaxOutstandingRequests());
+            assertEquals(ForwardProxyConsumer.DEFAULT_BATCH_COMPLETION_GRACE,
+                         ForwardProxyConsumer.configuredBatchCompletionGrace());
             System.setProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, "7");
+            System.setProperty(ForwardProxyConsumer.MAX_OUTSTANDING_REQUESTS_PROPERTY, "9");
+            System.setProperty(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY, "11");
             assertEquals(7, ForwardProxyConsumer.configuredMaxConcurrentRequests());
+            assertEquals(9, ForwardProxyConsumer.configuredMaxOutstandingRequests());
+            assertEquals(Duration.ofMillis(11), ForwardProxyConsumer.configuredBatchCompletionGrace());
             System.setProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, "0");
             IllegalArgumentException error = assertThrows(
                     IllegalArgumentException.class, ForwardProxyConsumer::configuredMaxConcurrentRequests);
             assertTrue(error.getMessage().contains("must be >= 1"));
+
+            System.setProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, "10");
+            error = assertThrows(IllegalArgumentException.class,
+                                 ForwardProxyConsumer::configuredMaxOutstandingRequests);
+            assertTrue(error.getMessage().contains(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY));
+
+            System.setProperty(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY, "-1");
+            error = assertThrows(IllegalArgumentException.class,
+                                 ForwardProxyConsumer::configuredBatchCompletionGrace);
+            assertTrue(error.getMessage().contains("must be >= 0"));
         } finally {
-            restoreProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, previous);
+            restoreProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, previousConcurrent);
+            restoreProperty(ForwardProxyConsumer.MAX_OUTSTANDING_REQUESTS_PROPERTY, previousOutstanding);
+            restoreProperty(ForwardProxyConsumer.BATCH_COMPLETION_GRACE_MILLIS_PROPERTY, previousGrace);
         }
     }
 
     private static Client mockForwardingClient() {
         Client client = mock(Client.class);
         GatewayClient responseGateway = mock(GatewayClient.class);
+        GatewayClient requestGateway = mock(GatewayClient.class);
         when(client.id()).thenReturn("client");
         when(client.name()).thenReturn("proxy");
         when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(client.getGatewayClient(MessageType.WEBREQUEST)).thenReturn(requestGateway);
         when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(requestGateway.append(eq(STORED), any(SerializedMessage[].class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
         return client;
     }

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
@@ -27,6 +27,7 @@ import io.fluxzero.sdk.configuration.client.Client;
 import io.fluxzero.sdk.publishing.client.GatewayClient;
 import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.tracking.BatchProcessingException;
+import io.fluxzero.sdk.tracking.ConsumerConfiguration;
 import io.fluxzero.sdk.tracking.IndexUtils;
 import io.fluxzero.sdk.web.WebRequest;
 import io.fluxzero.sdk.web.WebRequestSettings;
@@ -36,6 +37,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,10 +64,12 @@ import static io.fluxzero.sdk.web.HttpRequestMethod.POST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -189,7 +194,10 @@ class ForwardProxyConsumerTest {
         assertFalse(drain.isDone(), "Shutdown should await runtime storage without blocking normal response handling");
         stored.complete(null);
         drain.get(1, TimeUnit.SECONDS);
-        verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
+        ArgumentCaptor<SerializedMessage> response = ArgumentCaptor.forClass(SerializedMessage.class);
+        verify(responseGateway).append(eq(STORED), response.capture());
+        assertEquals(42, response.getValue().getRequestId());
+        assertEquals("requester", response.getValue().getTarget());
     }
 
     @Test
@@ -222,10 +230,10 @@ class ForwardProxyConsumerTest {
         when(httpResponse.statusCode()).thenReturn(200);
         when(httpResponse.body()).thenReturn("ok".getBytes());
         when(httpResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
-        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
-                .thenThrow(new IOException("first"))
-                .thenThrow(new IOException("second"))
-                .thenReturn(httpResponse);
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.failedFuture(new IOException("first")))
+                .thenReturn(CompletableFuture.failedFuture(new IOException("second")))
+                .thenReturn(CompletableFuture.completedFuture(httpResponse));
         ForwardProxyConsumer consumer = new ForwardProxyConsumer(
                 client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
         WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
@@ -241,7 +249,7 @@ class ForwardProxyConsumerTest {
         consumer.handle(serializedRequest, URI.create(request.getPath()), deserializedSettings);
 
         assertEquals(2, deserializedSettings.getMaxRetries());
-        verify(httpClient, times(3)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        verify(httpClient, times(3)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
         verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
     }
 
@@ -263,8 +271,9 @@ class ForwardProxyConsumerTest {
         when(successResponse.statusCode()).thenReturn(200);
         when(successResponse.body()).thenReturn("ok".getBytes());
         when(successResponse.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
-        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
-                .thenReturn(retryResponse, successResponse);
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(retryResponse),
+                            CompletableFuture.completedFuture(successResponse));
         ForwardProxyConsumer consumer = new ForwardProxyConsumer(
                 client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean());
         WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
@@ -282,7 +291,7 @@ class ForwardProxyConsumerTest {
 
         assertEquals(Set.of(429), deserializedSettings.getRetryableStatusCodes());
         assertEquals(Duration.ofMillis(1), deserializedSettings.getRetryDelay());
-        verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        verify(httpClient, times(2)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
         verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
     }
 
@@ -309,5 +318,205 @@ class ForwardProxyConsumerTest {
 
         verify(responseGateway).append(eq(STORED), any(SerializedMessage.class));
         verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void boundsConcurrentRequestsAndResumesWhenCapacityBecomesAvailable() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<HttpResponse<byte[]>> first = new CompletableFuture<>();
+        CompletableFuture<HttpResponse<byte[]>> second = new CompletableFuture<>();
+        CompletableFuture<HttpResponse<byte[]>> third = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(first, second, third);
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(), 2);
+
+        CompletableFuture<Void> batch = runAsync(() -> consumer.accept(List.of(
+                serializedRequest("one", CONSUMER_NAME), serializedRequest("two", CONSUMER_NAME),
+                serializedRequest("three", CONSUMER_NAME))));
+
+        verify(httpClient, timeout(1_000).times(2))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertFalse(batch.isDone());
+        first.complete(response);
+        verify(httpClient, timeout(1_000).times(3))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        second.complete(response);
+        third.complete(response);
+        batch.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void consumersHaveIndependentConcurrentRequestCapacity() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<HttpResponse<byte[]>> first = new CompletableFuture<>();
+        CompletableFuture<HttpResponse<byte[]>> second = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(first, second);
+        ForwardProxyConsumer firstConsumer = new ForwardProxyConsumer(
+                client, "first-consumer", 0L, false, false, httpClient, new AtomicBoolean(), 1);
+        ForwardProxyConsumer secondConsumer = new ForwardProxyConsumer(
+                client, "second-consumer", 0L, false, false, httpClient, new AtomicBoolean(), 1);
+
+        CompletableFuture<Void> firstBatch = runAsync(
+                () -> firstConsumer.accept(List.of(serializedRequest("one", "first-consumer"))));
+        CompletableFuture<Void> secondBatch = runAsync(
+                () -> secondConsumer.accept(List.of(serializedRequest("two", "second-consumer"))));
+
+        verify(httpClient, timeout(1_000).times(2))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertFalse(firstBatch.isDone());
+        assertFalse(secondBatch.isDone());
+        first.complete(response);
+        second.complete(response);
+        CompletableFuture.allOf(firstBatch, secondBatch).get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void retryDelayRetainsCapacityWithoutBlockingAnotherHttpCall() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<Void> retryDelay = new CompletableFuture<>();
+        CompletableFuture<Duration> observedDelay = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.failedFuture(new IOException("retry")))
+                .thenReturn(CompletableFuture.completedFuture(response))
+                .thenReturn(CompletableFuture.completedFuture(response));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(), 1, delay -> {
+            observedDelay.complete(delay);
+            return retryDelay;
+        });
+        WebRequestSettings retrySettings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
+                .timeout(Duration.ofSeconds(5)).maxRetries(1).retryDelay(Duration.ofMillis(250)).build();
+
+        CompletableFuture<Void> batch = runAsync(() -> consumer.accept(List.of(
+                serializedRequest("retrying", retrySettings), serializedRequest("waiting", CONSUMER_NAME))));
+
+        assertEquals(Duration.ofMillis(250), observedDelay.get(1, TimeUnit.SECONDS));
+        verify(httpClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        assertFalse(batch.isDone());
+        retryDelay.complete(null);
+        verify(httpClient, timeout(1_000).times(3))
+                .sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        batch.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void forcedStopCancelsPendingRetryDelayAndDoesNotStartAnotherAttempt() throws Exception {
+        Client client = mockForwardingClient();
+        HttpClient httpClient = mock(HttpClient.class);
+        CompletableFuture<Void> retryDelay = new CompletableFuture<>();
+        CompletableFuture<Duration> observedDelay = new CompletableFuture<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.failedFuture(new IOException("retry")));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(), 1, delay -> {
+            observedDelay.complete(delay);
+            return retryDelay;
+        });
+        WebRequestSettings settings = WebRequestSettings.builder().consumer(CONSUMER_NAME)
+                .timeout(Duration.ofSeconds(5)).maxRetries(1).retryDelay(Duration.ofSeconds(1)).build();
+        CompletableFuture<Void> batch = runAsync(
+                () -> consumer.accept(List.of(serializedRequest("retrying", settings))));
+        assertEquals(Duration.ofSeconds(1), observedDelay.get(1, TimeUnit.SECONDS));
+
+        consumer.forceActiveRequests();
+
+        batch.get(1, TimeUnit.SECONDS);
+        assertTrue(retryDelay.isCancelled());
+        verify(httpClient, times(1)).sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+        verify(httpClient).shutdownNow();
+    }
+
+    @Test
+    void trackerFetchMatchesPerConsumerCapacity() {
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                testFixture.getFluxzero().client(), CONSUMER_NAME, 0L, false, false,
+                mock(HttpClient.class), new AtomicBoolean(), 3);
+
+        ConsumerConfiguration configuration = consumer.consumerConfiguration();
+
+        assertEquals(3, configuration.getThreads());
+        assertEquals(1, configuration.getMaxFetchSize());
+    }
+
+    @Test
+    @ResourceLock(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY)
+    void validatesConfiguredConcurrentRequestCapacity() {
+        String previous = System.getProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY);
+        try {
+            System.clearProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY);
+            assertEquals(ForwardProxyConsumer.DEFAULT_MAX_CONCURRENT_REQUESTS,
+                         ForwardProxyConsumer.configuredMaxConcurrentRequests());
+            System.setProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, "7");
+            assertEquals(7, ForwardProxyConsumer.configuredMaxConcurrentRequests());
+            System.setProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, "0");
+            IllegalArgumentException error = assertThrows(
+                    IllegalArgumentException.class, ForwardProxyConsumer::configuredMaxConcurrentRequests);
+            assertTrue(error.getMessage().contains("must be >= 1"));
+        } finally {
+            restoreProperty(ForwardProxyConsumer.MAX_CONCURRENT_REQUESTS_PROPERTY, previous);
+        }
+    }
+
+    private static Client mockForwardingClient() {
+        Client client = mock(Client.class);
+        GatewayClient responseGateway = mock(GatewayClient.class);
+        when(client.id()).thenReturn("client");
+        when(client.name()).thenReturn("proxy");
+        when(client.getGatewayClient(MessageType.WEBRESPONSE)).thenReturn(responseGateway);
+        when(responseGateway.append(eq(STORED), any(SerializedMessage.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        return client;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<byte[]> httpResponse(int status, String body) {
+        HttpResponse<byte[]> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.body()).thenReturn(body.getBytes());
+        when(response.headers()).thenReturn(HttpHeaders.of(Map.of(), (name, value) -> true));
+        return response;
+    }
+
+    private static SerializedMessage serializedRequest(String id, String consumer) {
+        return serializedRequest(id, WebRequestSettings.builder().consumer(consumer)
+                .timeout(Duration.ofSeconds(5)).build());
+    }
+
+    private static SerializedMessage serializedRequest(String id, WebRequestSettings settings) {
+        SerializedMessage request = WebRequest.get("https://example.com/" + id)
+                .metadata(Metadata.of("settings", settings)).build().serialize(ForwardProxyConsumer.serializer);
+        request.setIndex(IndexUtils.indexForCurrentTime());
+        request.setRequestId(id.hashCode());
+        request.setSource("requester");
+        return request;
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    private static CompletableFuture<Void> runAsync(Runnable task) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Thread.ofVirtual().start(() -> {
+            try {
+                task.run();
+                result.complete(null);
+            } catch (Throwable e) {
+                result.completeExceptionally(e);
+            }
+        });
+        return result;
     }
 }

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxySchedulerBenchmark.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxySchedulerBenchmark.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Fluxzero IP or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.proxy;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Small allocation and throughput benchmark for the forward-proxy scheduler without network latency.
+ *
+ * <p>Example:</p>
+ * <pre>{@code
+ * ./mvnw -pl proxy -am -DskipTests install
+ * ./mvnw -pl proxy -DskipTests \
+ *   org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
+ *   -Dexec.classpathScope=test \
+ *   -Dexec.mainClass=io.fluxzero.proxy.ForwardProxySchedulerBenchmark \
+ *   -Drequests=500000 -Drepeats=5
+ * }</pre>
+ */
+public final class ForwardProxySchedulerBenchmark {
+    private static final int MAX_CONCURRENT = 8;
+    private static final int MAX_OUTSTANDING = 1024;
+    private static final int SEGMENTS = 128;
+
+    public static void main(String[] args) throws Exception {
+        int requests = Integer.getInteger("requests", 500_000);
+        int warmup = Integer.getInteger("warmup", 50_000);
+        int repeats = Integer.getInteger("repeats", 5);
+        run(warmup, false);
+        run(warmup, true);
+        long[] baseline = new long[repeats];
+        long[] scheduled = new long[repeats];
+        for (int i = 0; i < repeats; i++) {
+            baseline[i] = run(requests, false);
+            scheduled[i] = run(requests, true);
+        }
+        Arrays.sort(baseline);
+        Arrays.sort(scheduled);
+        long baselineNanos = baseline[repeats / 2];
+        long scheduledNanos = scheduled[repeats / 2];
+        System.out.printf("Forward scheduler benchmark: requests=%d, concurrent=%d, outstanding=%d, segments=%d%n",
+                          requests, MAX_CONCURRENT, MAX_OUTSTANDING, SEGMENTS);
+        System.out.printf("bounded concurrency: %,.0f requests/s%n", throughput(requests, baselineNanos));
+        System.out.printf("segment scheduler: %,.0f requests/s, overhead=%+.1f%%%n",
+                          throughput(requests, scheduledNanos),
+                          100.0 * (scheduledNanos - baselineNanos) / baselineNanos);
+    }
+
+    private static long run(int requests, boolean scheduled) throws Exception {
+        ExecutorService completions = Executors.newFixedThreadPool(MAX_CONCURRENT);
+        CompletableFuture<Void> allDone = new CompletableFuture<>();
+        AtomicInteger remaining = new AtomicInteger(requests);
+        SegmentSerialScheduler<BenchmarkTask> scheduler = scheduled
+                ? new SegmentSerialScheduler<>(MAX_CONCURRENT, MAX_OUTSTANDING) : null;
+        Semaphore concurrentCapacity = scheduled ? null : new Semaphore(MAX_CONCURRENT);
+        long start = System.nanoTime();
+        try {
+            for (int i = 0; i < requests; i++) {
+                BenchmarkTask task = new BenchmarkTask(i % SEGMENTS, completions, remaining, allDone);
+                if (scheduler == null) {
+                    concurrentCapacity.acquire();
+                    task.completion().whenComplete((ignored, error) -> concurrentCapacity.release());
+                    task.start();
+                } else if (!scheduler.schedule(task)) {
+                    throw new IllegalStateException("Scheduler stopped during benchmark");
+                }
+            }
+            allDone.get(30, TimeUnit.SECONDS);
+            return System.nanoTime() - start;
+        } finally {
+            completions.shutdownNow();
+        }
+    }
+
+    private static double throughput(int requests, long nanos) {
+        return requests / (nanos / (double) Duration.ofSeconds(1).toNanos());
+    }
+
+    private record BenchmarkTask(int segment, ExecutorService executor, AtomicInteger remaining,
+                                 CompletableFuture<Void> allDone, CompletableFuture<Void> completion)
+            implements SegmentSerialScheduler.Task {
+        private BenchmarkTask(int segment, ExecutorService executor, AtomicInteger remaining,
+                              CompletableFuture<Void> allDone) {
+            this(segment, executor, remaining, allDone, new CompletableFuture<>());
+        }
+
+        @Override
+        public void admitted() {
+        }
+
+        @Override
+        public void start() {
+            executor.execute(() -> {
+                completion.complete(null);
+                if (remaining.decrementAndGet() == 0) {
+                    allDone.complete(null);
+                }
+            });
+        }
+
+        @Override
+        public void fail(Throwable error) {
+            allDone.completeExceptionally(error);
+        }
+    }
+}

--- a/proxy/src/test/java/io/fluxzero/proxy/ProxyServerLifecycleTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ProxyServerLifecycleTest.java
@@ -305,7 +305,7 @@ class ProxyServerLifecycleTest {
 
     @Test
     @Timeout(20)
-    void shutdownForcesPermanentlyBlockedForwardRequestAfterDeadline() throws Exception {
+    void shutdownRequeuesPermanentlyBlockedForwardRequestAfterDeadline() throws Exception {
         CountDownLatch requestReceived = new CountDownLatch(1);
         CountDownLatch neverReleaseDuringShutdown = new CountDownLatch(1);
         ExecutorService targetExecutor = Executors.newCachedThreadPool();
@@ -317,14 +317,17 @@ class ProxyServerLifecycleTest {
                 neverReleaseDuringShutdown.await();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-            } finally {
-                exchange.close();
             }
+            byte[] response = "retried".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
         });
         target.start();
 
         Server runtime = null;
         ProxyServer proxyServer = null;
+        ProxyServer restartedProxy = null;
         Fluxzero requester = null;
         String previousFluxzeroProxyPort = System.getProperty("FLUXZERO_PROXY_PORT");
         String previousFluxzeroBaseUrl = System.getProperty("FLUXZERO_BASE_URL");
@@ -351,7 +354,13 @@ class ProxyServerLifecycleTest {
 
             assertTrue(Duration.ofNanos(System.nanoTime() - start).compareTo(Duration.ofSeconds(2)) < 0,
                        "Forced proxy shutdown exceeded its hard-stop allowance");
-            assertEquals(502, response.get(2, TimeUnit.SECONDS).getStatus());
+            assertFalse(response.isDone(), "Hard stop should hand off the request instead of publishing a local 502");
+            neverReleaseDuringShutdown.countDown();
+            restartedProxy = ProxyServer.start();
+            assertEventuallyReady(restartedProxy,
+                                  "http://localhost:" + restartedProxy.getPort()
+                                  + ProxyServer.DEFAULT_READINESS_ENDPOINT);
+            assertEquals(200, response.get(5, TimeUnit.SECONDS).getStatus());
         } finally {
             neverReleaseDuringShutdown.countDown();
             if (requester != null) {
@@ -359,6 +368,9 @@ class ProxyServerLifecycleTest {
             }
             if (proxyServer != null) {
                 proxyServer.cancel();
+            }
+            if (restartedProxy != null) {
+                restartedProxy.cancel();
             }
             if (runtime != null) {
                 runtime.stop();


### PR DESCRIPTION
## Summary

- execute forwarded HTTP attempts through the asynchronous JDK client
- share one proxy-wide scheduler across named consumers, with strict serial handling for each exact message segment
- retain the default tracker batch size, allow a 250 ms best-case batch completion window, and bound total outstanding work at 1024
- keep retry delays and durable response publication inside the logical request slot
- on hard shutdown, cancel queued or HTTP-active work best effort and append it to the WebRequest log in original order; never requeue response-publishing work

## Configuration

- `FLUXZERO_PROXY_FORWARD_MAX_CONCURRENT_REQUESTS` (default `8`)
- `FLUXZERO_PROXY_FORWARD_MAX_OUTSTANDING_REQUESTS` (default `1024`)
- `FLUXZERO_PROXY_FORWARD_BATCH_COMPLETION_GRACE_MILLIS` (default `250`)

## Verification

- focused concurrency, segment-ordering, backpressure, retry, cancellation, correlation, and lifecycle tests
- full proxy reactor: 125 proxy tests, with all dependencies green
- full nine-module `./mvnw -B install`, including proxy shading and Java/Kotlin downstream checks
- network-free scheduler benchmark: median 163,271 requests/s, about 6.1 microseconds per request at 8 active / 1024 outstanding / 128 segments
- adversarial regression review, including end-to-end durable hard-stop handoff to a restarted proxy