### PR TITLE
fix: remove proxy and model cascade races

### DIFF
--- a/common/src/main/java/io/fluxzero/common/modeling/ModelCommitConflicts.java
+++ b/common/src/main/java/io/fluxzero/common/modeling/ModelCommitConflicts.java
@@ -29,8 +29,9 @@ import java.util.Map;
 import java.util.function.ToLongFunction;
 
 /**
- * Owns generic model-commit conflict detection and conflict-policy outcomes. Stores supply their current heads and
- * optional relationship positions; storage-specific loading and cascade checks remain store responsibilities.
+ * Owns generic model-commit conflict detection and conflict-policy outcomes. Stores supply their current heads,
+ * optional relationship positions and the identities whose operation depends on a current relationship closure;
+ * storage-specific loading remains the store's responsibility.
  */
 public final class ModelCommitConflicts {
 
@@ -45,6 +46,22 @@ public final class ModelCommitConflicts {
             ToLongFunction<? super H> sequenceNumber,
             ToLongFunction<? super H> stateIndex,
             Map<String, Long> relationStateIndices) {
+        return detect(
+                commit, heads, sequenceNumber, stateIndex,
+                relationStateIndices, List.of());
+    }
+
+    /**
+     * Detects ordinary model conflicts plus relationship-only changes for identities whose evaluated operation
+     * depended on their relationship closure, such as cascade-deletion roots.
+     */
+    public static <H> List<ModelCommitConflict> detect(
+            CommitModels commit,
+            Map<String, ? extends H> heads,
+            ToLongFunction<? super H> sequenceNumber,
+            ToLongFunction<? super H> stateIndex,
+            Map<String, Long> relationStateIndices,
+            Iterable<String> relationshipSensitiveModelIds) {
         List<ModelCommitConflict> conflicts = null;
         for (int modelIndex = 0; modelIndex < commit.getReadModelIds().size(); modelIndex++) {
             String modelId = commit.getReadModelIds().get(modelIndex);
@@ -80,6 +97,22 @@ public final class ModelCommitConflicts {
                             relationStateIndices.getOrDefault(target.getModelId(), -1L)));
                 }
             }
+        }
+        for (String modelId : relationshipSensitiveModelIds) {
+            long currentRelationStateIndex =
+                    relationStateIndices.getOrDefault(modelId, -1L);
+            if (currentRelationStateIndex <= commit.getReadStateIndex()
+                || contains(conflicts, modelId)) {
+                continue;
+            }
+            if (conflicts == null) {
+                conflicts = new ArrayList<>();
+            }
+            H head = heads.get(modelId);
+            conflicts.add(new ModelCommitConflict(
+                    modelId,
+                    head == null ? -1L : stateIndex.applyAsLong(head),
+                    currentRelationStateIndex));
         }
         return conflicts == null ? List.of() : List.copyOf(conflicts);
     }

--- a/common/src/test/java/io/fluxzero/common/modeling/ModelCommitConflictsTest.java
+++ b/common/src/test/java/io/fluxzero/common/modeling/ModelCommitConflictsTest.java
@@ -71,10 +71,31 @@ class ModelCommitConflictsTest {
                 Map.of("current", new Head(3L, 10L)),
                 Head::sequenceNumber,
                 Head::stateIndex,
-                Map.of());
+                Map.of("current", 11L));
 
         assertTrue(conflicts.isEmpty());
         assertNull(ModelCommitConflicts.result(commit, conflicts, 20L));
+    }
+
+    @Test
+    void detectsRelationshipOnlyConflictsForSensitiveModels() {
+        CommitModels commit = commit(
+                ModelConflictPolicy.ACCEPT,
+                List.of("cascade-root"),
+                target("cascade-root", 3L));
+
+        List<ModelCommitConflict> conflicts = ModelCommitConflicts.detect(
+                commit,
+                Map.of("cascade-root", new Head(3L, 10L)),
+                Head::sequenceNumber,
+                Head::stateIndex,
+                Map.of("cascade-root", 11L),
+                List.of("cascade-root"));
+
+        assertEquals(
+                List.of(new ModelCommitConflict(
+                        "cascade-root", 10L, 11L)),
+                conflicts);
     }
 
     @Test

--- a/proxy/src/main/java/io/fluxzero/proxy/JettyProxyWebsocketAdapter.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/JettyProxyWebsocketAdapter.java
@@ -95,11 +95,19 @@ public class JettyProxyWebsocketAdapter extends Session.Listener.AbstractAutoDem
     @Override
     public void onWebSocketClose(int statusCode, String reason, Callback callback) {
         JettyProxyWebsocketSession session = this.session;
-        if (session != null) {
-            session.markClosed();
-            endpoint.onClose(session, new WebsocketCloseReason(statusCode, reason));
+        if (session == null) {
+            callback.succeed();
+            return;
         }
+        session.markClosed();
+        // Acknowledge the transport frame before notifying the application. The notification may wait for a remote
+        // handler, but that must never delay or replace the close code already received from the websocket peer.
         callback.succeed();
+        try {
+            endpoint.onClose(session, new WebsocketCloseReason(statusCode, reason));
+        } catch (Throwable e) {
+            endpoint.onError(session, e);
+        }
     }
 
     private static byte[] copyBytes(ByteBuffer buffer) {

--- a/proxy/src/test/java/io/fluxzero/proxy/JettyProxyWebsocketAdapterTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/JettyProxyWebsocketAdapterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.fluxzero.proxy;
+
+import io.fluxzero.sdk.common.websocket.WebsocketCloseReason;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JettyProxyWebsocketAdapterTest {
+
+    @Test
+    void acknowledgesCloseFrameBeforeNotifyingApplication() {
+        ProxyWebsocketEndpoint endpoint = mock(ProxyWebsocketEndpoint.class);
+        Session jettySession = mock(Session.class);
+        when(jettySession.isOpen()).thenReturn(true);
+        JettyProxyWebsocketAdapter adapter = new JettyProxyWebsocketAdapter(endpoint, Map.of(), 8, null);
+        adapter.onWebSocketOpen(jettySession);
+
+        AtomicBoolean acknowledged = new AtomicBoolean();
+        AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+        doAnswer(invocation -> {
+            ProxyWebsocketSession session = invocation.getArgument(0);
+            WebsocketCloseReason closeReason = invocation.getArgument(1);
+            assertTrue(acknowledged.get());
+            assertFalse(session.isOpen());
+            assertEquals(new WebsocketCloseReason(1000, "done"), closeReason);
+            return null;
+        }).when(endpoint).onClose(any(), any());
+
+        adapter.onWebSocketClose(1000, "done", Callback.from(
+                () -> acknowledged.set(true), callbackFailure::set));
+
+        assertTrue(acknowledged.get());
+        assertNull(callbackFailure.get());
+        verify(endpoint).onClose(any(), any());
+    }
+
+    @Test
+    void notificationFailureCannotChangeAcknowledgedClose() {
+        ProxyWebsocketEndpoint endpoint = mock(ProxyWebsocketEndpoint.class);
+        Session jettySession = mock(Session.class);
+        when(jettySession.isOpen()).thenReturn(true);
+        JettyProxyWebsocketAdapter adapter = new JettyProxyWebsocketAdapter(endpoint, Map.of(), 8, null);
+        adapter.onWebSocketOpen(jettySession);
+        RuntimeException failure = new RuntimeException("notification failed");
+        doThrow(failure).when(endpoint).onClose(any(), any());
+
+        AtomicBoolean acknowledged = new AtomicBoolean();
+        AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+        adapter.onWebSocketClose(1000, "done", Callback.from(
+                () -> acknowledged.set(true), callbackFailure::set));
+
+        assertTrue(acknowledged.get());
+        assertNull(callbackFailure.get());
+        var session = ArgumentCaptor.forClass(ProxyWebsocketSession.class);
+        var error = ArgumentCaptor.forClass(Throwable.class);
+        verify(endpoint).onError(session.capture(), error.capture());
+        assertFalse(session.getValue().isOpen());
+        assertSame(failure, error.getValue());
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
@@ -267,19 +267,20 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
                         "Model readStateIndex %d is newer than visible stateIndex %d"
                                 .formatted(commit.getReadStateIndex(), modelStateIndex));
             }
+            ModelCommitAssignment.Description description =
+                    ModelCommitAssignment.describe(commit);
             CommitModelsResult conflict = ModelCommitConflicts.result(
                     commit,
                     ModelCommitConflicts.detect(
                             commit, modelHeads,
                             ModelStreamHead::sequenceNumber,
                             ModelStreamHead::stateIndex,
-                            modelRelationStateIndices),
+                            modelRelationStateIndices,
+                            description.cascadeRootIds()),
                     modelStateIndex);
             if (conflict != null) {
                 return new ModelCommitOutcome(conflict, List.of());
             }
-            ModelCommitAssignment.Description description =
-                    ModelCommitAssignment.describe(commit);
             validateCommitRelationships(description);
             description.aliases().validate(modelAliases);
             List<ModelStreamHead> assignedHeads = new ArrayList<>(

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
@@ -1143,6 +1143,52 @@ class InMemoryEventStoreModelCommitTest {
     }
 
     @Test
+    void staleCascadeDeleteRebasesWhenAChildWasAttachedAfterItsReadBoundary() {
+        InMemoryEventStore store = denseStore();
+        store.commitModels(commit(
+                "create-parent", -1L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("parent"))
+                        .targets(List.of(storedTarget("parent-1")))
+                        .build())).join();
+        store.commitModels(commit(
+                "create-child", 0L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("child"))
+                        .targets(List.of(storedTarget("child-1").toBuilder()
+                                                 .updateRelationships(true)
+                                                 .relationships(List.of(
+                                                         ModelRelationship.builder()
+                                                                 .parentId("parent-1")
+                                                                 .parentType("Parent")
+                                                                 .path("children")
+                                                                 .build()))
+                                                 .build()))
+                        .build())).join();
+        ModelCommitTarget staleCascadeDelete = storedTarget("parent-1").toBuilder()
+                .delete(true)
+                .cascadeDelete(true)
+                .updateRelationships(true)
+                .relationships(List.of())
+                .build();
+
+        CommitModelsResult result = store.commitModels(commit(
+                "delete-parent", 0L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("delete"))
+                        .targets(List.of(staleCascadeDelete))
+                        .build())).join();
+
+        assertTrue(result.isRebaseRequired());
+        assertEquals("parent-1", result.getConflicts().getFirst().getModelId());
+        assertEquals(1L, result.getConflicts().getFirst().getCurrentRelationStateIndex());
+        assertFalse(modelStream(store, "parent-1").getHead().isDeleted());
+    }
+
+    @Test
     void deletionPlanIncludesDetachedAndExternallySharedDescendantsWithoutMutating() {
         InMemoryEventStore store =
                 denseStore();


### PR DESCRIPTION
## Summary

- acknowledge Jetty close frames before notifying application handlers, so slow or failing close handlers cannot rewrite a normal peer close into 1011
- rebase stale cascade deletions when a child relationship changed after the root read boundary
- add deterministic transport-ordering and relationship-only conflict regressions

## Contract preserved

The close handler is still notified exactly once after the session is marked closed. Ordinary Model commits do not become relationship-sensitive; only cascade roots are reevaluated when their closure changed.