### PR TITLE
docs(modeling): align manuals and merge SDK main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3442,9 +3442,9 @@ public record User(@EntityId UserId userId, String name) {
 `materializeGraph` is sufficient: Fluxzero keeps the private root document needed for composition without exposing a
 direct Model collection. Enable `searchable` separately only when callers should also be able to search the root Model
 itself. Use `searchProjection = @Searchable(...)` or `graphProjection = @GraphProjection(...)` only for advanced
-configuration. The graph collection is `User-graphs` by default; for a searchable root it derives from the resolved
-direct collection instead. Set `GraphProjection.collection` only when a custom durable name is needed. Projection is
-asynchronous unless completion is explicitly configured otherwise. Both live and materialized composition follow the
+configuration. The graph collection is `User-graphs` by default; for a searchable root Fluxzero appends `-graphs` to
+the resolved direct collection. Set `GraphProjection.collection` only when a custom durable name is needed. Projection
+is asynchronous unless completion is explicitly configured otherwise. Both live and materialized composition follow the
 complete finite graph by default; lower-level `ModelGraphComposition` maxima are optional advanced guardrails and use
 `UNBOUNDED` (`-1`) when absent. An explicit guardrail fails instead of publishing a partial graph.
 
@@ -3532,7 +3532,9 @@ the complete operation, and a collision while creating a new identity never reba
 
 `Graph<T>` is the public context view around a model. A typed `loadGraph` is source-lazy: typed ancestor resolution
 need not load the source value or intermediate parents. A typed `Id` or explicit parent-scoped load also makes `id()`
-available immediately; an alias lookup resolves the source before reporting its true primary ID. `get()` returns the value; `parent()`, `root()`, `children(...)`
+available immediately; an alias lookup resolves the source before reporting its true primary ID. `id()` is that
+collision-safe repository identity, while `functionalId()` exposes the public ID from the current or last present
+Model value without repository affixes or parent scope. `get()` returns the value; `parent()`, `root()`, `children(...)`
 and `descendants(...)` navigate relationships; `previous()`, `atStateIndex(...)` and `playBackToEvent(...)` expose
 history; and `apply(...)`, `assertAndApply(...)` or `delete()` stage model transitions. Graph creation itself performs
 only the same direct model load as `T` injection. Relationship state is loaded lazily when navigation is requested.
@@ -3554,6 +3556,10 @@ that omits rejected placements while sharing every accepted model value. `filter
 tree selection: a matched parent retains its subtree, while a matched leaf automatically retains the ancestors needed
 to serialize its path.
 
+Ordinary `loadGraph(...)` calls inside a message handler inherit its coherent current or historical read boundary. Use
+`loadCurrentGraph(...)` only after a synchronous nested command when the rest of that handler deliberately needs the
+newer Model state produced by the command; it is an explicit boundary escape, not the normal loading route.
+
 Use `@GraphProperty` for a value that belongs to the serialized graph rather than to one independently stored model:
 
 ```java
@@ -3569,6 +3575,9 @@ ancestor from the graph already in memory, so defining a derived property perfor
 Graph properties are also added to generated response schemas for `@ApiDocResponse(modelGraph = ...)`; they are never
 added to request schemas. Annotate a graph-property method with `@ApiDoc` to describe it or with `@ApiDocExclude` (or
 `@ApiDoc(exclude = true)`) to keep it out of API documentation without changing serialized responses.
+For one already-batched response lookup that several nodes use, attach the value once with
+`graph.withContext(value)` and read it inside a property method through `graph.context(ValueType.class)`. This immutable
+view context follows parents, children and revisions but is never loaded or persisted as Model state.
 
 An event or notification handler with only one unqualified `Graph<T>` parameter subscribes to durable changes anywhere
 below that root:

--- a/common/src/main/java/io/fluxzero/common/tracking/DefaultTrackingStrategy.java
+++ b/common/src/main/java/io/fluxzero/common/tracking/DefaultTrackingStrategy.java
@@ -62,10 +62,14 @@ import static java.util.Optional.ofNullable;
 @Slf4j
 public class DefaultTrackingStrategy implements TrackingStrategy {
 
+    /** Default look-back applied when a consumer has no stored or client-controlled position. */
+    public static final Duration DEFAULT_INITIAL_POSITION_LAG = Duration.ofSeconds(1);
+
     private final MessageStore source;
     private final PositionStore positionStore;
     private final TaskScheduler scheduler;
     private final int segments;
+    private final long initialPositionLagMillis;
     private final ConcurrentHashMap<Tracker, WaitingTracker> waitingTrackers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Tracker, TrackerRequest<?>> openRequests = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, TrackerCluster> clusters = new ConcurrentHashMap<>();
@@ -78,21 +82,46 @@ public class DefaultTrackingStrategy implements TrackingStrategy {
     private volatile boolean stopped;
 
     public DefaultTrackingStrategy(MessageStore source, PositionStore positionStore) {
+        this(source, positionStore, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    /**
+     * Creates a tracking strategy with a configurable look-back for consumers without a stored position.
+     *
+     * @param source                 source message log
+     * @param positionStore          consumer position store
+     * @param initialPositionLag     duration subtracted from the current time for a new consumer
+     */
+    public DefaultTrackingStrategy(MessageStore source, PositionStore positionStore, Duration initialPositionLag) {
         this(source, positionStore, new InMemoryTaskScheduler(
                 "tracking-scheduler-%s".formatted(source),
-                newWorkerPool("tracking-worker-%s".formatted(source), 8)));
+                newWorkerPool("tracking-worker-%s".formatted(source), 8)), initialPositionLag);
     }
 
     public DefaultTrackingStrategy(MessageStore source, PositionStore positionStore, TaskScheduler scheduler) {
-        this(source, positionStore, scheduler, MAX_SEGMENT);
+        this(source, positionStore, scheduler, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    protected DefaultTrackingStrategy(MessageStore source, PositionStore positionStore, TaskScheduler scheduler,
+                                      Duration initialPositionLag) {
+        this(source, positionStore, scheduler, MAX_SEGMENT, initialPositionLag);
     }
 
     protected DefaultTrackingStrategy(MessageStore source, PositionStore positionStore, TaskScheduler scheduler,
                                       int segments) {
+        this(source, positionStore, scheduler, segments, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    protected DefaultTrackingStrategy(MessageStore source, PositionStore positionStore, TaskScheduler scheduler,
+                                      int segments, Duration initialPositionLag) {
         this.source = source;
         this.positionStore = positionStore;
         this.scheduler = scheduler;
         this.segments = segments;
+        if (initialPositionLag == null || initialPositionLag.isNegative()) {
+            throw new IllegalArgumentException("initialPositionLag must be non-negative");
+        }
+        this.initialPositionLagMillis = initialPositionLag.toMillis();
         sourceRegistration = source.registerMonitor(this::onUpdate);
         purgeCeasedTrackers(Duration.ofSeconds(2));
     }
@@ -262,12 +291,12 @@ public class DefaultTrackingStrategy implements TrackingStrategy {
     protected Position position(Tracker tracker, int[] segment) {
         if (tracker.clientControlledIndex()) {
             return new Position(segment, ofNullable(tracker.getLastTrackerIndex())
-                    .orElseGet(() -> indexFromMillis(currentTimeMillis() - 1000L)));
+                    .orElseGet(() -> initialPositionIndex()));
         }
         Position position = positionStore.position(tracker.getConsumerName());
         if (position.isNew(segment)) {
             return new Position(segment, ofNullable(tracker.getLastTrackerIndex())
-                    .orElseGet(() -> indexFromMillis(currentTimeMillis() - 1000L)));
+                    .orElseGet(() -> initialPositionIndex()));
         }
         if (tracker.singleTracker()) {
             return ofNullable(tracker.getLastTrackerIndex()).map(
@@ -275,6 +304,10 @@ public class DefaultTrackingStrategy implements TrackingStrategy {
         } else {
             return position;
         }
+    }
+
+    private long initialPositionIndex() {
+        return indexFromMillis(currentTimeMillis() - initialPositionLagMillis);
     }
 
     protected List<SerializedMessage> filter(List<SerializedMessage> messages, int[] segmentRange,

--- a/common/src/test/java/io/fluxzero/common/tracking/DefaultTrackingStrategyTest.java
+++ b/common/src/test/java/io/fluxzero/common/tracking/DefaultTrackingStrategyTest.java
@@ -62,6 +62,24 @@ import static org.mockito.Mockito.when;
 class DefaultTrackingStrategyTest {
 
     @Test
+    void appliesConfiguredInitialPositionLagForNewConsumer() {
+        Duration lag = Duration.ofSeconds(10);
+        TestScheduler scheduler = new TestScheduler();
+        long earliestExpectedMillis = System.currentTimeMillis() - lag.toMillis();
+        try (TestStrategy subject = new TestStrategy(mockSource(), scheduler, mockPositionStore(), lag)) {
+            Tracker newTracker = tracker("consumer", "tracker").withLastTrackerIndex(null);
+            long initialPositionMillis = subject.initialPosition(newTracker).getIndex(0)
+                    .orElseThrow() >> 16;
+            long latestExpectedMillis = System.currentTimeMillis() - lag.toMillis();
+
+            assertTrue(initialPositionMillis >= earliestExpectedMillis,
+                       () -> initialPositionMillis + " < " + earliestExpectedMillis);
+            assertTrue(initialPositionMillis <= latestExpectedMillis,
+                       () -> initialPositionMillis + " > " + latestExpectedMillis);
+        }
+    }
+
+    @Test
     void deliversAvailableMessagesImmediately() {
         TestScheduler scheduler = new TestScheduler();
         try (TestStrategy subject = new TestStrategy(mockSource(), scheduler)
@@ -462,6 +480,15 @@ class DefaultTrackingStrategyTest {
 
         TestStrategy(MessageStore source, TaskScheduler scheduler, PositionStore positionStore) {
             super(source, positionStore, scheduler);
+        }
+
+        TestStrategy(MessageStore source, TaskScheduler scheduler, PositionStore positionStore,
+                     Duration initialPositionLag) {
+            super(source, positionStore, scheduler, initialPositionLag);
+        }
+
+        Position initialPosition(Tracker tracker) {
+            return position(tracker, new int[]{0, MAX_SEGMENT});
         }
 
         @SafeVarargs

--- a/docs/developer/getting-started/core-concepts.mdx
+++ b/docs/developer/getting-started/core-concepts.mdx
@@ -43,7 +43,10 @@ public record RenameProject(ProjectId projectId,
 
     @Apply
     Project apply(Project project) {
-        return new Project(projectId, name, project.ownerId());
+        return new Project(
+                projectId,
+                new ProjectDetails(name),
+                project.ownerId());
     }
 }
 ```
@@ -65,7 +68,11 @@ data class RenameProject(
 
     @Apply
     fun apply(project: Project) =
-        Project(projectId, name, project.ownerId)
+        Project(
+            projectId,
+            ProjectDetails(name),
+            project.ownerId
+        )
 }
 ```
 
@@ -93,14 +100,8 @@ Use an explicit `@HandleCommand` when the action needs orchestration around the 
 ```java
 @Model(searchable = true)
 public record Project(@EntityId ProjectId projectId,
-                      String name,
+                      ProjectDetails details,
                       UserId ownerId) {
-}
-
-public final class ProjectId extends Id<Project> {
-    public ProjectId(String value) {
-        super(value, "project-");
-    }
 }
 ```
 
@@ -111,15 +112,16 @@ public final class ProjectId extends Id<Project> {
 @Model(searchable = true)
 data class Project(
     @EntityId val projectId: ProjectId,
-    val name: String,
+    val details: ProjectDetails,
     val ownerId: UserId
 )
-
-class ProjectId(value: String) : Id<Project>(value, "project-")
 ```
 
   </TabItem>
 </Tabs>
+
+`ProjectId` is the application's typed `Id<Project>` and `ProjectDetails` its immutable details value; their ordinary
+value-type definitions are omitted here so the example stays focused on Model behavior.
 
 Each model ID is its own persistence and lifecycle boundary. Its event stream, cache, snapshots and direct search
 document are enabled independently through `@Model` settings. The exact
@@ -146,10 +148,10 @@ An `@Apply` method returns the target model state:
 
 ```java
 public record CreateProject(ProjectId projectId,
-                            String name) {
+                            ProjectDetails details) {
     @Apply
     Project apply(Sender sender) {
-        return new Project(projectId, name, sender.userId());
+        return new Project(projectId, details, sender.userId());
     }
 }
 
@@ -215,14 +217,14 @@ Use `@Parent` when independently stored models form a navigable graph:
 @Model(searchable = true)
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
-                   String description,
+                   TaskDetails details,
                    boolean completed) {
 }
 ```
 
-Changing only `projectId` moves a task. The parent, siblings and children do not need to be loaded. The stable `path`
-is optional; without it, Fluxzero still stores the relation but does not automatically place the child in a stitched
-tree document.
+Changing only `projectId` moves a task. The parent, siblings and children do not need to be loaded. The stable
+`pathInParent` is optional; without it, Fluxzero still stores the relation but does not automatically place the child
+in a stitched tree document.
 
 Parents and further ancestors can be injected into model assertions, apply interceptors and applies. Use
 `@Association("path")` when more than one relation could match:
@@ -297,8 +299,8 @@ public final class ProjectQueries {
     @HandleQuery
     CompletableFuture<List<Project>> handle(FindProjects query) {
         return Fluxzero.search(Project.class)
-                .lookAhead(query.term(), "name")
-                .fetchAsync(50, Project.class);
+                .lookAhead(query.term(), "details/name")
+                .fetchAsync(50);
     }
 }
 ```
@@ -330,11 +332,13 @@ payload.
 
 ```java
 TestFixture.create()
-        .givenCommands(new CreateProject(projectId, "Initial"))
+        .givenCommands(new CreateProject(
+                projectId, new ProjectDetails("Initial")))
         .whenCommand(new RenameProject(projectId, "Launch"))
         .expectThat(fluxzero -> assertEquals(
                 "Launch",
-                Fluxzero.loadModel(projectId).get().name()))
+                Fluxzero.loadModel(projectId)
+                        .get().details().name()))
         .expectEvents(new RenameProject(projectId, "Launch"));
 ```
 

--- a/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
+++ b/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
@@ -47,8 +47,12 @@ List<LineItem> lines = graph.childModels("lines", LineItem.class);
 `Graph<T>` carries:
 
 - `isPresent()` distinguishes an existing model from an empty or logically deleted model;
-- `id()` and `type()` expose its persisted identity and type;
+- `id()` and `type()` expose its collision-safe persisted identity and type;
+- `functionalId()` exposes the public ID from the current or last present model value, without repository prefixes,
+  postfixes or parent scope;
 - `previous()` returns the retained previous revision when `cachingDepth` permits it;
+- `stateIndex()` pins the whole graph read, while `revisionStateIndex()` says when this concrete node revision became
+  current;
 - `sequenceNumber()` is the position within this model's own stream;
 - `root()`, `parent()`, `children(...)` and `descendants(...)` navigate the temporal model graph;
 - `apply(...)`, `update(...)`, `assertAndApply(...)` and `delete()` stage model changes.
@@ -198,6 +202,17 @@ ancestors of the requested type are reachable.
 Later cache entries never leak into historical event handling. Earlier `STORE_ONLY` model transitions are included
 because exactness is based on the committed model commit, not only on the globally published event stream.
 
+Ordinary `loadGraph(...)` calls made while handling a message inherit that same coherent read boundary. This is usually
+what event and notification handlers need. After sending a synchronous nested command, use `loadCurrentGraph(...)`
+only when the remainder of the handler deliberately needs the newer state produced by that command:
+
+```java
+Fluxzero.sendCommandAndWait(new ReserveItem(itemId));
+Graph<Item> current = Fluxzero.loadCurrentGraph(itemId);
+```
+
+This explicit escape prevents a handler from accidentally mixing the event-visible past with unrelated latest state.
+
 ### Backfilling Models from legacy events
 
 Configure the SDK-owned migration runner in a dedicated application:
@@ -320,6 +335,12 @@ operation intentionally accepts only a bounded graph; use a direct model load wh
 Returning `Graph<T>` from a message or web handler serializes the root and descendants placed through explicit
 `@Parent(pathInParent = "...")` edges. Pathless relationships remain available through typed `children(...)` and
 `descendants(...)`, but do not invent a public JSON property name.
+
+Use `@GraphProperty` for a response value derived from graph context rather than from one independently stored Model.
+The method may receive the current graph or a typed ancestor graph. When many nodes share an already-batched lookup,
+attach that response-only value once with `graph.withContext(value)` and read it inside the property method with
+`graph.context(ValueType.class)`. The context is shared by the immutable graph view and is never persisted as Model
+state.
 
 A current graph load inside an ordered tracking batch includes pending model state produced by earlier messages in the
 same routing segment. This includes newly created nodes, changed values and `@Parent` moves. Moving an existing node

--- a/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
+++ b/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
@@ -93,34 +93,45 @@ For a string or another untyped ID, declare the type when graph features need it
 String orderId
 ```
 
+For one polymorphic typed relation, enumerate the statically allowed parent types. The concrete typed ID selects one of
+them at runtime:
+
+```java
+@Parent(
+    types = {Project.class, Folder.class},
+    pathInParent = "items")
+Id<?> containerId
+```
+
+Use separate properties when the relations have different domain roles, paths or deletion ownership.
+
 Model identity is still only `id.toString()`. The model type is reconstruction and graph metadata; it is never
 concatenated into the persisted key.
 
 ## Paths and graph composition
 
-`path` is an explicit durable placement contract. It is intentionally not derived from a Java class name:
+`pathInParent` is an explicit durable placement contract. It is intentionally not derived from a Java class name:
 
 ```java
 @Parent(pathInParent = "shipping/lines")
 OrderId orderId
 ```
 
-When `path` is omitted, Fluxzero still stores and traverses the relation, but it does not automatically stitch that edge
-into a search or serialized graph document. Typed `Graph` traversal and parent-deletion lifecycle handling still follow
-it. This keeps package and class renames from silently changing public document structure.
+When `pathInParent` is omitted, Fluxzero still stores and traverses the relation, but it does not automatically stitch
+that edge into a search or serialized graph document. Typed `Graph` traversal and parent-deletion lifecycle handling
+still follow it. This keeps package and class renames from silently changing public document structure.
 
-Current graph documents can be assembled on demand:
+Current graphs can be assembled on demand:
 
 ```java
-ObjectNode order = Fluxzero.searchGraph(Order.class)
-        .fetch(1)
-        .getFirst();
+Graph<Order> order = Fluxzero.searchGraph(Order.class)
+        .fetchFirstOrNull();
 ```
 
 If `Order` configures a graph projection, the default search reads that materialized view. Without one, it stitches
 the graph live. Pass `true` as the second argument to force live stitching. Constraints, sorting, field selection and
-pagination apply to the complete graph view in either route. Request `SerializedDocument.class`, `Document.class` or
-stream typed `SearchHit<ObjectNode>` values when transport or index details are needed.
+pagination apply to the complete graph view in either route. Use an explicit terminal result type such as
+`fetch(1, ObjectNode.class)` only at a raw JSON, document or transport boundary.
 
 Or reconstructed as typed models:
 
@@ -182,7 +193,7 @@ List<LineItem> lines = Fluxzero.search(LineItem.class)
                 2,
                 MatchConstraint.match(
                         "Acme", true, "name"))
-        .fetchAll(LineItem.class);
+        .fetchAll();
 ```
 
 The reverse is also possible:
@@ -197,7 +208,7 @@ List<Order> orders = Fluxzero.search(Order.class)
                         productId.toString(),
                         true,
                         "productId"))
-        .fetchAll(Order.class);
+        .fetchAll();
 ```
 
 These current searches use relational joins between direct model documents and current edges. They do not require an
@@ -209,15 +220,16 @@ For repeated whole-root queries, opt in to a durable graph projection:
 
 ```java
 @Model(
-    searchable = true,
+    materializeGraph = true,
     graphProjection = @GraphProjection(
         collection = "order-graphs"))
 record Order(@EntityId OrderId orderId, String customerName) {
 }
 ```
 
-The runtime consumes durable projection signals, coalesces affected roots, composes each bounded graph and writes it
-with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root.
+The runtime consumes durable projection signals, coalesces affected roots, composes each complete graph and writes it
+with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root. `searchable = true` is a
+separate choice that enables direct `Order` search; it is not required for this whole-graph projection.
 
 Projection completion is configurable:
 

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -38,6 +38,10 @@ record Account(@EntityId AccountId accountId, Money balance) {
 Each applied update is stored in this account's model stream. Loading reconstructs the account by replaying its
 `@Apply` methods, optionally starting at a snapshot or checkpoint.
 
+By default an event-sourced Model fails when its stream contains an event for which no applicable `@Apply` exists.
+Set `ignoreUnknownEvents = true` only when skipping such historical events is an explicit compatibility decision; it
+changes reconstructed state and is not a substitute for upcasting or retaining old handlers.
+
 Independent models prevent unrelated histories from accumulating in one enormous stream. An order line, payment
 attempt or short-lived process can keep its own small history while still participating in one multi-model commit.
 
@@ -49,7 +53,8 @@ Set `eventSourced = false` to make the current direct document the normal load s
 @Model(
     eventSourced = false,
     searchable = true,
-    collection = "countries")
+    searchProjection = @Searchable(
+        collection = "countries"))
 record Country(
         @EntityId CountryId countryId,
         String name) {
@@ -115,12 +120,20 @@ materialization until the fenced search write succeeds. A retry or the runtime's
 package; application code is never re-evaluated to repair an already committed action. Materialized whole-root graph
 projections may continue asynchronously unless `AWAIT` was selected.
 
+`commitPolicy` controls when the automatic atomic commit starts and when handler or batch completion awaits it. The
+default starts after Model apply handlers and awaits all started commits at batch completion. Keep `DEFAULT` unless an
+application has a measured ordering, latency or concurrency reason to choose another `ModelCommitPolicy`; the policy
+does not split one multi-Model action into separate commits.
+
 ## Searchable models
 
 `searchable = true` gives every model its own direct current document:
 
 ```java
-@Model(searchable = true, collection = "line-items")
+@Model(
+    searchable = true,
+    searchProjection = @Searchable(
+        collection = "line-items"))
 record LineItem(
         @EntityId LineItemId lineItemId,
         @Parent(pathInParent = "lines") OrderId orderId,
@@ -138,9 +151,10 @@ Fluxzero stores no graph-component document and performs no extra document write
 You can additionally:
 
 - join current direct documents through `whereAncestor(...)` and `whereDescendant(...)`;
-- search a complete JSON graph with `searchGraph(Root.class)`, using a materialized projection when configured and
+- search typed complete graphs with `searchGraph(Root.class)`, using a materialized projection when configured and
   otherwise stitching live;
-- configure `graphProjection = @GraphProjection(...)` for a durable, materialized root document.
+- set `materializeGraph = true` for a durable whole-root document and optionally configure it with
+  `graphProjection = @GraphProjection(...)`.
 
 ## Caching
 
@@ -157,7 +171,7 @@ Use `FluxzeroBuilder.withModelCache(cache)` for a dedicated model cache, or
 `FluxzeroBuilder.disableAutomaticModelCaching()` to disable both shared model caching and its update tracker.
 
 The default `cachingDepth` retains the previous revision needed by common event-handler comparison logic. Configure a
-larger depth only when the application actively uses deeper `Entity.previous()` chains.
+larger depth only when the application actively uses deeper `Graph.previous()` chains.
 
 Disable shared caching with `cached = false`; action-local consistency remains available while evaluating one model
 action.

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -91,19 +91,29 @@ Many domain models and stateful handlers in Fluxzero are automatically indexable
   </TabItem>
 </Tabs>
 
-By default, the collection name is derived from the class’s **simple name** (UserAccount → `"UserAccount"`),
-unless explicitly overridden via an annotation like `@Model`, `@Stateful` or `@Searchable` or in the search/index
-call:
+By default, the collection name is derived from the class’s **simple name** (UserAccount → `"UserAccount"`). Configure
+a Model's direct document through its `searchProjection`; `@Stateful` and directly searchable values expose the
+`@Searchable` settings themselves:
 
 <Tabs>
   <TabItem label="Java">
     ```java
-    @Model(searchable = true, collection = "users", timestampPath = "profile/createdAt")
+    @Model(
+        searchable = true,
+        searchProjection = @Searchable(
+            collection = "users",
+            timestampPath = "profile/createdAt"))
     ```
   </TabItem>
   <TabItem label="Kotlin">
     ```kotlin
-    @Model(searchable = true, collection = "users", timestampPath = "profile/createdAt")
+    @Model(
+        searchable = true,
+        searchProjection = @Searchable(
+            collection = "users",
+            timestampPath = "profile/createdAt"
+        )
+    )
     ```
   </TabItem>
 </Tabs>
@@ -118,7 +128,7 @@ Use the fluent `search(...)` API:
   <TabItem label="Java">
     ```java
     List<UserAccount> admins = Fluxzero
-            .search("users")
+            .search(UserAccount.class)
             .match("admin", "profile/role")
             .inLast(Duration.ofDays(30))
             .sortBy("profile/lastLogin", true)
@@ -128,7 +138,7 @@ Use the fluent `search(...)` API:
   <TabItem label="Kotlin">
     ```kotlin
     val admins: List<UserAccount> = Fluxzero
-        .search("users")
+        .search(UserAccount::class.java)
         .match("admin", "profile/role")
         .inLast(Duration.ofDays(30))
         .sortBy("profile/lastLogin", true)
@@ -216,7 +226,8 @@ Search execution also has asynchronous variants for request handlers and web end
 `CompletableFuture`. Return the future directly instead of calling `.join()` inside the handler; this lets Fluxzero keep
 processing other work while the search request is in flight.
 
-- `fetchAsync(maxSize)` / `fetchAsync(maxSize, type)` fetch matching documents asynchronously.
+- `fetchAsync(maxSize)` fetches the search's configured result type asynchronously. Pass an explicit result class only
+  at a raw collection, JSON or document boundary.
 - `countAsync()` returns the matching document count asynchronously.
 - `aggregateAsync(fields...)` and `groupBy(paths...).aggregateAsync(fields...)` return search statistics
   asynchronously.
@@ -229,7 +240,7 @@ processing other work while the search request is in flight.
     CompletableFuture<List<UserAccount>> handle(SearchUsers query) {
         return Fluxzero.search(UserAccount.class)
                 .lookAhead(query.term(), "profile.name", "email")
-                .fetchAsync(50, UserAccount.class);
+                .fetchAsync(50);
     }
     ```
   </TabItem>
@@ -239,7 +250,7 @@ processing other work while the search request is in flight.
     fun handle(query: SearchUsers): CompletableFuture<List<UserAccount>> =
         Fluxzero.search(UserAccount::class.java)
             .lookAhead(query.term, "profile.name", "email")
-            .fetchAsync(50, UserAccount::class.java)
+            .fetchAsync(50)
     ```
   </TabItem>
 </Tabs>

--- a/docs/developer/tutorials/first-app.mdx
+++ b/docs/developer/tutorials/first-app.mdx
@@ -33,21 +33,16 @@ Fluxzero does not require controller, service and repository layers around this 
 
 ## Define a project
 
-First define a strong ID and an immutable model:
+First define an immutable model with a typed ID and a details value. The ordinary `ProjectId` and `ProjectDetails`
+value types are assumed below so the example can stay focused on Model behavior:
 
 <Tabs>
   <TabItem label="Java">
 
 ```java
-public final class ProjectId extends Id<Project> {
-    public ProjectId(String value) {
-        super(value, "project-");
-    }
-}
-
 @Model(searchable = true)
 public record Project(@EntityId ProjectId projectId,
-                      String name,
+                      ProjectDetails details,
                       UserId ownerId,
                       boolean archived) {
 }
@@ -57,12 +52,10 @@ public record Project(@EntityId ProjectId projectId,
   <TabItem label="Kotlin">
 
 ```kotlin
-class ProjectId(value: String) : Id<Project>(value, "project-")
-
 @Model(searchable = true)
 data class Project(
     @EntityId val projectId: ProjectId,
-    val name: String,
+    val details: ProjectDetails,
     val ownerId: UserId,
     val archived: Boolean
 )
@@ -85,11 +78,11 @@ The creation command carries its transition:
 
 ```java
 public record CreateProject(ProjectId projectId,
-                            @NotBlank String name) {
+                            @Valid ProjectDetails details) {
     @Apply
     Project apply(Sender sender) {
         return new Project(
-                projectId, name,
+                projectId, details,
                 sender.userId(), false);
     }
 }
@@ -101,11 +94,11 @@ public record CreateProject(ProjectId projectId,
 ```kotlin
 data class CreateProject(
     val projectId: ProjectId,
-    @field:NotBlank val name: String
+    @field:Valid val details: ProjectDetails
 ) {
     @Apply
     fun apply(sender: Sender) =
-        Project(projectId, name, sender.userId(), false)
+        Project(projectId, details, sender.userId(), false)
 }
 ```
 
@@ -116,7 +109,9 @@ Send it like any command:
 
 ```java
 Project result = Fluxzero.sendCommandAndWait(
-        new CreateProject(projectId, "Website launch"));
+        new CreateProject(
+                projectId,
+                new ProjectDetails("Website launch")));
 ```
 
 Fluxzero discovers the `@Apply` method, resolves the target from `ProjectId`, checks that the project does not already
@@ -136,16 +131,10 @@ model and link it to a project:
   <TabItem label="Java">
 
 ```java
-public final class TaskId extends Id<Task> {
-    public TaskId(String value) {
-        super(value, "task-");
-    }
-}
-
 @Model(searchable = true)
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
-                   String description,
+                   TaskDetails details,
                    boolean completed) {
 }
 ```
@@ -154,13 +143,11 @@ public record Task(@EntityId TaskId taskId,
   <TabItem label="Kotlin">
 
 ```kotlin
-class TaskId(value: String) : Id<Task>(value, "task-")
-
 @Model(searchable = true)
 data class Task(
     @EntityId val taskId: TaskId,
     @Parent(pathInParent = "tasks") val projectId: ProjectId,
-    val description: String,
+    val details: TaskDetails,
     val completed: Boolean
 )
 ```
@@ -179,7 +166,7 @@ Now create a task while checking its unrelated parent model:
 ```java
 public record AddTask(TaskId taskId,
                       ProjectId projectId,
-                      @NotBlank String description) {
+                      @Valid TaskDetails details) {
     @AssertLegal
     void assertProjectActive(Project project) {
         if (project.archived()) {
@@ -192,7 +179,7 @@ public record AddTask(TaskId taskId,
     Task apply() {
         return new Task(
                 taskId, projectId,
-                description, false);
+                details, false);
     }
 }
 ```
@@ -204,7 +191,7 @@ public record AddTask(TaskId taskId,
 data class AddTask(
     val taskId: TaskId,
     val projectId: ProjectId,
-    @field:NotBlank val description: String
+    @field:Valid val details: TaskDetails
 ) {
     @AssertLegal
     fun assertProjectActive(project: Project) {
@@ -215,7 +202,7 @@ data class AddTask(
 
     @Apply
     fun apply() =
-        Task(taskId, projectId, description, false)
+        Task(taskId, projectId, details, false)
 }
 ```
 
@@ -247,7 +234,7 @@ public record CompleteTask(TaskId taskId) {
         return new Task(
                 task.taskId(),
                 task.projectId(),
-                task.description(),
+                task.details(),
                 true);
     }
 }
@@ -295,7 +282,7 @@ public record MoveTask(TaskId taskId,
     Task apply(Task task) {
         return new Task(
                 task.taskId(), destinationId,
-                task.description(), task.completed());
+                task.details(), task.completed());
     }
 }
 ```
@@ -319,9 +306,9 @@ public final class ProjectQueries {
     CompletableFuture<List<Task>> handle(
             FindOpenTasks query) {
         return Fluxzero.search(Task.class)
-                .lookAhead(query.term(), "description")
+                .lookAhead(query.term(), "details/description")
                 .match(false, "completed")
-                .fetchAsync(100, Task.class);
+                .fetchAsync(100);
     }
 }
 ```
@@ -337,9 +324,9 @@ class ProjectQueries {
     fun handle(query: FindOpenTasks):
             CompletableFuture<List<Task>> =
         Fluxzero.search(Task::class.java)
-            .lookAhead(query.term, "description")
+            .lookAhead(query.term, "details/description")
             .match(false, "completed")
-            .fetchAsync(100, Task::class.java)
+            .fetchAsync(100)
 }
 ```
 
@@ -361,9 +348,9 @@ import static io.fluxzero.common.api.search.constraints.MatchConstraint.match;
 List<Task> launchTasks = Fluxzero.search(Task.class)
         .whereParent(
                 Project.class,
-                match("Website launch", "name"))
+                match("Website launch", "details/name"))
         .match(false, "completed")
-        .fetchAll(Task.class);
+        .fetchAll();
 ```
 
   </TabItem>
@@ -373,10 +360,10 @@ List<Task> launchTasks = Fluxzero.search(Task.class)
 val launchTasks = Fluxzero.search(Task::class.java)
     .whereParent(
         Project::class.java,
-        MatchConstraint.match("Website launch", "name")
+        MatchConstraint.match("Website launch", "details/name")
     )
     .match(false, "completed")
-    .fetchAll(Task::class.java)
+    .fetchAll()
 ```
 
   </TabItem>
@@ -396,11 +383,11 @@ Graph<Project> graph = Fluxzero.loadGraph(projectId);
 List<Task> tasks = graph.childModels("tasks", Task.class);
 ```
 
-Search returns the complete graph as JSON. It uses a configured materialized projection and otherwise stitches direct
-documents at query time:
+Graph search returns typed lazy graphs. It uses a configured materialized projection and otherwise stitches current
+Model documents at query time:
 
 ```java
-List<ObjectNode> projects = Fluxzero.searchGraph(Project.class)
+List<Graph<Project>> projects = Fluxzero.searchGraph(Project.class)
         .fetchAll();
 ```
 
@@ -409,6 +396,7 @@ For repeatedly queried large trees, enable a graph projection on the root:
 ```java
 @Model(
     searchable = true,
+    materializeGraph = true,
     graphProjection = @GraphProjection(
         collection = "project-overviews"))
 public record Project(/* ... */) {
@@ -429,15 +417,16 @@ public final class TaskNotifications {
     @HandleEvent
     void on(CompleteTask event,
             Task task,
-            Entity<Task> entity) {
+            Graph<Task> graph) {
         // task is the state exactly after this event,
         // even if newer task events already exist.
-        assert task.equals(entity.get());
+        assert task.equals(graph.get());
     }
 }
 ```
 
-For a logical delete event, `Entity<Task>` may be empty. A bare non-null `Task` only matches while a value exists.
+For a logical delete event, `Graph<Task>` is empty and exposes the deleted value through `previous()`. A bare non-null
+`Task` only matches while a value exists.
 
 ## Test the application
 
@@ -459,10 +448,12 @@ class TaskTest {
                 .givenCommands(
                         new CreateProject(
                                 projectId,
-                                "Website launch"),
+                                new ProjectDetails(
+                                        "Website launch")),
                         new AddTask(
                                 taskId, projectId,
-                                "Write documentation"))
+                                new TaskDetails(
+                                        "Write documentation")))
                 .whenCommand(
                         new CompleteTask(taskId))
                 .expectEvents(
@@ -488,10 +479,13 @@ class TaskTest {
     fun completesTask() {
         TestFixture.create()
             .givenCommands(
-                CreateProject(projectId, "Website launch"),
+                CreateProject(
+                    projectId,
+                    ProjectDetails("Website launch")
+                ),
                 AddTask(
                     taskId, projectId,
-                    "Write documentation"
+                    TaskDetails("Write documentation")
                 )
             )
             .whenCommand(CompleteTask(taskId))

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>6.1.3</junit.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.16.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
         <maven.compiler.version>3.15.0</maven.compiler.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>

--- a/kotlin-downstream-project/pom.xml
+++ b/kotlin-downstream-project/pom.xml
@@ -20,7 +20,7 @@
         <junit.version>6.1.3</junit.version>
         <kotlin.version>2.4.10</kotlin.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.16.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <junit.parallelism>2</junit.parallelism>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <fluxzero.maven.plugin.version>1.16.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
         <fluxzero.package.channel-tag>latest</fluxzero.package.channel-tag>
         <fluxzero.package.base-image>gcr.io/distroless/java25-debian13:nonroot@sha256:9ccf2b8bce700d9f450523e2055afabe4d4ee795e6d69a0647a2dcd6e180e411</fluxzero.package.base-image>
         <argLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
             <plugin>
                 <groupId>io.fluxzero</groupId>
                 <artifactId>lychee-maven-plugin</artifactId>
-                <version>0.2.9</version>
+                <version>0.2.10</version>
                 <inherited>false</inherited>
                 <configuration>
                     <scanDirectories>

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -27,25 +27,26 @@ public record Project(
         ProjectDetails details,
         UserId ownerId) {
 }
-
-public final class ProjectId extends Id<Project> {
-    public ProjectId(String value) {
-        super(value, "project-");
-    }
-}
 ```
+
+Assume conventional typed `ProjectId` and `ProjectDetails` value types; do not expand obvious ID or details
+definitions unless the user asks for them.
 
 Important settings:
 
 - `eventSourced`: controls the current-state load route. Events are still stored when `false`.
+- `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
 - `searchable`: maintains an independently searchable synchronous current-state document. `false` suppresses only the
   model's own collection; an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true` still retains the
   private graph-component document needed for composition.
 - `searchProjection`: optional `@Searchable` configuration for the direct collection and timestamp paths.
 - `eventPublication`: controls whether unchanged transitions create an event.
-- `publicationStrategy`: `STORE_AND_PUBLISH`, `STORE_ONLY`, `PUBLISH_ONLY` or `NEVER`.
+- `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
+- `checkpointPeriod`: bounds repeated replay work within one reconstruction session.
 - `cached` and `cachingDepth`: current and previous revisions retained in the SDK cache.
+- `conflictPolicy`: `ACCEPT`, `RETRY`, `FAIL` or inherited `DEFAULT` for concurrent writes.
+- `commitPolicy`: controls commit timing and completion-phase concurrency; normally keep `DEFAULT`.
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `@GraphProjection` configuration; its collection defaults to the resolved direct
@@ -241,6 +242,8 @@ default cascade ownership. Being displayed below or deleted with the parent does
 - Updating `projectId` moves the task.
 - The parent and siblings do not need to load for a task-only change.
 - Typed `Id<Parent>` supplies the relation type. A role is only needed for untyped/ambiguous IDs.
+- For one polymorphic typed relation, use `@Parent(types = {Project.class, Folder.class}, ...) Id<?> parentId`; the
+  concrete typed ID selects one statically declared parent type. Use separate properties for distinct relation roles.
 - `pathInParent` is a stable public graph-placement and serialization contract. A pathless relation remains available through
   typed `Graph` traversal and parent-deletion lifecycle handling, but is not emitted as a named JSON graph edge.
 - A child is logically deleted by default when any parent referenced by that `@Parent` is finally deleted. Set
@@ -299,6 +302,7 @@ Project project = Fluxzero.loadModel(projectId).get();
 
 Graph<Project> graph = Fluxzero.loadGraph(projectId);
 Project sameProject = graph.get();
+String publicId = graph.functionalId();
 List<Task> tasks = graph.childModels("tasks", Task.class);
 Graph<Project> previous = graph.previous();
 ```
@@ -308,6 +312,14 @@ children, descendants, history or staged updates. Resolving the graph itself cos
 injection; relationships are fetched only when traversed. Typed ancestor lookup follows relationship identities first
 and loads only the selected ancestor value. Every child is itself a graph, so `parent()`, `root()`,
 `previous()`, `atStateIndex(...)`, `apply(...)` and `assertAndApply(...)` remain available at every placement.
+
+`id()` is the collision-safe repository identity; `functionalId()` is the public ID from the current or last present
+model value and omits repository affixes or parent scope. `stateIndex()` pins the complete graph read, while
+`revisionStateIndex()` reports when the selected node revision became current.
+
+Ordinary `loadGraph(...)` calls inside a handler inherit its coherent message or historical event boundary. Use
+`loadCurrentGraph(...)` only after a synchronous nested command when later handler logic deliberately needs that
+command's newer state. Do not use it as the default loading route.
 
 Use `graph.delete()` to stage logical deletion of a selected node; return or explicitly commit that resulting graph
 according to the surrounding handler contract.
@@ -324,6 +336,9 @@ Use `selectPaths(...)`, `filterNodes(...)` or ancestor-preserving `filterBranche
 accepted model values are shared.
 Annotate a model method with `@GraphProperty` when a serialized property is derived from the current graph or a typed
 ancestor graph. It is evaluated only during graph serialization and reuses the graph already in memory.
+For one response-wide lookup that several nodes consume, attach the already-batched result once with
+`graph.withContext(value)` and read it inside the property method with `graph.context(ValueType.class)`; graph context
+is immutable, shared across the view and never persisted as Model state.
 
 Use `@Alias` for a current alternative identity of an independently stored model:
 
@@ -358,6 +373,23 @@ inject directly addressed Models at one current pinned boundary. If a migration 
 Model commit, the same injection resolves its exact historical state instead. Such an event is not implicitly a
 complete graph-change subscription; that requires the durable Model commit metadata.
 
+## Complete graph-change handlers
+
+Use an unqualified `Graph<T>` as the sole handler parameter to subscribe to every durable change of that root or one
+of its descendants:
+
+```java
+@HandleEvent
+void projectChanged(Graph<Project> graph) {
+    Graph<Project> before = graph.previous();
+}
+```
+
+Creation has no previous graph; deletion supplies an empty current graph and the complete deleted graph through
+`previous()`; moving a child invokes both old and new roots. The previous graph is commit-exact and does not depend on
+cache depth. One handler object may declare several such methods for distinct root types. Adding an explicit event
+payload turns the method back into ordinary payload handling with direct/ancestor Graph injection.
+
 ## Search and graph composition
 
 Direct searchable-model documents are synchronous with successful commit completion:
@@ -376,7 +408,7 @@ List<Task> tasks = Fluxzero.search(Task.class)
                 Project.class,
                 MatchConstraint.match(
                         "active", "status"))
-        .fetchAll(Task.class);
+        .fetchAll();
 ```
 
 Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Use
@@ -388,8 +420,8 @@ nested-path filter when the child type is known. Use
 reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 `searchGraph(Root.class, true)`
 forces live composition. Use `fetch(..., ObjectNode.class)` for explicit raw JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Modelsearch. A blank projection
-collection derives from the direct Model collection when searchable, or from the simple root-model name otherwise;
+`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Model search. A blank projection
+collection appends `-graphs` to the direct Model collection when searchable, or to the simple root-model name otherwise;
 explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy

--- a/project-files/java/agents/rules/fluxzero-fqns-grouped.md
+++ b/project-files/java/agents/rules/fluxzero-fqns-grouped.md
@@ -58,6 +58,7 @@ io.fluxzero.sdk.configuration.DefaultFluxzero
 io.fluxzero.sdk.configuration.DefaultFluxzero.Builder
 io.fluxzero.sdk.configuration.FluxzeroBuilder
 io.fluxzero.sdk.configuration.FluxzeroConfiguration
+io.fluxzero.sdk.configuration.PublishedEventModelMigration
 io.fluxzero.sdk.configuration.client.AbstractClient
 io.fluxzero.sdk.configuration.client.Client
 io.fluxzero.sdk.configuration.client.ClientDispatchMonitor
@@ -88,6 +89,7 @@ io.fluxzero.sdk.modeling.Alias
 io.fluxzero.sdk.modeling.AnnotatedEntityHolder
 io.fluxzero.sdk.modeling.AppliedEvent
 io.fluxzero.sdk.modeling.AssertLegal
+io.fluxzero.sdk.modeling.AutomaticModelHandling
 io.fluxzero.sdk.modeling.BatchingHandlerRepository
 io.fluxzero.sdk.modeling.DefaultEntityHelper
 io.fluxzero.sdk.modeling.DefaultEntityHelper.DeserializingMessageWithEntity
@@ -100,6 +102,11 @@ io.fluxzero.sdk.modeling.EntityId
 io.fluxzero.sdk.modeling.EntityParameterResolver
 io.fluxzero.sdk.modeling.EventPublication
 io.fluxzero.sdk.modeling.EventPublicationStrategy
+io.fluxzero.sdk.modeling.Graph<T>
+io.fluxzero.sdk.modeling.GraphLookupPolicy
+io.fluxzero.sdk.modeling.GraphProjection
+io.fluxzero.sdk.modeling.GraphProjectionCompletion
+io.fluxzero.sdk.modeling.GraphProperty
 io.fluxzero.sdk.modeling.HandlerRepository
 io.fluxzero.sdk.modeling.HasEntity
 io.fluxzero.sdk.modeling.Id<T>
@@ -107,10 +114,13 @@ io.fluxzero.sdk.modeling.ImmutableAggregateRoot<T>
 io.fluxzero.sdk.modeling.ImmutableEntity<T>
 io.fluxzero.sdk.modeling.LazyAggregateRoot<T>
 io.fluxzero.sdk.modeling.Member
+io.fluxzero.sdk.modeling.Model
+io.fluxzero.sdk.modeling.ModelCommitPolicy
 io.fluxzero.sdk.modeling.ModifiableAggregateRoot.CommitHandler
 io.fluxzero.sdk.modeling.ModifiableAggregateRoot<T>
 io.fluxzero.sdk.modeling.ModifiableEntity<T>
 io.fluxzero.sdk.modeling.NoOpEntity<T>
+io.fluxzero.sdk.modeling.Parent
 io.fluxzero.sdk.modeling.SearchParameters
 io.fluxzero.sdk.modeling.SideEffectFreeEntity<T>
 io.fluxzero.common.caching.AdaptiveObjectCache
@@ -149,6 +159,7 @@ io.fluxzero.sdk.persisting.keyvalue.client.WebsocketKeyValueClient
 io.fluxzero.sdk.persisting.repository.AggregateRepository
 io.fluxzero.sdk.persisting.repository.CachingAggregateRepository
 io.fluxzero.sdk.persisting.repository.DefaultAggregateRepository
+io.fluxzero.sdk.persisting.repository.ModelRepository
 io.fluxzero.sdk.persisting.search.DefaultDocumentStore
 io.fluxzero.sdk.persisting.search.DefaultIndexOperation
 io.fluxzero.sdk.persisting.search.DocumentSerializer
@@ -156,7 +167,7 @@ io.fluxzero.sdk.persisting.search.DocumentStore
 io.fluxzero.sdk.persisting.search.DocumentStoreException
 io.fluxzero.sdk.persisting.search.GroupSearch
 io.fluxzero.sdk.persisting.search.IndexOperation
-io.fluxzero.sdk.persisting.search.Search
+io.fluxzero.sdk.persisting.search.Search<R>
 io.fluxzero.sdk.persisting.search.SearchHit<T>
 io.fluxzero.sdk.persisting.search.Searchable
 io.fluxzero.sdk.persisting.search.client.CollectionMessageStore
@@ -461,6 +472,10 @@ io.fluxzero.common.api.modeling.GetAggregateIds
 io.fluxzero.common.api.modeling.GetAggregateIdsResult
 io.fluxzero.common.api.modeling.GetRelationships
 io.fluxzero.common.api.modeling.GetRelationshipsResult
+io.fluxzero.common.api.modeling.ModelConflictPolicy
+io.fluxzero.common.api.modeling.ModelDeletionCascade
+io.fluxzero.common.api.modeling.ModelDeletionPlan
+io.fluxzero.common.api.modeling.ModelDeletionResult
 io.fluxzero.common.api.modeling.Relationship
 io.fluxzero.common.api.modeling.RepairRelationships
 io.fluxzero.common.api.modeling.UpdateRelationships

--- a/project-files/java/agents/rules/glossary.md
+++ b/project-files/java/agents/rules/glossary.md
@@ -12,6 +12,13 @@ and current-document consequences. A meaningful domain identity is strong eviden
 child-only identity can be parent-scoped. Related independent models form dynamic action boundaries and a temporal
 graph through `@Parent`.
 
+### Graph
+
+A typed, lazy view around one Model and its temporal `@Parent` relationships. `Graph<T>` exposes current or historical
+state, parents, descendants, functional and repository identity, previous revisions and staged transitions without
+turning those Models into one persistence boundary. As the sole parameter of an event or notification handler, it is
+also a subscription to durable changes anywhere below that root.
+
 ### Aggregate (legacy)
 
 The Fluxzero 1.x shared-root persistence API. Keep it for existing persisted state only. New code uses `@Model`;

--- a/project-files/java/agents/rules/guidelines.md
+++ b/project-files/java/agents/rules/guidelines.md
@@ -197,12 +197,14 @@ Use this tree to find the correct manual for your current task, ordered by the r
 17. **Domain Errors**: Use Error Interfaces like `ProjectErrors` to group domain-specific exceptions.
 18. **Present-Tense Events**: Don't invent event types. The applied command payload (e.g. `CreateOrder`) is
     automatically reused for the event.
-19. **Entity History**: Fluxzero enables viewing Entity history using `Entity.previous()`. This removes the need for
-    second-class events like `BalanceChanged` after e.g. a `DepositMoney` command to see what changed.
+19. **Model History**: View current Model history through `Graph.previous()`, `revisions()` and
+    `playBackToCondition(...)`. This removes the need for second-class events like `BalanceChanged` after a
+    `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Remember that `sendCommandAndWait` only waits for the primary state change. Use
-    WebSockets or secondary queries to handle eventually consistent side-effects like search index updates.
+21. **The Consistency Window**: Direct searchable Model documents complete with the Model commit. Materialized Graph
+    projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
+    side effects remain eventually consistent.
 22. **Let go of Sequentialism**: Don't try to build long sequential scripts. Let handlers respond to the results of
     messages asynchronously.
 23. **Model IDs**: Use `Fluxzero.generateId(...)` when creating new models or members. Do this in the **endpoint**

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -36,8 +36,8 @@ data through a unified document store, leveraging automatic indexing and a rich 
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
    historical, search is optimized for current data.
-6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Use the `collection`
-   attribute in annotations to override this.
+6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Configure a Model's
+   direct collection through `searchProjection = @Searchable(collection = "...")`.
 7. **Server-side Search Logic**: Keep filtering and sorting in Fluxzero search calls (`match`, `any/all`, `sortBy`,
    etc.). Avoid re-implementing filtering/sorting in client app code.
 
@@ -115,7 +115,7 @@ Access the search engine via `Fluxzero.search(Class<T>)` or by providing a colle
 [//]: # (@formatter:off)
 ```java
 List<Project> results = Fluxzero.search(Project.class)
-    .lookAhead("flux", "name")
+    .lookAhead("flux", "details/name")
     .match("ACTIVE", "status")
     .fetch(10);
 ```
@@ -214,8 +214,8 @@ value before doing more work.
 @HandleQuery
 CompletableFuture<List<Project>> handle(SearchProjects query) {
     return Fluxzero.search(Project.class)
-        .lookAhead(query.term(), "name")
-        .fetchAsync(50, Project.class);
+        .lookAhead(query.term(), "details/name")
+        .fetchAsync(50);
 }
 
 @HandleQuery

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -27,22 +27,26 @@ data class Project(
     val details: ProjectDetails,
     val ownerId: UserId
 )
-
-class ProjectId(value: String) :
-    Id<Project>(value, "project-")
 ```
+
+Assume conventional typed `ProjectId` and `ProjectDetails` value types; do not expand obvious ID or details
+definitions unless the user asks for them.
 
 Important settings:
 
 - `eventSourced`: controls the current-state load route. Events are still stored when `false`.
+- `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
 - `searchable`: maintains an independently searchable synchronous current-state document. `false` suppresses only the
   model's own collection; an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true` still retains the
   private graph-component document needed for composition.
 - `searchProjection`: optional `Searchable` configuration for the direct collection and timestamp paths.
 - `eventPublication`: controls whether unchanged transitions create an event.
-- `publicationStrategy`: `STORE_AND_PUBLISH`, `STORE_ONLY`, `PUBLISH_ONLY` or `NEVER`.
+- `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
+- `checkpointPeriod`: bounds repeated replay work within one reconstruction session.
 - `cached` and `cachingDepth`: current and previous revisions retained in the SDK cache.
+- `conflictPolicy`: `ACCEPT`, `RETRY`, `FAIL` or inherited `DEFAULT` for concurrent writes.
+- `commitPolicy`: controls commit timing and completion-phase concurrency; normally keep `DEFAULT`.
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `GraphProjection` configuration; its collection defaults to the resolved direct
@@ -216,6 +220,9 @@ default cascade ownership. Being displayed below or deleted with the parent does
 - Updating `projectId` moves the task.
 - The parent and siblings do not need to load for a task-only change.
 - Typed `Id<Parent>` supplies the relation type. A role is only needed for untyped/ambiguous IDs.
+- For one polymorphic typed relation, use
+  `@Parent(types = [Project::class, Folder::class], ...) val parentId: Id<*>`; the concrete typed ID selects one
+  statically declared parent type. Use separate properties for distinct relation roles.
 - `pathInParent` is a stable public graph-placement and serialization contract. A pathless relation remains available through
   typed `Graph` traversal and parent-deletion lifecycle handling, but is not emitted as a named JSON graph edge.
 - A child is logically deleted by default when any parent referenced by that `@Parent` is finally deleted. Set
@@ -273,6 +280,7 @@ val project = Fluxzero.loadModel(projectId).get()
 
 val graph: Graph<Project> = Fluxzero.loadGraph(projectId)
 val sameProject = graph.get()
+val publicId = graph.functionalId()
 val tasks = graph.childModels("tasks", Task::class.java)
 val previous = graph.previous()
 ```
@@ -282,6 +290,14 @@ descendants, history or staged updates. Resolving the graph itself costs the sam
 relationships are fetched only when traversed. Typed ancestor lookup follows relationship identities first and loads
 only the selected ancestor value. Every child remains a graph with `parent()`, `root()`, `previous()`,
 `atStateIndex(...)`, `apply(...)` and `assertAndApply(...)`.
+
+`id()` is the collision-safe repository identity; `functionalId()` is the public ID from the current or last present
+model value and omits repository affixes or parent scope. `stateIndex()` pins the complete graph read, while
+`revisionStateIndex()` reports when the selected node revision became current.
+
+Ordinary `loadGraph(...)` calls inside a handler inherit its coherent message or historical event boundary. Use
+`loadCurrentGraph(...)` only after a synchronous nested command when later handler logic deliberately needs that
+command's newer state. Do not use it as the default loading route.
 
 Use `graph.delete()` to stage logical deletion of a selected node; return or explicitly commit that resulting graph
 according to the surrounding handler contract.
@@ -298,6 +314,9 @@ Pathless relations remain queryable through the typed graph API but are absent f
 accepted model values are shared. Annotate
 a model method with `@GraphProperty` when a serialized property is derived from the current graph or a typed ancestor
 graph. It runs only during graph serialization and reuses the graph already in memory.
+For one response-wide lookup that several nodes consume, attach the already-batched result once with
+`graph.withContext(value)` and read it inside the property method with `graph.context(ValueType::class.java)`; graph
+context is immutable, shared across the view and never persisted as Model state.
 
 Use `@Alias` for a current alternative identity of an independently stored model:
 
@@ -334,6 +353,23 @@ without model-commit metadata may inject directly addressed Models at one curren
 linked that global event to a Model commit, the same injection resolves its exact historical state instead. Such an
 event is not implicitly a complete graph-change subscription; that requires the durable Model commit metadata.
 
+## Complete graph-change handlers
+
+Use an unqualified `Graph<T>` as the sole handler parameter to subscribe to every durable change of that root or one
+of its descendants:
+
+```kotlin
+@HandleEvent
+fun projectChanged(graph: Graph<Project>) {
+    val before = graph.previous()
+}
+```
+
+Creation has no previous graph; deletion supplies an empty current graph and the complete deleted graph through
+`previous()`; moving a child invokes both old and new roots. The previous graph is commit-exact and does not depend on
+cache depth. One handler object may declare several such methods for distinct root types. Adding an explicit event
+payload turns the method back into ordinary payload handling with direct/ancestor Graph injection.
+
 ## Search and graph composition
 
 ```kotlin
@@ -346,7 +382,7 @@ val related = Fluxzero.search(Task::class.java)
         Project::class.java,
         MatchConstraint.match("active", "status")
     )
-    .fetchAll(Task::class.java)
+    .fetchAll()
 ```
 
 Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Use
@@ -358,23 +394,33 @@ forced-live nested-path filter when the child type is known. Use
 It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` for explicit raw
 JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Modelsearch. A blank projection
-collection derives from the direct Model collection when searchable, or from the simple root-model name otherwise;
+`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Model search. A blank projection
+collection appends `-graphs` to the direct Model collection when searchable, or to the simple root-model name otherwise;
 explicit lower-level composition limits fail rather than returning a partial graph.
 
-## Conflict and deletion
+## Conflict policy
 
-`ModelConflictPolicy.DEFAULT` resolves from apply/model, builder configuration or application properties:
+Model commits default to `ModelConflictPolicy.DEFAULT`, resolved from apply/model, builder configuration or application
+properties. Public policies are:
 
 - `ACCEPT`: preserve the event once; rebase derived documents and relationships on current merged state.
 - `RETRY`: reload and rerun assertions/interceptors/applies.
 - `FAIL`: return the conflict.
 
-Returning `null` is logical deletion. Parent deletion recursively deletes children whose relevant `@Parent` keeps
-the default `deleteOnParentDeletion = true`, including pathless and shared-DAG descendants. Moving a child away in the
-same atomic commit preserves it. `modelRepository().deleteModel(id, NONE)` physically erases modelstream, direct
-document, snapshots and cache state. Physical descendant erasure still requires an explicit plan. Erasure fences
-prevent delayed writes from resurrecting data.
+If multiple applies request different policies, the stricter applicable policy wins; failure is not weakened by retry.
+
+## Deletion
+
+- Returning `null` from `@Apply` is logical deletion and preserves history.
+- Logical parent deletion recursively deletes children whose relevant `@Parent` keeps the default
+  `deleteOnParentDeletion = true`. This follows pathless relations and shared descendants too; a shared descendant is
+  deleted when any owning parent disappears. Moving a child away in the same atomic commit preserves it.
+- `modelRepository().deleteModel(id, NONE)` physically erases that Model's stream, current document, snapshots and
+  cache state while leaving the global event log untouched.
+- Physical descendant erasure remains a separate destructive operation and requires `planDeletion(...)` followed by
+  confirmation/execution of that exact plan.
+- Erasure fences prevent delayed document, snapshot or projection writes from resurrecting deleted data.
+- Detached descendants remain discoverable through deleted-parent lineage for later GDPR/lifecycle erasure.
 
 ## Testing
 

--- a/project-files/kotlin/agents/rules/fluxzero-fqns-grouped.md
+++ b/project-files/kotlin/agents/rules/fluxzero-fqns-grouped.md
@@ -58,6 +58,7 @@ io.fluxzero.sdk.configuration.DefaultFluxzero
 io.fluxzero.sdk.configuration.DefaultFluxzero.Builder
 io.fluxzero.sdk.configuration.FluxzeroBuilder
 io.fluxzero.sdk.configuration.FluxzeroConfiguration
+io.fluxzero.sdk.configuration.PublishedEventModelMigration
 io.fluxzero.sdk.configuration.client.AbstractClient
 io.fluxzero.sdk.configuration.client.Client
 io.fluxzero.sdk.configuration.client.ClientDispatchMonitor
@@ -88,6 +89,7 @@ io.fluxzero.sdk.modeling.Alias
 io.fluxzero.sdk.modeling.AnnotatedEntityHolder
 io.fluxzero.sdk.modeling.AppliedEvent
 io.fluxzero.sdk.modeling.AssertLegal
+io.fluxzero.sdk.modeling.AutomaticModelHandling
 io.fluxzero.sdk.modeling.BatchingHandlerRepository
 io.fluxzero.sdk.modeling.DefaultEntityHelper
 io.fluxzero.sdk.modeling.DefaultEntityHelper.DeserializingMessageWithEntity
@@ -100,6 +102,11 @@ io.fluxzero.sdk.modeling.EntityId
 io.fluxzero.sdk.modeling.EntityParameterResolver
 io.fluxzero.sdk.modeling.EventPublication
 io.fluxzero.sdk.modeling.EventPublicationStrategy
+io.fluxzero.sdk.modeling.Graph<T>
+io.fluxzero.sdk.modeling.GraphLookupPolicy
+io.fluxzero.sdk.modeling.GraphProjection
+io.fluxzero.sdk.modeling.GraphProjectionCompletion
+io.fluxzero.sdk.modeling.GraphProperty
 io.fluxzero.sdk.modeling.HandlerRepository
 io.fluxzero.sdk.modeling.HasEntity
 io.fluxzero.sdk.modeling.Id<T>
@@ -107,10 +114,13 @@ io.fluxzero.sdk.modeling.ImmutableAggregateRoot<T>
 io.fluxzero.sdk.modeling.ImmutableEntity<T>
 io.fluxzero.sdk.modeling.LazyAggregateRoot<T>
 io.fluxzero.sdk.modeling.Member
+io.fluxzero.sdk.modeling.Model
+io.fluxzero.sdk.modeling.ModelCommitPolicy
 io.fluxzero.sdk.modeling.ModifiableAggregateRoot.CommitHandler
 io.fluxzero.sdk.modeling.ModifiableAggregateRoot<T>
 io.fluxzero.sdk.modeling.ModifiableEntity<T>
 io.fluxzero.sdk.modeling.NoOpEntity<T>
+io.fluxzero.sdk.modeling.Parent
 io.fluxzero.sdk.modeling.SearchParameters
 io.fluxzero.sdk.modeling.SideEffectFreeEntity<T>
 io.fluxzero.common.caching.AdaptiveObjectCache
@@ -149,6 +159,7 @@ io.fluxzero.sdk.persisting.keyvalue.client.WebsocketKeyValueClient
 io.fluxzero.sdk.persisting.repository.AggregateRepository
 io.fluxzero.sdk.persisting.repository.CachingAggregateRepository
 io.fluxzero.sdk.persisting.repository.DefaultAggregateRepository
+io.fluxzero.sdk.persisting.repository.ModelRepository
 io.fluxzero.sdk.persisting.search.DefaultDocumentStore
 io.fluxzero.sdk.persisting.search.DefaultIndexOperation
 io.fluxzero.sdk.persisting.search.DocumentSerializer
@@ -156,7 +167,7 @@ io.fluxzero.sdk.persisting.search.DocumentStore
 io.fluxzero.sdk.persisting.search.DocumentStoreException
 io.fluxzero.sdk.persisting.search.GroupSearch
 io.fluxzero.sdk.persisting.search.IndexOperation
-io.fluxzero.sdk.persisting.search.Search
+io.fluxzero.sdk.persisting.search.Search<R>
 io.fluxzero.sdk.persisting.search.SearchHit<T>
 io.fluxzero.sdk.persisting.search.Searchable
 io.fluxzero.sdk.persisting.search.client.CollectionMessageStore
@@ -461,6 +472,10 @@ io.fluxzero.common.api.modeling.GetAggregateIds
 io.fluxzero.common.api.modeling.GetAggregateIdsResult
 io.fluxzero.common.api.modeling.GetRelationships
 io.fluxzero.common.api.modeling.GetRelationshipsResult
+io.fluxzero.common.api.modeling.ModelConflictPolicy
+io.fluxzero.common.api.modeling.ModelDeletionCascade
+io.fluxzero.common.api.modeling.ModelDeletionPlan
+io.fluxzero.common.api.modeling.ModelDeletionResult
 io.fluxzero.common.api.modeling.Relationship
 io.fluxzero.common.api.modeling.RepairRelationships
 io.fluxzero.common.api.modeling.UpdateRelationships

--- a/project-files/kotlin/agents/rules/glossary.md
+++ b/project-files/kotlin/agents/rules/glossary.md
@@ -12,6 +12,13 @@ and current-document consequences. A meaningful domain identity is strong eviden
 child-only identity can be parent-scoped. Related independent models form dynamic action boundaries and a temporal
 graph through `@Parent`.
 
+### Graph
+
+A typed, lazy view around one Model and its temporal `@Parent` relationships. `Graph<T>` exposes current or historical
+state, parents, descendants, functional and repository identity, previous revisions and staged transitions without
+turning those Models into one persistence boundary. As the sole parameter of an event or notification handler, it is
+also a subscription to durable changes anywhere below that root.
+
 ### Aggregate (legacy)
 
 The Fluxzero 1.x shared-root persistence API. Keep it for existing persisted state only. New code uses `@Model`;

--- a/project-files/kotlin/agents/rules/guidelines.md
+++ b/project-files/kotlin/agents/rules/guidelines.md
@@ -197,12 +197,14 @@ Use this tree to find the correct manual for your current task, ordered by the r
 17. **Domain Errors**: Use Error Interfaces like `ProjectErrors` (singleton objects) to group domain-specific exceptions.
 18. **Present-Tense Events**: Don't invent event types. The applied command payload (e.g. `CreateOrder`) is
     automatically reused for the event.
-19. **Entity History**: Fluxzero enables viewing Entity history using `Entity.previous()`. This removes the need for
-    second-class events like `BalanceChanged` after e.g. a `DepositMoney` command to see what changed.
+19. **Model History**: View current Model history through `Graph.previous()`, `revisions()` and
+    `playBackToCondition(...)`. This removes the need for second-class events like `BalanceChanged` after a
+    `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Remember that `sendCommandAndWait` only waits for the primary state change. Use
-    WebSockets or secondary queries to handle eventually consistent side-effects like search index updates.
+21. **The Consistency Window**: Direct searchable Model documents complete with the Model commit. Materialized Graph
+    projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
+    side effects remain eventually consistent.
 22. **Let go of Sequentialism**: Don't try to build long sequential scripts. Let handlers respond to the results of
     messages asynchronously.
 23. **Model IDs**: Use `Fluxzero.generateId(...)` when creating new models or members. Do this in the **endpoint**
@@ -270,7 +272,7 @@ If a pattern is not documented, ask the user for clarification rather than guess
 ## Kotlin Specific Guidelines
 
 - **Use `::class`**: In Kotlin applications, you can use `::class` directly instead of `::class.java` when referencing
-  types in SDK methods (e.g., in `Fluxzero.generateId(ProjectId::class)` or
+  types in SDK methods (e.g., in `Fluxzero.generateId(ProjectId::class.java)` or
   `@HandleDocument(documentClass = OrderDocument::class)`).
 - **Data Classes**: Use `data class` for all payloads (Commands, Queries, Events) and Entities to benefit from
   automatic `copy()`, `equals()`, and `hashCode()` implementations.

--- a/project-files/kotlin/agents/rules/handling.md
+++ b/project-files/kotlin/agents/rules/handling.md
@@ -477,7 +477,7 @@ class ProjectsEndpoint {
 class ProjectsEndpoint {
     @HandlePost
     fun createProject(details: ProjectDetails): ProjectId {
-        val id = Fluxzero.generateId(ProjectId::class)
+        val id = Fluxzero.generateId(ProjectId::class.java)
         Fluxzero.sendCommandAndWait(CreateProject(id, details))
         return id
     }
@@ -826,7 +826,7 @@ class ProjectId(id: String) : Id<Project>(id)
 ```
 [//]: # (@formatter:on)
 
-**Important**: Always use `Fluxzero.generateId(ProjectId::class)` to create new IDs.
+**Important**: Always use `Fluxzero.generateId(ProjectId::class.java)` to create new IDs.
 
 ---
 

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -36,8 +36,8 @@ data through a unified document store, leveraging automatic indexing and a rich 
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
    historical, search is optimized for current data.
-6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Use the `collection`
-   attribute in annotations to override this.
+6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Configure a Model's
+   direct collection through `searchProjection = Searchable(collection = "...")`.
 7. **Server-side Search Logic**: Keep filtering and sorting in Fluxzero search calls (`match`, `any/all`, `sortBy`,
    etc.). Avoid re-implementing filtering/sorting in client app code.
 
@@ -99,7 +99,7 @@ For response shaping, prefer search projections instead of post-processing in ap
 
 ## Searching for Data
 
-Access the search engine via `Fluxzero.search(Project::class)` or by providing a collection name.
+Access the search engine via `Fluxzero.search(Project::class.java)` or by providing a collection name.
 
 <a name="basic-constraints"></a>
 
@@ -110,8 +110,8 @@ Access the search engine via `Fluxzero.search(Project::class)` or by providing a
 - **query(text, paths...)**: Full-text search with support for wildcards and operators (`*`, `&`, `|`).
 
 ```kotlin
-val results: List<Project> = Fluxzero.search(Project::class)
-    .lookAhead("flux", "name")
+val results: List<Project> = Fluxzero.search(Project::class.java)
+    .lookAhead("flux", "details/name")
     .match("ACTIVE", "status")
     .fetch(10)
 ```
@@ -147,7 +147,7 @@ Filter documents based on their creation or modification time.
 - **inLast(duration)** / **beforeLast(duration)**: Relative time ranges.
 
 ```kotlin
-val recent: List<Project> = Fluxzero.search(Project::class)
+val recent: List<Project> = Fluxzero.search(Project::class.java)
     .inLast(Duration.ofDays(7))
     .fetchAll()
 ```
@@ -159,7 +159,7 @@ val recent: List<Project> = Fluxzero.search(Project::class)
 Combine multiple constraints using logical operations.
 
 ```kotlin
-val complex: List<User> = Fluxzero.search(User::class)
+val complex: List<User> = Fluxzero.search(User::class.java)
     .any(
         MatchConstraint.match("ADMIN", "role"),
         AllConstraint.all(
@@ -203,8 +203,8 @@ value before doing more work.
 @HandleQuery
 fun handle(query: SearchProjects): CompletableFuture<List<Project>> =
     Fluxzero.search(Project::class.java)
-        .lookAhead(query.term, "name")
-        .fetchAsync(50, Project::class.java)
+        .lookAhead(query.term, "details/name")
+        .fetchAsync(50)
 
 @HandleQuery
 fun handle(query: ProjectFacetQuery): CompletableFuture<List<FacetStats>> =
@@ -267,7 +267,7 @@ Retrieve document counts grouped by their facet values. This is ideal for buildi
 sidebars.
 
 ```kotlin
-val stats: List<FacetStats> = Fluxzero.search(Product::class)
+val stats: List<FacetStats> = Fluxzero.search(Product::class.java)
     .lookAhead("wireless")
     .facetStats()
 ```

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/client/LocalClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/client/LocalClient.java
@@ -39,6 +39,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 
+import static io.fluxzero.common.tracking.DefaultTrackingStrategy.DEFAULT_INITIAL_POSITION_LAG;
+
 /**
  * An in-memory {@link Client} implementation used for local development, testing, or isolated environments where no
  * connection to the Fluxzero Runtime is required.
@@ -75,6 +77,8 @@ public class LocalClient extends AbstractClient {
 
     @Getter
     private final Duration messageExpiration;
+    @Getter
+    private final Duration initialPositionLag;
     private final LocalEventStoreClient eventStore;
     private final LocalSchedulingClient scheduleStore;
     private Clock clock;
@@ -98,15 +102,36 @@ public class LocalClient extends AbstractClient {
         return new LocalClient(messageExpiration);
     }
 
+    /**
+     * Creates a local client with configurable message retention and initial look-back for new consumers.
+     *
+     * @param messageExpiration  retention duration for local messages
+     * @param initialPositionLag duration subtracted from the current time for consumers without a stored position
+     * @return a new local client
+     */
+    public static LocalClient newInstance(Duration messageExpiration, Duration initialPositionLag) {
+        return new LocalClient(messageExpiration, initialPositionLag);
+    }
+
     protected LocalClient(Duration messageExpiration) {
-        this(messageExpiration, "public", null, null);
+        this(messageExpiration, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    protected LocalClient(Duration messageExpiration, Duration initialPositionLag) {
+        this(messageExpiration, initialPositionLag, "public", null, null);
     }
 
     protected LocalClient(Duration messageExpiration, String namespace, LocalClient applicationClient, Clock clock) {
+        this(messageExpiration, DEFAULT_INITIAL_POSITION_LAG, namespace, applicationClient, clock);
+    }
+
+    protected LocalClient(Duration messageExpiration, Duration initialPositionLag, String namespace,
+                          LocalClient applicationClient, Clock clock) {
         this.messageExpiration = messageExpiration;
-        this.eventStore = new LocalEventStoreClient(messageExpiration);
-        this.scheduleStore = clock == null ? new LocalSchedulingClient(messageExpiration)
-                : new LocalSchedulingClient(messageExpiration, clock);
+        this.initialPositionLag = initialPositionLag;
+        this.eventStore = new LocalEventStoreClient(messageExpiration, initialPositionLag);
+        this.scheduleStore = clock == null ? new LocalSchedulingClient(messageExpiration, initialPositionLag)
+                : new LocalSchedulingClient(messageExpiration, clock, initialPositionLag);
         this.clock = clock;
         this.namespace = namespace;
         this.applicationClient = applicationClient;
@@ -144,15 +169,17 @@ public class LocalClient extends AbstractClient {
             case NOTIFICATION, EVENT -> eventStore;
             case SCHEDULE -> scheduleStore;
             case DOCUMENT -> new LocalTrackingClient(new CollectionMessageStore((InMemorySearchStore) getSearchClient(),
-                                                                                topic), MessageType.DOCUMENT, topic);
-            default -> new LocalTrackingClient(messageType, topic, messageExpiration);
+                                                                                topic), MessageType.DOCUMENT, topic,
+                                                     initialPositionLag);
+            default -> new LocalTrackingClient(messageType, topic, messageExpiration, initialPositionLag);
         };
     }
 
     @Override
     protected TrackingClient createTrackingClient(MessageType messageType, String topic) {
         if (messageType == MessageType.NOTIFICATION) {
-            return new LocalTrackingClient(eventStore.getMessageStore(), MessageType.NOTIFICATION);
+            return new LocalTrackingClient(eventStore.getMessageStore(), MessageType.NOTIFICATION, null,
+                                           initialPositionLag);
         }
         return (TrackingClient) getGatewayClient(messageType, topic);
     }
@@ -189,6 +216,7 @@ public class LocalClient extends AbstractClient {
         if (namespace == null) {
             return this;
         }
-        return registerNamespaceClient(new LocalClient(getMessageExpiration(), namespace, this, clock));
+        return registerNamespaceClient(new LocalClient(getMessageExpiration(), getInitialPositionLag(), namespace,
+                                                       this, clock));
     }
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EventPublication.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EventPublication.java
@@ -52,7 +52,8 @@ public enum EventPublication {
     /**
      * Never publish or store applied updates.
      * <p>
-     * Useful for aggregates where event sourcing is disabled or updates should remain private.
+     * Useful for document-backed models or aggregates when the state change deliberately has no stored or published
+     * event. Event-sourced state-changing updates reject this value because they could not be reconstructed later.
      */
     NEVER,
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EventPublicationStrategy.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EventPublicationStrategy.java
@@ -18,48 +18,49 @@ import io.fluxzero.sdk.persisting.eventsourcing.Apply;
 
 /**
  * Strategy for controlling how applied updates (typically from {@link Apply @Apply} methods)
- * are handled in terms of event storage, event publication, and aggregate state updates.
+ * are handled in terms of event storage, event publication, and model or aggregate state updates.
  * <p>
- * This strategy determines whether an update is published to the global event log, stored in the aggregate event store,
- * and whether its apply result should advance the aggregate state in cache, snapshots, relationships, and search
- * indexing.
- * It can be configured at the aggregate level, or overridden per update.
+ * This strategy determines whether an update is published to the global event log, linked to the target model streams
+ * or legacy aggregate event store, and whether its apply result may advance document-backed state. It can be
+ * configured on a {@link Model}, a legacy {@link Aggregate}, or an individual update.
  *
  * @see Apply
+ * @see Model
  * @see Aggregate
  * @see EventPublication
  */
 public enum EventPublicationStrategy {
 
     /**
-     * Inherit the strategy from the enclosing aggregate or global default.
+     * Inherit the strategy from the enclosing model, legacy aggregate, or global default.
      * <p>
      * If not configured anywhere, the fallback is {@link #STORE_AND_PUBLISH}.
      */
     DEFAULT,
 
     /**
-     * Store the applied update in the aggregate event store, publish it to the global event log, and update aggregate
-     * state.
+     * Store the applied update in every targeted model stream or the legacy aggregate event store, publish it to the
+     * global event log, and advance the resulting state.
      * <p>
-     * This is the default behavior used for event-sourced aggregates.
+     * This is the default behavior used for event-sourced models and aggregates.
      */
     STORE_AND_PUBLISH,
 
     /**
-     * Store the applied update in the aggregate event store and update aggregate state, but do not publish it to the
-     * global event log.
+     * Store the applied update in every targeted model stream or the legacy aggregate event store and advance state,
+     * but do not publish it to the global event log.
      * <p>
      * Useful when updates must be persisted but should not trigger side effects or listeners.
      */
     STORE_ONLY,
 
     /**
-     * Publish the update to the global event log but do not store it in the aggregate event store.
+     * Publish the update to the global event log but do not store it in the target model stream or legacy aggregate
+     * event store.
      * <p>
-     * This disables event sourcing for the update. On event-sourced aggregates, the apply result does not advance
-     * aggregate state in cache, snapshots, or search indexing because replay would not be able to reconstruct it. On
-     * non-event-sourced, document-backed aggregates, the apply result still updates aggregate/search state.
+     * A state-changing event-sourced Model rejects this strategy before commit because its next reconstruction could
+     * not reproduce the state. A publish-only no-op remains valid. Document-backed Models and non-event-sourced legacy
+     * aggregates may still advance their directly stored current state.
      */
     PUBLISH_ONLY
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphProperty.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphProperty.java
@@ -27,7 +27,9 @@ import java.lang.annotation.Target;
  *
  * <p>The annotated instance method must return a value and accept one or more {@code Graph<T>} parameters. A parameter
  * may select the current model graph or one of its typed ancestors. The method is not invoked when the model value is
- * serialized by itself, and resolving its parameters reuses the graph that is already being serialized.</p>
+ * serialized by itself, and resolving its parameters reuses the graph that is already being serialized. Response-wide
+ * values attached through {@link Graph#withContext(Object...)} are available through
+ * {@link Graph#context(Class)} and never become persisted model state.</p>
  */
 @Documented
 @Target(ElementType.METHOD)

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/LocalEventStoreClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/LocalEventStoreClient.java
@@ -32,6 +32,16 @@ public class LocalEventStoreClient extends LocalTrackingClient implements EventS
         super(new InMemoryEventStore(messageExpiration), MessageType.EVENT);
     }
 
+    /**
+     * Creates a local event store with a configurable look-back for consumers without a stored position.
+     *
+     * @param messageExpiration  retention duration for local events
+     * @param initialPositionLag duration subtracted from the current time for a new consumer
+     */
+    public LocalEventStoreClient(Duration messageExpiration, Duration initialPositionLag) {
+        super(new InMemoryEventStore(messageExpiration), MessageType.EVENT, null, initialPositionLag);
+    }
+
     @Override
     @Delegate
     public InMemoryEventStore getMessageStore() {

--- a/sdk/src/main/java/io/fluxzero/sdk/scheduling/client/LocalSchedulingClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/scheduling/client/LocalSchedulingClient.java
@@ -33,8 +33,29 @@ public class LocalSchedulingClient extends LocalTrackingClient implements Schedu
         super(new InMemoryScheduleStore(messageExpiration), MessageType.SCHEDULE);
     }
 
+    /**
+     * Creates a local scheduling client with a configurable look-back for consumers without a stored position.
+     *
+     * @param messageExpiration  retention duration for local schedules
+     * @param initialPositionLag duration subtracted from the current time for a new consumer
+     */
+    public LocalSchedulingClient(Duration messageExpiration, Duration initialPositionLag) {
+        super(new InMemoryScheduleStore(messageExpiration), MessageType.SCHEDULE, null, initialPositionLag);
+    }
+
     public LocalSchedulingClient(Duration messageExpiration, Clock clock) {
         super(new InMemoryScheduleStore(messageExpiration, clock), MessageType.SCHEDULE);
+    }
+
+    /**
+     * Creates a clock-controlled local scheduling client with a configurable initial look-back.
+     *
+     * @param messageExpiration  retention duration for local schedules
+     * @param clock              clock used by the schedule store
+     * @param initialPositionLag duration subtracted from the current time for a new consumer
+     */
+    public LocalSchedulingClient(Duration messageExpiration, Clock clock, Duration initialPositionLag) {
+        super(new InMemoryScheduleStore(messageExpiration, clock), MessageType.SCHEDULE, null, initialPositionLag);
     }
 
     public void setClock(Clock clock) {

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/client/LocalTrackingClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/client/LocalTrackingClient.java
@@ -32,7 +32,6 @@ import io.fluxzero.common.tracking.TrackingStrategy;
 import io.fluxzero.common.tracking.WebSocketTracker;
 import io.fluxzero.sdk.publishing.client.GatewayClient;
 import io.fluxzero.sdk.tracking.ConsumerConfiguration;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.lang.management.ManagementFactory;
@@ -41,6 +40,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+
+import static io.fluxzero.common.tracking.DefaultTrackingStrategy.DEFAULT_INITIAL_POSITION_LAG;
 
 /**
  * In-memory implementation of the {@link TrackingClient} and {@link GatewayClient} interfaces, designed for
@@ -80,7 +81,6 @@ import java.util.function.Consumer;
  * @see InMemoryMessageStore
  * @see InMemoryPositionStore
  */
-@AllArgsConstructor
 public class LocalTrackingClient implements TrackingClient, GatewayClient, HasMessageStore {
     private static final String LOCAL_CLIENT_ID = ManagementFactory.getRuntimeMXBean().getName();
 
@@ -92,18 +92,60 @@ public class LocalTrackingClient implements TrackingClient, GatewayClient, HasMe
     private final MessageType messageType;
     @Getter
     private final String topic;
+    private final Duration initialPositionLag;
 
     @Getter(lazy = true)
-    private final TrackingStrategy trackingStrategy = new DefaultTrackingStrategy(messageStore, positionStore);
+    private final TrackingStrategy trackingStrategy =
+            new DefaultTrackingStrategy(messageStore, positionStore, initialPositionLag);
     @Getter(lazy = true)
     private final MessageLogMaintenance messageLogMaintenance =
             new MessageLogMaintenance(messageStore, positionStore, getTrackingStrategy());
 
+    /**
+     * Creates a local tracking client from explicit storage components using the default initial look-back.
+     */
+    public LocalTrackingClient(MessageStore messageStore, PositionStore positionStore, MessageType messageType,
+                               String topic) {
+        this(messageStore, positionStore, messageType, topic, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    /**
+     * Creates a local tracking client from explicit storage components.
+     *
+     * @param messageStore       local message store
+     * @param positionStore      local consumer position store
+     * @param messageType        message log type
+     * @param topic              optional message topic
+     * @param initialPositionLag duration subtracted from the current time for a new consumer
+     */
+    public LocalTrackingClient(MessageStore messageStore, PositionStore positionStore, MessageType messageType,
+                               String topic, Duration initialPositionLag) {
+        this.messageStore = messageStore;
+        this.positionStore = positionStore;
+        this.messageType = messageType;
+        this.topic = topic;
+        this.initialPositionLag = validateInitialPositionLag(initialPositionLag);
+    }
+
     public LocalTrackingClient(MessageType messageType, String topic, Duration messageExpiration) {
+        this(messageType, topic, messageExpiration, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    /**
+     * Creates a local tracking client with a configurable look-back for consumers without a stored position.
+     *
+     * @param messageType         message log type
+     * @param topic               optional message topic
+     * @param messageExpiration   retention duration for local messages
+     * @param initialPositionLag  duration subtracted from the current time for a new consumer
+     */
+    public LocalTrackingClient(MessageType messageType, String topic, Duration messageExpiration,
+                               Duration initialPositionLag) {
         this.messageStore = new InMemoryMessageStore(messageType, messageExpiration);
         this.positionStore = new InMemoryPositionStore();
         this.messageType = messageType;
         this.topic = topic;
+        this.initialPositionLag = validateInitialPositionLag(initialPositionLag);
     }
 
     public LocalTrackingClient(MessageStore messageStore, MessageType messageType) {
@@ -111,10 +153,31 @@ public class LocalTrackingClient implements TrackingClient, GatewayClient, HasMe
     }
 
     public LocalTrackingClient(MessageStore messageStore, MessageType messageType, String topic) {
+        this(messageStore, messageType, topic, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    /**
+     * Creates a local tracking client over an existing message store with a configurable initial look-back.
+     *
+     * @param messageStore        local message store
+     * @param messageType         message log type
+     * @param topic               optional message topic
+     * @param initialPositionLag  duration subtracted from the current time for a new consumer
+     */
+    public LocalTrackingClient(MessageStore messageStore, MessageType messageType, String topic,
+                               Duration initialPositionLag) {
         this.messageStore = messageStore;
         this.messageType = messageType;
         this.topic = topic;
         this.positionStore = new InMemoryPositionStore();
+        this.initialPositionLag = validateInitialPositionLag(initialPositionLag);
+    }
+
+    private static Duration validateInitialPositionLag(Duration initialPositionLag) {
+        if (initialPositionLag == null || initialPositionLag.isNegative()) {
+            throw new IllegalArgumentException("initialPositionLag must be non-negative");
+        }
+        return initialPositionLag;
     }
 
     @Override

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/client/LocalTrackingClientTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/client/LocalTrackingClientTest.java
@@ -36,15 +36,37 @@ import static io.fluxzero.common.Guarantee.STORED;
 import static io.fluxzero.common.MessageType.CUSTOM;
 import static io.fluxzero.common.MessageType.EVENT;
 import static io.fluxzero.common.api.tracking.SegmentRange.MAX_SEGMENT;
+import static io.fluxzero.sdk.tracking.IndexUtils.indexFromTimestamp;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LocalTrackingClientTest {
 
     private static final int[] FULL_SEGMENT = new int[]{0, MAX_SEGMENT};
+
+    @Test
+    void configuredInitialPositionLagIncludesRecentMessagesForNewConsumer() {
+        try (LocalTrackingClient client = new LocalTrackingClient(
+                CUSTOM, "lagged", Duration.ofMinutes(5), Duration.ofSeconds(10))) {
+            SerializedMessage earlierMessage = message("earlier");
+            earlierMessage.setIndex(indexFromTimestamp(Instant.now().minusSeconds(5)));
+            client.append(STORED, earlierMessage).join();
+
+            assertEquals(1, read(client, "new-consumer").getSize());
+        }
+    }
+
+    @Test
+    void rejectsInvalidInitialPositionLagImmediately() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> new LocalTrackingClient(CUSTOM, null, Duration.ofMinutes(5), Duration.ofSeconds(-1)));
+        assertThrows(IllegalArgumentException.class,
+                     () -> new LocalTrackingClient(CUSTOM, null, Duration.ofMinutes(5), null));
+    }
 
     @Test
     @Timeout(10)

--- a/test-server/src/main/java/io/fluxzero/testserver/TestServer.java
+++ b/test-server/src/main/java/io/fluxzero/testserver/TestServer.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.component.LifeCycle;
 
+import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.List;
@@ -77,9 +78,11 @@ import static io.fluxzero.common.ServicePathBuilder.keyValuePath;
 import static io.fluxzero.common.ServicePathBuilder.schedulingPath;
 import static io.fluxzero.common.ServicePathBuilder.searchPath;
 import static io.fluxzero.common.ServicePathBuilder.trackingPath;
-import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
 import static io.fluxzero.common.api.RuntimeLifecycleEvent.Phase.STARTED;
 import static io.fluxzero.common.api.RuntimeLifecycleEvent.Phase.STOPPING;
+import static io.fluxzero.common.tracking.DefaultTrackingStrategy.DEFAULT_INITIAL_POSITION_LAG;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.mapProperty;
 import static io.fluxzero.testserver.websocket.WebsocketDeploymentUtils.deploy;
 import static io.fluxzero.testserver.websocket.WebsocketDeploymentUtils.deployFromSession;
 import static io.fluxzero.testserver.websocket.WebsocketDeploymentUtils.getNamespace;
@@ -94,7 +97,7 @@ public class TestServer {
     private static final String DEFAULT_NAMESPACE = "public";
     private static final String RUNTIME_NAME = "FluxzeroTestServer";
 
-    private static volatile ServerState latestState = new ServerState();
+    private static volatile ServerState latestState = new ServerState(DEFAULT_INITIAL_POSITION_LAG);
 
     /**
      * Standalone process entry point.
@@ -139,20 +142,37 @@ public class TestServer {
      * @return the started Jetty server
      */
     public static Server startServer(int port) {
-        return startServer(port, false, ignored -> {});
+        return startServer(port, DEFAULT_INITIAL_POSITION_LAG);
+    }
+
+    /**
+     * Starts an embedded test server with a configurable look-back for consumers without a stored position.
+     *
+     * <p>The default overload starts new consumers one second before the current end of their log. A larger duration
+     * can be useful in local development when a command may be appended shortly before its first matching consumer is
+     * registered. Existing stored consumer positions are unaffected. The returned Jetty server is owned by the caller
+     * and should be stopped by the caller.</p>
+     *
+     * @param port               the port to bind, or {@code 0} to select a random available port
+     * @param initialPositionLag duration subtracted from the current time for consumers without a stored position
+     * @return the started Jetty server
+     */
+    public static Server startServer(int port, Duration initialPositionLag) {
+        return startServer(port, false, ignored -> {}, initialPositionLag);
     }
 
     static Server startServer(int port, Consumer<WebSocketTracker> readRequestObserver) {
-        return startServer(port, false, readRequestObserver);
+        return startServer(port, false, readRequestObserver, DEFAULT_INITIAL_POSITION_LAG);
     }
 
     private static Server startServer(int port, boolean registerShutdownHook) {
-        return startServer(port, registerShutdownHook, ignored -> {});
+        return startServer(port, registerShutdownHook, ignored -> {}, DEFAULT_INITIAL_POSITION_LAG);
     }
 
     private static Server startServer(int port, boolean registerShutdownHook,
-                                      Consumer<WebSocketTracker> readRequestObserver) {
-        ServerState state = new ServerState();
+                                      Consumer<WebSocketTracker> readRequestObserver,
+                                      Duration initialPositionLag) {
+        ServerState state = new ServerState(initialPositionLag);
         latestState = state;
         JettyWebsocketRouter router = new JettyWebsocketRouter();
         CommandIdempotencyStore commandIdempotencyStore = new CommandIdempotencyStore();
@@ -164,13 +184,13 @@ public class TestServer {
                                                 runtimeLifecycleMetrics.metricsLog(namespace)),
                             format("/%s/", gatewayPath(messageType)), router);
             router = deploy(namespace -> new ConsumerEndpoint(state.getMessageLogMaintenance(namespace, messageType), messageType,
-                                                              commandIdempotencyStore)
+                                                              null, commandIdempotencyStore, readRequestObserver)
                                     .metricsLog(messageType == METRICS ? new NoOpMetricsLog() :
                                                 runtimeLifecycleMetrics.metricsLog(namespace)),
                             format("/%s/", trackingPath(messageType)), router);
         }
         router = deploy(namespace -> new ConsumerEndpoint(state.getMessageLogMaintenance(namespace, NOTIFICATION), NOTIFICATION,
-                                                          commandIdempotencyStore)
+                                                          null, commandIdempotencyStore, readRequestObserver)
                                 .metricsLog(runtimeLifecycleMetrics.metricsLog(namespace)),
                         format("/%s/", trackingPath(NOTIFICATION)), router);
 
@@ -312,10 +332,17 @@ public class TestServer {
     }
 
     private static class ServerState {
-        private final MemoizingFunction<String, Client> clients = memoize(
-                namespace -> new TestServerProject(LocalClient.newInstance()));
-        private final MemoizingFunction<String, MetricsLog> metricsLogSupplier = memoize(
-                namespace -> new DefaultMetricsLog(getMessageStore(namespace, METRICS)));
+        private final MemoizingFunction<String, Client> clients;
+        private final MemoizingFunction<String, MetricsLog> metricsLogSupplier;
+
+        private ServerState(Duration initialPositionLag) {
+            Duration messageExpiration = mapProperty(
+                    "FLUXZERO_LOG_RETENTION", Duration::parse, () -> Duration.ofMinutes(2));
+            clients = memoize(namespace -> new TestServerProject(
+                    LocalClient.newInstance(messageExpiration, initialPositionLag)));
+            metricsLogSupplier = memoize(
+                    namespace -> new DefaultMetricsLog(getMessageStore(namespace, METRICS)));
+        }
 
         private Client client(String namespace) {
             return clients.apply(namespace);


### PR DESCRIPTION
## Summary

- align the human guides, public Javadocs, README, and Java/Kotlin agent manuals with the current Model, Graph, Search, relationship, materialization, and migration APIs
- merge the current SDK `main` into the 2.0 line
- retain the 2.0 JFR tracking instrumentation while adding the configurable initial consumer look-back required by the Dev Server

## Compatibility

Existing embedded Test Server and local-client entry points keep the one-second look-back. The new duration overload allows local tooling to choose a wider startup window without changing stored consumer positions.

This prepares SDK `2.0.0-RC2`; stable release and documentation channels remain untouched.