### PR TITLE
perf(search): avoid quadratic monitored document indexing

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
@@ -67,6 +67,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -126,7 +127,7 @@ public class InMemorySearchStore implements SearchClient {
             new ConcurrentHashMap<>();
 
     private final AtomicLong nextIndex = new AtomicLong();
-    private final Map<String, ConcurrentSkipListMap<Long, SerializedMessage>> messageLogs = new ConcurrentHashMap<>();
+    private final Map<String, DocumentUpdateLog> messageLogs = new ConcurrentHashMap<>();
     private final List<BiConsumer<String, List<SerializedMessage>>> monitors = new CopyOnWriteArrayList<>();
     private final Set<String> collections = ConcurrentHashMap.newKeySet();
     private final Set<String> auditTrails = ConcurrentHashMap.newKeySet();
@@ -1155,7 +1156,7 @@ public class InMemorySearchStore implements SearchClient {
             return Stream.empty();
         }
         lastIndex = lastIndex == null ? -1L : lastIndex;
-        return map.tailMap(lastIndex, false).values().stream()
+        return map.openStream(lastIndex)
                 .filter(message -> includeDocumentTombstones
                         || message.getMetadata().get(
                                 ModelGraphDocumentManifest.TOMBSTONE_METADATA_KEY) == null)
@@ -1225,19 +1226,16 @@ public class InMemorySearchStore implements SearchClient {
     }
 
     private void storeMessagesInLog(String collection, List<SerializedMessage> messages) {
-        var log = messageLogs.computeIfAbsent(collection, c -> new ConcurrentSkipListMap<>());
-        messages.forEach(message -> {
-            log.values().removeIf(old -> old.getMessageId().equals(message.getMessageId()));
-            log.put(message.getIndex(), message);
-        });
+        assert Thread.holdsLock(this);
+        messageLogs.computeIfAbsent(collection, ignored -> new DocumentUpdateLog())
+                .store(messages);
     }
 
     private boolean hasGraphTombstone(String collection, String rootId) {
         var log = messageLogs.get(collection);
-        return log != null && log.values().stream().anyMatch(
-                message -> Objects.equals(rootId, message.getMessageId())
-                           && message.getMetadata().get(
-                                   ModelGraphDocumentManifest.TOMBSTONE_METADATA_KEY) != null);
+        SerializedMessage latest = log == null ? null : log.latest(rootId);
+        return latest != null && latest.getMetadata().get(
+                ModelGraphDocumentManifest.TOMBSTONE_METADATA_KEY) != null;
     }
 
     private SerializedMessage asGraphTombstone(
@@ -1281,9 +1279,15 @@ public class InMemorySearchStore implements SearchClient {
     }
 
     protected void purgeExpiredMessages(Duration messageExpiration) {
-        var threshold = Fluxzero.currentTime().minus(messageExpiration).toEpochMilli();
-        messageLogs.values().forEach(messageLog -> messageLog.headMap(
-                IndexUtils.maxIndexFromMillis(threshold), true).clear());
+        synchronized (this) {
+            var threshold = Fluxzero.currentTime().minus(messageExpiration).toEpochMilli();
+            long maximumIndex = IndexUtils.maxIndexFromMillis(threshold);
+            messageLogs.entrySet().removeIf(entry -> {
+                DocumentUpdateLog messageLog = entry.getValue();
+                messageLog.purgeThrough(maximumIndex);
+                return messageLog.isEmpty();
+            });
+        }
     }
 
     protected void notifyMonitors(String collection, List<SerializedMessage> messages) {
@@ -1313,5 +1317,60 @@ public class InMemorySearchStore implements SearchClient {
 
     @Override
     public void close() {
+    }
+
+    static final class DocumentUpdateLog {
+        private final ConcurrentSkipListMap<Long, SerializedMessage> messagesByIndex =
+                new ConcurrentSkipListMap<>();
+        private final Map<String, Long> indexByMessageId = new HashMap<>();
+
+        synchronized void store(List<SerializedMessage> messages) {
+            messages.forEach(message -> {
+                Long previousIndex = indexByMessageId.get(message.getMessageId());
+                if (previousIndex != null) {
+                    remove(previousIndex);
+                }
+                SerializedMessage displaced = messagesByIndex.put(message.getIndex(), message);
+                if (displaced != null) {
+                    indexByMessageId.remove(displaced.getMessageId(), message.getIndex());
+                }
+                indexByMessageId.put(message.getMessageId(), message.getIndex());
+            });
+        }
+
+        Stream<SerializedMessage> openStream(long lastIndex) {
+            return messagesByIndex.tailMap(lastIndex, false).values().stream();
+        }
+
+        synchronized SerializedMessage latest(String messageId) {
+            Long index = indexByMessageId.get(messageId);
+            return index == null ? null : messagesByIndex.get(index);
+        }
+
+        synchronized void purgeThrough(long maximumIndex) {
+            var expired = messagesByIndex.headMap(maximumIndex, true);
+            expired.forEach((index, message) ->
+                    indexByMessageId.remove(message.getMessageId(), index));
+            expired.clear();
+        }
+
+        synchronized boolean isEmpty() {
+            return messagesByIndex.isEmpty();
+        }
+
+        synchronized int messageCount() {
+            return messagesByIndex.size();
+        }
+
+        synchronized int lookupCount() {
+            return indexByMessageId.size();
+        }
+
+        private void remove(long index) {
+            SerializedMessage removed = messagesByIndex.remove(index);
+            if (removed != null) {
+                indexByMessageId.remove(removed.getMessageId(), index);
+            }
+        }
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/benchmark/InMemorySearchStoreMonitoringBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/benchmark/InMemorySearchStoreMonitoringBenchmark.java
@@ -19,7 +19,6 @@ package io.fluxzero.sdk.benchmark;
 import io.fluxzero.common.api.Data;
 import io.fluxzero.common.api.search.SerializedDocument;
 import io.fluxzero.sdk.persisting.search.client.InMemorySearchStore;
-import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -42,7 +41,6 @@ public class InMemorySearchStoreMonitoringBenchmark {
         new InMemorySearchStoreMonitoringBenchmark().reportsScaling();
     }
 
-    @Test
     void reportsScaling() {
         List<List<SerializedDocument>> documents = Arrays.stream(SIZES)
                 .mapToObj(InMemorySearchStoreMonitoringBenchmark::documents)

--- a/sdk/src/test/java/io/fluxzero/sdk/benchmark/InMemorySearchStoreMonitoringBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/benchmark/InMemorySearchStoreMonitoringBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.benchmark;
+
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.search.SerializedDocument;
+import io.fluxzero.sdk.persisting.search.client.InMemorySearchStore;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static io.fluxzero.common.Guarantee.STORED;
+
+/**
+ * Manual scaling diagnostic for monitored document indexing in the in-memory search store.
+ */
+public class InMemorySearchStoreMonitoringBenchmark {
+
+    private static final int[] SIZES = {1_000, 5_000, 10_000};
+    private static final int WARMUPS = Integer.getInteger("warmups", 2);
+    private static final int RUNS = Integer.getInteger("runs", 5);
+
+    public static void main(String[] args) {
+        new InMemorySearchStoreMonitoringBenchmark().reportsScaling();
+    }
+
+    @Test
+    void reportsScaling() {
+        List<List<SerializedDocument>> documents = Arrays.stream(SIZES)
+                .mapToObj(InMemorySearchStoreMonitoringBenchmark::documents)
+                .toList();
+        for (int i = 0; i < WARMUPS; i++) {
+            index(documents.getLast());
+        }
+        long[][] samples = new long[SIZES.length][RUNS];
+        for (int run = 0; run < RUNS; run++) {
+            for (int step = 0; step < SIZES.length; step++) {
+                int sizeIndex = run % 2 == 0 ? step : SIZES.length - step - 1;
+                samples[sizeIndex][run] = index(documents.get(sizeIndex));
+            }
+        }
+        for (int sizeIndex = 0; sizeIndex < SIZES.length; sizeIndex++) {
+            Arrays.sort(samples[sizeIndex]);
+            double medianMillis = samples[sizeIndex][RUNS / 2] / 1_000_000d;
+            int size = SIZES[sizeIndex];
+            System.out.printf("monitored documents: %,d, median %.3f ms, %.3f us/document%n",
+                              size, medianMillis, medianMillis * 1_000d / size);
+        }
+    }
+
+    private static long index(List<SerializedDocument> documents) {
+        InMemorySearchStore store = new InMemorySearchStore(Duration.ofDays(1));
+        store.registerMonitor((collection, messages) -> { });
+        long start = System.nanoTime();
+        store.index(documents, STORED, false).join();
+        long elapsed = System.nanoTime() - start;
+        long stored = store.openStream("benchmark", null, Integer.MAX_VALUE).count();
+        if (stored != documents.size()) {
+            throw new IllegalStateException("Expected " + documents.size() + " messages but found " + stored);
+        }
+        return elapsed;
+    }
+
+    private static List<SerializedDocument> documents(int size) {
+        Data<byte[]> data = new Data<>(new byte[0], "BenchmarkDocument", 0);
+        return IntStream.range(0, size)
+                .mapToObj(index -> new SerializedDocument(
+                        "document-" + index, null, null, "benchmark", data,
+                        null, Set.of(), Set.of()))
+                .toList();
+    }
+}

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreMonitoringTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreMonitoringTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.persisting.search.client;
+
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.common.api.search.SerializedDocument;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static io.fluxzero.common.Guarantee.STORED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InMemorySearchStoreMonitoringTest {
+
+    @Test
+    void replacesByMessageIdWhileRetainingIndexAndCursorOrdering() {
+        InMemorySearchStore store = new InMemorySearchStore(Duration.ofDays(1));
+        List<Integer> notificationSizes = new ArrayList<>();
+        store.registerMonitor("documents", messages -> notificationSizes.add(messages.size()));
+
+        store.index(List.of(document("a"), document("b")), STORED, false).join();
+        store.index(List.of(document("a")), STORED, false).join();
+
+        List<SerializedMessage> messages = store.openStream(
+                "documents", null, Integer.MAX_VALUE).toList();
+        assertEquals(List.of("b", "a"), messages.stream()
+                .map(SerializedMessage::getMessageId).toList());
+        assertTrue(messages.get(0).getIndex() < messages.get(1).getIndex());
+        assertEquals(List.of("a"), store.openStream(
+                        "documents", messages.getFirst().getIndex(), Integer.MAX_VALUE)
+                .map(SerializedMessage::getMessageId).toList());
+        assertEquals(List.of(2, 1), notificationSizes);
+    }
+
+    @Test
+    void retentionRemovesOrderedEntriesAndTheirMessageIdLookups() {
+        InMemorySearchStore.DocumentUpdateLog log = new InMemorySearchStore.DocumentUpdateLog();
+        log.store(List.of(message("a", 10L), message("b", 20L), message("a", 30L)));
+
+        assertEquals(2, log.messageCount());
+        assertEquals(2, log.lookupCount());
+        assertEquals(30L, log.latest("a").getIndex());
+
+        log.purgeThrough(20L);
+
+        assertEquals(1, log.messageCount());
+        assertEquals(1, log.lookupCount());
+        assertNull(log.latest("b"));
+        assertEquals(30L, log.latest("a").getIndex());
+
+        log.purgeThrough(30L);
+
+        assertTrue(log.isEmpty());
+        assertEquals(0, log.lookupCount());
+        assertNull(log.latest("a"));
+    }
+
+    @Test
+    void truncationAndCollectionDeletionDiscardTheCompleteMonitorLog() {
+        InMemorySearchStore store = new InMemorySearchStore(Duration.ofDays(1));
+        store.registerMonitor((collection, messages) -> { });
+
+        store.index(List.of(document("a")), STORED, false).join();
+        store.truncateCollection("documents");
+        assertEquals(0, store.openStream("documents", null, Integer.MAX_VALUE).count());
+
+        store.index(List.of(document("a")), STORED, false).join();
+        store.deleteCollection("documents", STORED).join();
+        assertEquals(0, store.openStream("documents", null, Integer.MAX_VALUE).count());
+
+        store.index(List.of(document("a")), STORED, false).join();
+        assertEquals(List.of("a"), store.openStream("documents", null, Integer.MAX_VALUE)
+                .map(SerializedMessage::getMessageId).toList());
+    }
+
+    private static SerializedDocument document(String id) {
+        return new SerializedDocument(
+                id, null, null, "documents",
+                new Data<>(new byte[0], "TestDocument", 0),
+                null, Set.of(), Set.of());
+    }
+
+    private static SerializedMessage message(String id, long index) {
+        SerializedMessage message = new SerializedMessage(
+                new Data<>(new byte[0], "TestDocument", 0),
+                Metadata.empty(), id, 0L);
+        message.setIndex(index);
+        return message;
+    }
+}


### PR DESCRIPTION
## Summary
- replace full monitor-log scans with a collection-local message ID lookup
- keep the ordered index log as the sole cursor and dispatch-order source
- clean both structures together during retention, truncation, and collection deletion
- make Graph tombstone lookup use the same latest-message index

## Verification
- matched 1k/5k/10k benchmark changes 10x scale growth from 101.7x to 8.9x
- 10k monitored documents improve from 132.817 ms to 3.583 ms median
- focused replacement, cursor, retention, truncation, and deletion tests
- full nine-module Maven install including test-server, Proxy, and downstream projects