### PR TITLE
test(concurrency): remove async fixture races

### DIFF
--- a/common/src/test/java/io/fluxzero/common/TimeboxedExecutorTest.java
+++ b/common/src/test/java/io/fluxzero/common/TimeboxedExecutorTest.java
@@ -17,15 +17,44 @@ package io.fluxzero.common;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimeboxedExecutorTest {
+
+    @Test
+    void callAndWaitInterruptsAnActiveTaskOnTimeout() throws Exception {
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch taskRelease = new CountDownLatch(1);
+        CountDownLatch taskInterrupted = new CountDownLatch(1);
+        ExecutorService executor = new StartAwaitingExecutor(taskStarted);
+        try (TimeboxedExecutor timeboxedExecutor = new TimeboxedExecutor(executor)) {
+            assertThrows(TimeoutException.class, () -> timeboxedExecutor.callAndWait(() -> {
+                taskStarted.countDown();
+                try {
+                    taskRelease.await();
+                } catch (InterruptedException e) {
+                    taskInterrupted.countDown();
+                    throw e;
+                }
+                return null;
+            }, Duration.ZERO));
+
+            assertTrue(taskInterrupted.await(1, TimeUnit.SECONDS));
+        }
+    }
 
     @Test
     void callAndWaitManagedBlocksWhenCalledFromForkJoinPool() throws Exception {
@@ -49,6 +78,54 @@ class TimeboxedExecutorTest {
         } finally {
             timeboxedExecutor.close();
             forkJoinPool.shutdownNow();
+        }
+    }
+
+    private static class StartAwaitingExecutor extends AbstractExecutorService {
+        private final CountDownLatch taskStarted;
+        private final ExecutorService delegate =
+                Executors.newSingleThreadExecutor(Thread.ofPlatform().daemon().factory());
+
+        private StartAwaitingExecutor(CountDownLatch taskStarted) {
+            this.taskStarted = taskStarted;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            delegate.execute(command);
+            try {
+                if (!taskStarted.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Task did not start");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while awaiting task start", e);
+            }
+        }
+
+        @Override
+        public void shutdown() {
+            delegate.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return delegate.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return delegate.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegate.awaitTermination(timeout, unit);
         }
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/websocket/AbstractWebsocketClientTest.java
@@ -861,9 +861,8 @@ class AbstractWebsocketClientTest {
 
         try (TimeoutObservingClient client = new TimeoutObservingClient(container, clientConfig,
                                                                         Duration.ofMillis(10))) {
+            // Active-task interruption is covered at the timebox owner with a deterministic task-start barrier.
             assertTimeout(Duration.ofSeconds(2), () -> assertThrows(TimeoutException.class, client::connectOnce));
-            assertTrue(container.connectStarted.await(1, TimeUnit.SECONDS));
-            assertTrue(container.connectInterrupted.await(1, TimeUnit.SECONDS));
         }
     }
 
@@ -1990,18 +1989,13 @@ class AbstractWebsocketClientTest {
     }
 
     private static class BlockingWebsocketConnector implements WebsocketConnector {
-        private final CountDownLatch connectStarted = new CountDownLatch(1);
-        private final CountDownLatch connectInterrupted = new CountDownLatch(1);
-
         @Override
         public WebsocketSession connect(WebsocketEndpoint endpoint, WebsocketConnectionOptions options, URI uri)
                 throws IOException {
-            connectStarted.countDown();
             try {
                 Thread.sleep(Duration.ofSeconds(30).toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                connectInterrupted.countDown();
                 throw new IOException("Interrupted while connecting", e);
             }
             throw new IOException("Connection unexpectedly completed");

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/client/LocalTrackingClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/client/LocalTrackingClientTest.java
@@ -207,7 +207,7 @@ class LocalTrackingClientTest {
     @Test
     @Timeout(10)
     void cachedTrackerUsesDelegateWhenAnchorIsNotCachedYet() throws Exception {
-        try (CountingLocalTrackingClient delegate = new CountingLocalTrackingClient(
+        try (CacheFillerBlockingLocalTrackingClient delegate = new CacheFillerBlockingLocalTrackingClient(
                 CUSTOM, "cached-anchor-update", Duration.ofMinutes(5))) {
             try (TestCachingTrackingClient client = new TestCachingTrackingClient(delegate)) {
                 SerializedMessage anchor = message("anchor");
@@ -218,7 +218,7 @@ class LocalTrackingClientTest {
                                 .maxWaitDuration(Duration.ofSeconds(5)).build());
 
                 SerializedMessage next = message("next");
-                Thread.sleep(100L);
+                assertTrue(delegate.cachedTrackerReadStarted.await(1, TimeUnit.SECONDS));
                 delegate.append(STORED, next).join();
 
                 MessageBatch batch = waitingBatch.get(2, TimeUnit.SECONDS);
@@ -331,7 +331,8 @@ class LocalTrackingClientTest {
     }
 
     private static class CountingLocalTrackingClient extends LocalTrackingClient {
-        private final AtomicInteger cachedTrackerReadCalls = new AtomicInteger();
+        final AtomicInteger cachedTrackerReadCalls = new AtomicInteger();
+        final CountDownLatch cachedTrackerReadStarted = new CountDownLatch(1);
 
         CountingLocalTrackingClient(io.fluxzero.common.MessageType messageType, String topic,
                                     Duration messageExpiration) {
@@ -342,8 +343,32 @@ class LocalTrackingClientTest {
         public CompletableFuture<MessageBatch> read(String trackerId, Long lastIndex, ConsumerConfiguration config) {
             if ("cached-tracker".equals(trackerId)) {
                 cachedTrackerReadCalls.incrementAndGet();
+                cachedTrackerReadStarted.countDown();
             }
             return super.read(trackerId, lastIndex, config);
+        }
+    }
+
+    private static class CacheFillerBlockingLocalTrackingClient extends CountingLocalTrackingClient {
+        private final CompletableFuture<MessageBatch> cacheFillerBatch = new CompletableFuture<>();
+
+        CacheFillerBlockingLocalTrackingClient(io.fluxzero.common.MessageType messageType, String topic,
+                                               Duration messageExpiration) {
+            super(messageType, topic, messageExpiration);
+        }
+
+        @Override
+        public CompletableFuture<MessageBatch> read(String trackerId, Long lastIndex, ConsumerConfiguration config) {
+            if (!"cached-tracker".equals(trackerId)) {
+                return cacheFillerBatch;
+            }
+            return super.read(trackerId, lastIndex, config);
+        }
+
+        @Override
+        public void close() {
+            cacheFillerBatch.cancel(true);
+            super.close();
         }
     }
 }


### PR DESCRIPTION
## Summary

- accept both valid pre-start and active timeout interleavings in websocket integration coverage
- prove active timebox cancellation with a deterministic task-start barrier at the owning component
- prevent the tracking cache filler from racing the delegate-fallback scenario
- remove the fixed sleep from the tracking test without changing production behavior

## Verification

- 20 repeated Maven/JUnit runs of the three affected contract tests
- complete websocket and local-tracking test classes
- full nine-module Maven reactor install
- adversarial review confirming a test-only diff