### PR TITLE
fix(testing): register intercepted model commands

### DIFF
--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixture.java
@@ -1067,7 +1067,7 @@ public class TestFixture implements Given<TestFixture>, When {
     }
 
     private void publishGivenEvent(Message event) {
-        if (hasModelHandlerMethods(event.getPayloadClass())) {
+        if (hasDirectModelApply(event.getPayloadClass())) {
             getDispatchResult(getFluxzero().executeStoredModelEvent(event));
         }
         getFluxzero().eventGateway().publish(event);
@@ -2048,17 +2048,24 @@ public class TestFixture implements Given<TestFixture>, When {
         }
         Class<?> payloadClass = message.getPayloadClass();
         boolean automaticHandler = ClientUtils.isSelfTracking(payloadClass)
-                                   || hasModelHandlerMethods(payloadClass);
+                                   || hasAutomaticModelHandler(payloadClass);
         if (automaticHandler && matchesTrackSelfConditions(payloadClass)
             && registeredAutomaticHandlers.add(payloadClass)) {
             registration = registration.merge(fluxzero.registerHandlers(payloadClass));
         }
     }
 
-    private static boolean hasModelHandlerMethods(Class<?> payloadClass) {
+    private static boolean hasDirectModelApply(Class<?> payloadClass) {
         return EntityMetadata.of(payloadClass).handlerMethods().stream()
                 .anyMatch(handler -> handler.kind() == EntityMetadata.HandlerKind.APPLY
                                      && !handler.targetModelTypes().isEmpty());
+    }
+
+    private static boolean hasAutomaticModelHandler(Class<?> payloadClass) {
+        return EntityMetadata.of(payloadClass).handlerMethods().stream()
+                .anyMatch(handler -> handler.kind() == EntityMetadata.HandlerKind.INTERCEPT_APPLY
+                                     || handler.kind() == EntityMetadata.HandlerKind.APPLY
+                                        && !handler.targetModelTypes().isEmpty());
     }
 
     private boolean matchesTrackSelfConditions(Class<?> payloadClass) {

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
@@ -143,6 +143,14 @@ class TestFixtureModelApiTest {
     }
 
     @Test
+    @Timeout(2)
+    void asynchronousFixturesAutomaticallyRegisterInterceptOnlyModelCommands() {
+        TestFixture.createAsync()
+                .whenCommand(new InterceptedCreateModel("model-1"))
+                .expectOnlyEvents(new CreateModel("model-1"));
+    }
+
+    @Test
     void givenEventsUpdateTheSameUncachedDocumentModelSynchronously() {
         TestFixture.create()
                 .givenEvents(new UpdateUncachedDocument("document-1", 1),
@@ -263,6 +271,13 @@ class TestFixtureModelApiTest {
         @Apply
         FixtureModel apply() {
             return new FixtureModel(id);
+        }
+    }
+
+    private record InterceptedCreateModel(String id) {
+        @InterceptApply
+        CreateModel intercept() {
+            return new CreateModel(id);
         }
     }
 


### PR DESCRIPTION
## Summary
- separate stored given-event detection from automatic Model handler discovery
- register async commands that only declare @InterceptApply
- preserve legacy intercepted given-event publication

## Verification
- full nine-module SDK install
- focused SDK Model fixture test
- previously failing Runtime parent/grandparent integration test