### PR TITLE
feat(modeling): make Model persistence explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3244,7 +3244,7 @@ Metrics messages provide lightweight hooks into system behavior — use them for
 Use `@Model` for all new persisted domain state:
 
 ```java
-@Model(searchable = true)
+@Model
 public record UserAccount(
         @EntityId UserId userId,
         UserProfile profile,
@@ -3255,6 +3255,35 @@ public record UserAccount(
 Every model ID is an independent persistence and lifecycle boundary. Depending on its `@Model` settings, it has its own
 event stream, cache entry, snapshots and direct search document. Commands can own their assertions and transitions
 directly:
+
+Choose one explicit persistence contract:
+
+| `ModelPersistence` | Authoritative load path | Direct searchable document |
+|---|---|---|
+| `EVENT_SOURCED` (default) | Model event stream, optionally from snapshots | No |
+| `EVENT_SOURCED_WITH_DOCUMENT` | Model event stream, optionally from snapshots | Yes |
+| `DOCUMENT` | Current document through the configured `DocumentSerializer` | Yes |
+
+Event storage and publication remain controlled independently by `eventPublication`, `publicationStrategy` and
+per-apply overrides. Internal type-isolated documents required for Graph composition are likewise independent: they do
+not make an `EVENT_SOURCED` Model directly searchable and never change its authoritative load path. Configure the
+direct document only when needed:
+
+```java
+@Model(
+        persistence = ModelPersistence.DOCUMENT,
+        document = @DocumentProjection(
+                collection = "user-accounts",
+                timestampPath = "profile/createdAt"))
+public record UserAccount(
+        @EntityId UserId userId,
+        UserProfile profile,
+        boolean accountClosed) {
+}
+```
+
+Event-sourcing-only settings such as `ignoreUnknownEvents`, `snapshotPeriod`, `maxSnapshotCount` and
+`checkpointPeriod` are rejected on `DOCUMENT` Models instead of being silently ignored.
 
 ```java
 public record UpdateProfile(
@@ -3287,9 +3316,9 @@ functional ID is unique only below its parent.
 
 Conversely, use `@Member` only when the nested value deliberately shares creation, every change, history, retention,
 and deletion with the root. Collection shape, convenient embedding, searchability, update frequency, and the chosen
-load strategy do not decide this boundary. Choose `eventSourced`, snapshots, caching, and document indexing only after
-the lifecycle boundary is correct. Splitting independently living children often turns one enormous legacy stream into
-many very small streams that are ideal for event sourcing.
+load strategy do not decide this boundary. Choose `persistence`, snapshots and caching only after the lifecycle
+boundary is correct. Splitting independently living children often turns one enormous legacy stream into many very
+small streams that are ideal for event sourcing.
 
 ### Combining payload and Model handlers
 
@@ -3338,7 +3367,7 @@ final state. Live handling, retry, rebase and event replay use this same phasing
 Related models remain independently stored:
 
 ```java
-@Model(searchable = true)
+@Model
 public record Address(
         @EntityId AddressId addressId,
         @Parent(pathInParent = "addresses") UserId userId,
@@ -3357,8 +3386,8 @@ being mixed with other component types or exposed by `Fluxzero.search(Component.
 cast or type witness. It uses a configured materialized projection and otherwise stitches current public or private
 documents live; `searchGraph(User.class, true)` forces live stitching. Use `fetch(..., ObjectNode.class)` only at a boundary that
 explicitly needs raw documents. Graph constraints have the same full-document meaning on both routes.
-`searchable = false` suppresses only the Model's own search collection: an explicit
-`@Parent(pathInParent = "...")` or `materializeGraph = true` still gives graph composition an internal current document.
+`ModelPersistence.EVENT_SOURCED` does not maintain a direct Model collection: an explicit
+`@Parent(pathInParent = "...")` or `materializeGraph = true` still gives Graph composition an internal current document.
 `pathInParent` is always relative to the parent document; it never points from the child to its parent.
 
 For a selective live Graph query based on children, express the child predicate as a relationship constraint so
@@ -3380,7 +3409,7 @@ Relations may be recursive. A `Folder` can, for example, point to another `Folde
 relation remains an ordinary independently stored edge and does not turn the descendants into embedded state:
 
 ```java
-@Model(searchable = true)
+@Model
 record Folder(
         @EntityId FolderId folderId,
         @Parent(pathInParent = "folders") FolderId parentFolderId,
@@ -3440,13 +3469,14 @@ public record User(@EntityId UserId userId, String name) {
 ```
 
 `materializeGraph` is sufficient: Fluxzero keeps the private root document needed for composition without exposing a
-direct Model collection. Enable `searchable` separately only when callers should also be able to search the root Model
-itself. Use `searchProjection = @Searchable(...)` or `graphProjection = @GraphProjection(...)` only for advanced
-configuration. The graph collection is `User-graphs` by default; for a searchable root Fluxzero appends `-graphs` to
-the resolved direct collection. Set `GraphProjection.collection` only when a custom durable name is needed. Projection
-is asynchronous unless completion is explicitly configured otherwise. Both live and materialized composition follow the
-complete finite graph by default; lower-level `ModelGraphComposition` maxima are optional advanced guardrails and use
-`UNBOUNDED` (`-1`) when absent. An explicit guardrail fails instead of publishing a partial graph.
+direct Model collection. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` only when callers should also be able to
+search the root Model itself. Use `document = @DocumentProjection(...)` or
+`graphProjection = @GraphProjection(...)` only for advanced configuration. The graph collection is `User-graphs` by
+default; for a root with a direct document Fluxzero appends `-graphs` to the resolved direct collection. Set
+`GraphProjection.collection` only when a custom durable name is needed. Projection is asynchronous unless completion
+is explicitly configured otherwise. Both live and materialized composition follow the complete finite graph by
+default; lower-level `ModelGraphComposition` maxima are optional advanced guardrails and use `UNBOUNDED` (`-1`) when
+absent. An explicit guardrail fails instead of publishing a partial graph.
 
 Every node in a materialized graph keeps its own serialized type and revision. On read, the normal serializer applies
 the registered `@Upcast` chain lazily to each root or descendant when that node is accessed; there is no separate
@@ -3470,8 +3500,9 @@ authoritative and unchanged; a delayed handler cannot overwrite a newer projecti
 
 Use `@Member` inside a model only for values that intentionally share the model's creation, changes, history, stream,
 document, cache, retention and deletion lifecycle. If any of those can diverge, use a separate `@Model` plus `@Parent`,
-including when the child is normally displayed as one item in a parent collection. Set `eventSourced = false` when
-current state should load from the direct document; model events are still stored and published. `@Model` defaults
+including when the child is normally displayed as one item in a parent collection. Select
+`persistence = ModelPersistence.DOCUMENT` when current state should load from the direct document; Model events are
+still stored and published. `@Model` defaults
 `eventPublication` to `IF_MODIFIED`, so returning unchanged state does not produce an event; use `ALWAYS` explicitly for
 intentional no-op domain notifications. Direct searchable documents are synchronous with model-commit completion.
 
@@ -4739,7 +4770,7 @@ documentStore.bulkUpdate("customCollection")
 
 Many domain objects in Flux (e.g. models or stateful handlers) are automatically indexable:
 
-- `@Model(searchable = true)`
+- `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
 - `@Stateful` (implicitly `@Searchable`)
 - Directly annotate any POJO with `@Searchable`
 
@@ -4748,7 +4779,7 @@ manually.
 
 ```java
 
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record UserAccount(@EntityId UserId userId,
                           UserProfile profile,
                           boolean accountClosed) {
@@ -4756,12 +4787,12 @@ public record UserAccount(@EntityId UserId userId,
 ```
 
 By default, the collection name is derived from the class’s **simple name** (UserAccount → `"UserAccount"`),
-unless explicitly overridden through `Model.searchProjection`, `@Stateful`, `@Searchable` or in the search/index call:
+unless explicitly overridden through `Model.document`, `@Stateful`, `@Searchable` or in the search/index call:
 
 ```java
 @Model(
-        searchable = true,
-        searchProjection = @Searchable(
+        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        document = @DocumentProjection(
                 collection = "users",
                 timestampPath = "profile/createdAt"))
 ```
@@ -5121,7 +5152,7 @@ Fluxzero.search("expiredTokens")
 
 - Use `Fluxzero.index(...)` to manually index documents.
 - Use `@Searchable` to configure the collection name or time range for an object.
-- Use `@Model(searchable = true)` or `@Stateful` for automatic indexing.
+- Use `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)` or `@Stateful` for automatic indexing.
 - Use `Fluxzero.search(...)` to query, stream, sort, and aggregate your documents.
 
 ---
@@ -5201,7 +5232,7 @@ UserAccount upgrade(UserAccount user) {
 You can subscribe to a document collection using any of the following styles:
 
 - `@HandleDocument` — infers the collection from the **first parameter** of the handler method; this is the preferred style when the document is the first parameter
-- `@HandleDocument(documentClass = MyModel.class)` — resolves the collection via the model’s `@Searchable` annotation when the document type cannot be inferred from the first parameter
+- `@HandleDocument(documentClass = MyModel.class)` — resolves the collection via the Model's `document` projection when the document type cannot be inferred from the first parameter
 - `@HandleDocument(modelGraph = MyModel.class)` — subscribes to the model's enabled materialized graph projection and can inject a typed lazy `Graph<MyModel>`, including its derived or explicitly configured graph collection. Returning that complete Graph persists node-by-node serializer upcasting only into the derived projection, using an atomic manifest comparison so a delayed handler cannot overwrite newer state; direct Models and relationships remain authoritative and unchanged. Returning an already-current Graph is a no-op. Deleting the root delivers an observational typed empty graph that retains its identity and boundary; `previous()` returns the complete last graph. Ordinary document handlers for the same collection do not receive this deletion record.
 - `@HandleDocument("myCollection")` — binds directly to the named collection
 
@@ -6094,8 +6125,8 @@ public class MyCustomizer implements FluxzeroCustomizer {
 
 - `replaceSerializer(...)` changes the default JSON serializer (e.g., for Jackson customizations).
 - `replaceDocumentSerializer(...)` owns complete document serialization in both directions, including current documents
-  of `@Model(eventSourced = false)`. It can therefore implement document-level encryption, compression, signing, or a
-  custom envelope using the document ID, collection, timestamps, and metadata.
+  of `@Model(persistence = ModelPersistence.DOCUMENT)`. It can therefore implement document-level encryption,
+  compression, signing, or a custom envelope using the document ID, collection, timestamps, and metadata.
 
 #### Parameter Injection and Handler Behavior
 

--- a/docs/developer/getting-started/core-concepts.mdx
+++ b/docs/developer/getting-started/core-concepts.mdx
@@ -98,7 +98,7 @@ Use an explicit `@HandleCommand` when the action needs orchestration around the 
   <TabItem label="Java">
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Project(@EntityId ProjectId projectId,
                       ProjectDetails details,
                       UserId ownerId) {
@@ -109,7 +109,7 @@ public record Project(@EntityId ProjectId projectId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -127,12 +127,12 @@ Each model ID is its own persistence and lifecycle boundary. Its event stream, c
 document are enabled independently through `@Model` settings. The exact
 `Id.toString()` value is its persisted identity.
 
-Models are event-sourced by default. Set `eventSourced = false` when current state should load from the direct
-document instead. Updates are still stored as model events and published according to `eventPublication`; the option
-only changes how current state is loaded.
+Models are event-sourced by default. Select `DOCUMENT` when the current document should be the durable representation
+and authoritative load source. Updates are still stored and published as Model events according to
+`eventPublication` and `publicationStrategy`.
 
 ```java
-@Model(eventSourced = false, searchable = true)
+@Model(persistence = ModelPersistence.DOCUMENT)
 public record Product(@EntityId ProductId productId,
                       String name,
                       BigDecimal price) {
@@ -214,7 +214,7 @@ Account debit(@Association("sourceId") Account source) { ... }
 Use `@Parent` when independently stored models form a navigable graph:
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
                    TaskDetails details,
@@ -248,7 +248,7 @@ Not every value needs an independent lifecycle. Use `@Member` inside a model for
 searches and disappears with that model:
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Invoice(@EntityId InvoiceId invoiceId,
                       @Member List<InvoiceLine> lines) {
 }
@@ -305,9 +305,10 @@ public final class ProjectQueries {
 }
 ```
 
-The direct collection of a searchable model is synchronous with its model commit. A whole-tree graph projection is a
-separate read optimization and is asynchronous by default. Choose `GraphProjectionCompletion.AWAIT` for an operation
-whose result must not be released until affected root projections have crossed its state boundary.
+The direct collection of a Model using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` is synchronous with its Model
+commit. A whole-tree Graph projection is a separate read optimization and is asynchronous by default. Choose
+`GraphProjectionCompletion.AWAIT` for an operation whose result must not be released until affected root projections
+have crossed its state boundary.
 
 ## Events and handlers
 

--- a/docs/developer/guides/Configuration/270-configuring-fluxzero.mdx
+++ b/docs/developer/guides/Configuration/270-configuring-fluxzero.mdx
@@ -92,7 +92,8 @@ In Spring environments, it can be customized by implementing the `FluxzeroCustom
 
 - `replaceSerializer(...)` changes the default JSON serializer (e.g., for Jackson customizations).
 - `replaceDocumentSerializer(...)` owns complete document serialization in both directions, including current documents
-  of `@Model(eventSourced = false)`. It can therefore implement document-level encryption, compression, signing, or a
+  of `@Model(persistence = ModelPersistence.DOCUMENT)`. It can therefore implement document-level encryption,
+  compression, signing, or a
   custom envelope using the document ID, collection, timestamps, and metadata.
 
 ### Parameter injection and handler behavior

--- a/docs/developer/guides/Messaging/030-message-tracking.mdx
+++ b/docs/developer/guides/Messaging/030-message-tracking.mdx
@@ -75,8 +75,8 @@ If multiple consumers handle the same request message type, multiple results can
 
 ### Command followed by query
 
-For a searchable model, the direct document is part of model-commit completion. A command followed by a direct model
-query therefore reads committed state.
+For a Model using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+A command followed by a direct Model query therefore reads committed state.
 
 Whole-graph projections and documents written by event handlers remain asynchronous. Await their own completion
 boundary when a request result must not be released first.

--- a/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
+++ b/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
@@ -145,10 +145,10 @@ history of the order, inventory model or its siblings.
 
 ## Document-based loading
 
-Set `eventSourced = false` to load the current model directly from its synchronously maintained document:
+Select document persistence to load the current model directly from its synchronously maintained document:
 
 ```java
-@Model(eventSourced = false, searchable = true)
+@Model(persistence = ModelPersistence.DOCUMENT)
 record Country(@EntityId CountryId countryId, String name) {
 }
 ```

--- a/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
+++ b/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
@@ -13,13 +13,13 @@ Domain objects may form a tree without sharing one permanent storage boundary. A
 storing its parent's ID in an `@Parent` property:
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 record Order(
         @EntityId OrderId orderId,
         String customerName) {
 }
 
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 record LineItem(
         @EntityId LineItemId lineItemId,
         @Parent(pathInParent = "lines") OrderId orderId,
@@ -32,14 +32,14 @@ record LineItem(
 and direct search document. Updating it does not load or
 rewrite the order.
 
-The child does not have to be independently searchable. With `@Model(searchable = false)`, the explicit
-`@Parent(pathInParent = "lines")` still retains a private current document for graph composition; only the child’s own public
-search collection is suppressed.
+The child does not need a direct public document. With the default `EVENT_SOURCED` persistence, the explicit
+`@Parent(pathInParent = "lines")` still retains a private current document for Graph composition; only the child's own
+public search collection is absent.
 
 The relation may point to the same Model type, which makes recursive domains such as folders natural:
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 record Folder(
         @EntityId FolderId folderId,
         @Parent(pathInParent = "folders") FolderId parentFolderId,
@@ -228,8 +228,9 @@ record Order(@EntityId OrderId orderId, String customerName) {
 ```
 
 The runtime consumes durable projection signals, coalesces affected roots, composes each complete graph and writes it
-with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root. `searchable = true` is a
-separate choice that enables direct `Order` search; it is not required for this whole-graph projection.
+with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root. Selecting
+`EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` is a separate choice that enables direct `Order` search; it is not
+required for this whole-Graph projection.
 
 Projection completion is configurable:
 

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -6,16 +6,14 @@ sidebar:
    order: 200
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Aside } from '@astrojs/starlight/components';
 
-Every `@Model` has an independent persisted identity. The annotation configures how that model is loaded, cached,
-snapshotted, searched and conflict-checked:
+Every `@Model` has an independent persisted identity. `ModelPersistence` makes its durable representation and
+authoritative load path explicit:
 
 ```java
 @Model(
-    eventSourced = true,
-    searchable = true,
+    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
     snapshotPeriod = 1000)
 record Account(
         @EntityId AccountId accountId,
@@ -47,13 +45,12 @@ attempt or short-lived process can keep its own small history while still partic
 
 ## Document-based models
 
-Set `eventSourced = false` to make the current direct document the normal load source:
+Select `DOCUMENT` to make the current direct document the normal load source:
 
 ```java
 @Model(
-    eventSourced = false,
-    searchable = true,
-    searchProjection = @Searchable(
+    persistence = ModelPersistence.DOCUMENT,
+    document = @DocumentProjection(
         collection = "countries"))
 record Country(
         @EntityId CountryId countryId,
@@ -61,17 +58,14 @@ record Country(
 }
 ```
 
-`eventSourced` controls the **load path**, not whether updates become events. Applied updates are still stored and
-published by default. This preserves auditing, exact event-handler boundaries and the option to change loading strategy
-later.
+`persistence` controls the durable representation and **load path**, not whether updates become events. Applied updates
+are still stored and published by default. This preserves auditing and exact event-handler boundaries.
 
 The direct searchable document is synchronously maintained with the model commit. After a successful command result,
 an immediate direct search can observe the changed model.
 
-<Aside type="caution">
-A document-based model needs a current document. Normally that means `searchable = true`; a non-searchable child with
-an explicit `@Parent(pathInParent = "...")` can instead load from its private graph-component document.
-</Aside>
+`DOCUMENT` always maintains this direct document. Its collection and temporal paths can be configured through
+`document = @DocumentProjection(...)`.
 
 ## Event storage and publication
 
@@ -125,14 +119,15 @@ default starts after Model apply handlers and awaits all started commits at batc
 application has a measured ordering, latency or concurrency reason to choose another `ModelCommitPolicy`; the policy
 does not split one multi-Model action into separate commits.
 
-## Searchable models
+## Direct Model documents
 
-`searchable = true` gives every model its own direct current document:
+`EVENT_SOURCED_WITH_DOCUMENT` keeps event replay authoritative while also maintaining a directly searchable current
+document:
 
 ```java
 @Model(
-    searchable = true,
-    searchProjection = @Searchable(
+    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    document = @DocumentProjection(
         collection = "line-items"))
 record LineItem(
         @EntityId LineItemId lineItemId,
@@ -141,12 +136,13 @@ record LineItem(
 }
 ```
 
-This document is authoritative for direct search and for document-based loading. It is not the asynchronously stitched
-root graph.
+This document is authoritative for direct search, but event replay remains authoritative for loading the Model. With
+`DOCUMENT`, the same direct document is authoritative for both search and loading. It is never the asynchronously
+stitched root Graph.
 
-`searchable = false` controls only this independent collection. A child with an explicit `@Parent(pathInParent = "...")`
-still supplies a private current document to virtual and materialized graph composition. Without an explicit path,
-Fluxzero stores no graph-component document and performs no extra document write.
+Plain `EVENT_SOURCED` omits only this independent collection. A child with an explicit
+`@Parent(pathInParent = "...")` still supplies a private current document to virtual and materialized Graph composition.
+Without an explicit path, Fluxzero stores no Graph-component document and performs no extra document write.
 
 You can additionally:
 

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -61,18 +61,18 @@ You can also specify the collection in which the object should be stored directl
 
 ---
 
-## Searchable domain models
+## Domain Models with direct documents
 
 Many domain models and stateful handlers in Fluxzero are automatically indexable:
 
-- `@Model(searchable = true)`
+- `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
 - `@Stateful` (implicitly `@Searchable`)
 - Directly annotate any POJO with `@Searchable`
 
 <Tabs>
   <TabItem label="Java">
     ```java
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     public record UserAccount(@EntityId UserId userId,
                               UserProfile profile,
                               boolean accountClosed) {
@@ -81,7 +81,7 @@ Many domain models and stateful handlers in Fluxzero are automatically indexable
   </TabItem>
   <TabItem label="Kotlin">
     ```kotlin
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     data class UserAccount(
         @EntityId val userId: UserId,
         val profile: UserProfile,
@@ -92,15 +92,15 @@ Many domain models and stateful handlers in Fluxzero are automatically indexable
 </Tabs>
 
 By default, the collection name is derived from the class’s **simple name** (UserAccount → `"UserAccount"`). Configure
-a Model's direct document through its `searchProjection`; `@Stateful` and directly searchable values expose the
-`@Searchable` settings themselves:
+a Model's direct document through its `document`; `@Stateful` and directly searchable values expose the `@Searchable`
+settings themselves:
 
 <Tabs>
   <TabItem label="Java">
     ```java
     @Model(
-        searchable = true,
-        searchProjection = @Searchable(
+        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        document = @DocumentProjection(
             collection = "users",
             timestampPath = "profile/createdAt"))
     ```
@@ -108,8 +108,8 @@ a Model's direct document through its `searchProjection`; `@Stateful` and direct
   <TabItem label="Kotlin">
     ```kotlin
     @Model(
-        searchable = true,
-        searchProjection = @Searchable(
+        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        document = @DocumentProjection(
             collection = "users",
             timestampPath = "profile/createdAt"
         )
@@ -149,9 +149,9 @@ Use the fluent `search(...)` API:
 
 ### Consistency after commands
 
-Search is optimized for current state, but indexing still follows the commit path. The direct document of a searchable
-model is synchronously maintained with its model commit. Calling `sendCommandAndWait(...)` and then querying that
-model's direct collection observes the committed state.
+Search is optimized for current state, but indexing still follows the commit path. A Model using `DOCUMENT` or
+`EVENT_SOURCED_WITH_DOCUMENT` synchronously maintains its direct document with the Model commit. Calling
+`sendCommandAndWait(...)` and then querying that Model's direct collection observes the committed state.
 
 This does not automatically wait for a materialized whole-root graph projection. Select
 `GraphProjectionCompletion.AWAIT` for the operation or consumer when an immediate root query must include all affected
@@ -673,6 +673,6 @@ To remove documents from the index:
 
 - Use `Fluxzero.index(...)` to manually index documents.
 - Use `@Searchable` to configure the collection name or time range for an object.
-- Use `@Model(searchable = true)` or `@Stateful` for automatic indexing.
+- Use `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)` or `@Stateful` for automatic indexing.
 - Use `Fluxzero.search(...)` to query, stream, sort, and aggregate your documents.
 - Use `fetchAsync(...)`, `countAsync()`, `aggregateAsync(...)`, and `facetStatsAsync()` in asynchronous handlers.

--- a/docs/developer/guides/Modeling & persistence/230-tracking-and-updating-documents.mdx
+++ b/docs/developer/guides/Modeling & persistence/230-tracking-and-updating-documents.mdx
@@ -120,7 +120,7 @@ document model safely.
 You can subscribe to a document collection using any of the following styles:
 
 - `@HandleDocument` — infers the collection from the **first parameter** of the handler method; this is the preferred style when the document is the first parameter
-- `@HandleDocument(documentClass = MyModel.class)` — resolves the collection via the model’s `@Searchable` annotation when the document type cannot be inferred from the first parameter
+- `@HandleDocument(documentClass = MyModel.class)` — resolves the collection via the Model's `document` projection when the document type cannot be inferred from the first parameter
 - `@HandleDocument(modelGraph = MyModel.class)` — subscribes to the model's enabled materialized graph projection, including its derived or explicitly configured graph collection. Deleting the root delivers a typed empty graph that retains its identity and boundary; `previous()` returns the complete last graph. Ordinary document handlers for the same collection do not receive this deletion record.
 - `@HandleDocument("myCollection")` — binds directly to the named collection
 

--- a/docs/developer/tutorials/first-app.mdx
+++ b/docs/developer/tutorials/first-app.mdx
@@ -40,7 +40,7 @@ value types are assumed below so the example can stay focused on Model behavior:
   <TabItem label="Java">
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Project(@EntityId ProjectId projectId,
                       ProjectDetails details,
                       UserId ownerId,
@@ -52,7 +52,7 @@ public record Project(@EntityId ProjectId projectId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -64,10 +64,9 @@ data class Project(
   </TabItem>
 </Tabs>
 
-`@Model` gives each project ID its own persistence and lifecycle boundary. Here `searchable = true` also gives it a
-synchronously maintained direct search document; caching, event sourcing and snapshots remain independently
-configurable.
-`@EntityId` identifies the model. `searchable = true` makes the current project directly searchable.
+`@Model` gives each project ID its own persistence and lifecycle boundary. Here
+`EVENT_SOURCED_WITH_DOCUMENT` keeps event replay authoritative and also maintains a synchronous direct search
+document. `@EntityId` identifies the Model.
 
 ## Create a project
 
@@ -131,7 +130,7 @@ model and link it to a project:
   <TabItem label="Java">
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
                    TaskDetails details,
@@ -143,7 +142,7 @@ public record Task(@EntityId TaskId taskId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 data class Task(
     @EntityId val taskId: TaskId,
     @Parent(pathInParent = "tasks") val projectId: ProjectId,
@@ -395,7 +394,7 @@ For repeatedly queried large trees, enable a graph projection on the root:
 
 ```java
 @Model(
-    searchable = true,
+    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
     materializeGraph = true,
     graphProjection = @GraphProjection(
         collection = "project-overviews"))

--- a/java-downstream-project/src/main/java/io/fluxzero/downstream/DownstreamModel.java
+++ b/java-downstream-project/src/main/java/io/fluxzero/downstream/DownstreamModel.java
@@ -17,20 +17,22 @@
 package io.fluxzero.downstream;
 
 import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.modeling.DocumentProjection;
 import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.Member;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
-import io.fluxzero.sdk.persisting.search.Searchable;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-@Model(eventSourced = false, searchable = true,
-        searchProjection = @Searchable(collection = "downstream-models"))
+@Model(
+        persistence = ModelPersistence.DOCUMENT,
+        document = @DocumentProjection(collection = "downstream-models"))
 public record DownstreamModel(@EntityId String id, String value, @Member List<Part> parts) {
 
     @Apply

--- a/java-downstream-project/src/test/java/io/fluxzero/downstream/DownstreamProjectTest.java
+++ b/java-downstream-project/src/test/java/io/fluxzero/downstream/DownstreamProjectTest.java
@@ -18,6 +18,7 @@ import io.fluxzero.common.serialization.JsonUtils;
 import io.fluxzero.common.serialization.TypeRegistryProcessor;
 import io.fluxzero.proxy.ProxyServer;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.modeling.Parent;
 import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.web.OpenApiProcessor;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,9 +65,8 @@ class DownstreamProjectTest {
                 DownstreamModel.Child.class.getDeclaredMethod("externalParentId").getAnnotation(Parent.class);
 
         assertNotNull(model);
-        assertFalse(model.eventSourced());
-        assertTrue(model.searchable());
-        assertEquals("downstream-models", model.searchProjection().collection());
+        assertEquals(ModelPersistence.DOCUMENT, model.persistence());
+        assertEquals("downstream-models", model.document().collection());
         assertNotNull(typedParent);
         assertNotNull(untypedParent);
         assertEquals("children", typedParent.pathInParent());

--- a/kotlin-downstream-project/src/test/kotlin/io/fluxzero/sdk/modeling/ModelKotlinTest.kt
+++ b/kotlin-downstream-project/src/test/kotlin/io/fluxzero/sdk/modeling/ModelKotlinTest.kt
@@ -2,12 +2,9 @@ package io.fluxzero.sdk.modeling
 
 import io.fluxzero.sdk.Fluxzero
 import io.fluxzero.sdk.persisting.eventsourcing.Apply
-import io.fluxzero.sdk.persisting.search.Searchable
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class ModelKotlinTest {
     @Test
@@ -15,9 +12,8 @@ class ModelKotlinTest {
         val annotation = KotlinModel::class.java.getAnnotation(Model::class.java)
 
         assertNotNull(annotation)
-        assertFalse(annotation.eventSourced)
-        assertTrue(annotation.searchable)
-        assertEquals("kotlin-models", annotation.searchProjection.collection)
+        assertEquals(ModelPersistence.DOCUMENT, annotation.persistence)
+        assertEquals("kotlin-models", annotation.document.collection)
         assertEquals(1, KotlinModel("model", emptyList()).rename(RenameKotlinModel("new")).parts.size)
     }
 
@@ -28,9 +24,8 @@ class ModelKotlinTest {
 }
 
 @Model(
-    eventSourced = false,
-    searchable = true,
-    searchProjection = Searchable(collection = "kotlin-models"),
+    persistence = ModelPersistence.DOCUMENT,
+    document = DocumentProjection(collection = "kotlin-models"),
 )
 data class KotlinModel(
     @EntityId val id: String,

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -21,7 +21,7 @@ Fluxzero 1.x compatibility surfaces and are scheduled for deprecation in 2.0.
 ## Define a model
 
 ```java
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 public record Project(
         @EntityId ProjectId projectId,
         ProjectDetails details,
@@ -34,12 +34,13 @@ definitions unless the user asks for them.
 
 Important settings:
 
-- `eventSourced`: controls the current-state load route. Events are still stored when `false`.
+- `persistence`: selects exactly one durable/load contract:
+  - `EVENT_SOURCED` (default): reconstruct from Model events, without a direct public document.
+  - `EVENT_SOURCED_WITH_DOCUMENT`: reconstruct from events and maintain a direct searchable current document.
+  - `DOCUMENT`: load authoritative current state from the direct document.
 - `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
-- `searchable`: maintains an independently searchable synchronous current-state document. `false` suppresses only the
-  model's own collection; an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true` still retains the
-  private graph-component document needed for composition.
-- `searchProjection`: optional `@Searchable` configuration for the direct collection and timestamp paths.
+- `document`: optional `@DocumentProjection` configuration for the direct collection and timestamp paths. It is valid
+  only when `persistence` stores a direct document.
 - `eventPublication`: controls whether unchanged transitions create an event.
 - `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
@@ -50,11 +51,13 @@ Important settings:
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `@GraphProjection` configuration; its collection defaults to the resolved direct
-  Model collection plus `-graphs` when searchable, or `<simple model name>-graphs` otherwise, and materializes the
-  complete finite graph without implicit size limits.
+  Model collection plus `-graphs` when a direct document exists, or `<simple model name>-graphs` otherwise, and
+  materializes the complete finite graph without implicit size limits.
 
-`eventSourced = false` does not disable event storage or publication. It means current state loads from the direct
-document. Historical event-boundary loads still use stored model events.
+Persistence does not control event storage or publication. Those remain owned by `eventPublication`,
+`publicationStrategy` and per-apply overrides. Internal Graph-component documents are also orthogonal: they neither
+make an `EVENT_SOURCED` Model directly searchable nor change its load path. Event-sourcing-only options such as
+`ignoreUnknownEvents`, snapshots and replay checkpoints are rejected on `DOCUMENT` Models.
 
 ## Apply actions
 
@@ -227,7 +230,7 @@ when that order is a domain requirement.
 Use `@Parent` on the child:
 
 ```java
-@Model(searchable = true)
+@Model
 public record Task(
         @EntityId TaskId taskId,
         @Parent(pathInParent = "tasks") ProjectId projectId,
@@ -278,7 +281,7 @@ not modify direct Models, histories or relationships.
 `@Model` plus `@Member` is the intentional shared-stream option:
 
 ```java
-@Model(searchable = true)
+@Model
 public record Invoice(
         @EntityId InvoiceId invoiceId,
         @Member List<InvoiceLine> lines) {
@@ -392,7 +395,8 @@ payload turns the method back into ordinary payload handling with direct/ancesto
 
 ## Search and graph composition
 
-Direct searchable-model documents are synchronous with successful commit completion:
+Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are synchronous with successful commit
+completion:
 
 ```java
 List<Task> open = Fluxzero.search(Task.class)
@@ -420,9 +424,9 @@ nested-path filter when the child type is known. Use
 reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 `searchGraph(Root.class, true)`
 forces live composition. Use `fetch(..., ObjectNode.class)` for explicit raw JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Model search. A blank projection
-collection appends `-graphs` to the direct Model collection when searchable, or to the simple root-model name otherwise;
-explicit lower-level composition limits fail rather than returning a partial graph.
+`@Model(materializeGraph = true)`. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` separately only for direct public
+Model search. A blank projection collection appends `-graphs` to the direct Model collection when one exists, or to the
+simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy
 

--- a/project-files/java/agents/rules/guidelines.md
+++ b/project-files/java/agents/rules/guidelines.md
@@ -202,7 +202,8 @@ Use this tree to find the correct manual for your current task, ordered by the r
     `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Direct searchable Model documents complete with the Model commit. Materialized Graph
+21. **The Consistency Window**: Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`
+    complete with the Model commit. Materialized Graph
     projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
     side effects remain eventually consistent.
 22. **Let go of Sequentialism**: Don't try to build long sequential scripts. Let handlers respond to the results of

--- a/project-files/java/agents/rules/runtime-interaction.md
+++ b/project-files/java/agents/rules/runtime-interaction.md
@@ -46,9 +46,9 @@ sequenceDiagram
 
 ### Command Followed by Query
 
-For searchable models, the direct document is part of model-commit completion. A command followed by a direct model
-query therefore reads committed state. Whole-graph projections and documents written by event handlers remain
-asynchronous unless their own completion boundary is awaited.
+For Models using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+A command followed by a direct Model query therefore reads committed state. Whole-Graph projections and documents
+written by event handlers remain asynchronous unless their own completion boundary is awaited.
 
 ---
 

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -31,13 +31,14 @@ data through a unified document store, leveraging automatic indexing and a rich 
 ## Core Rules
 
 1. **No SQL**: Data retrieval is performed exclusively via the `Fluxzero.search()` API or by loading entities.
-2. **Automatic Indexing**: Models with `searchable = true` maintain a direct current-state document.
+2. **Automatic Indexing**: Models with `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` persistence maintain a direct
+   current-state document.
 3. **Stateful Handlers**: `@Stateful` handlers are automatically searchable as they are backed by the document store.
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
    historical, search is optimized for current data.
 6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Configure a Model's
-   direct collection through `searchProjection = @Searchable(collection = "...")`.
+   direct collection through `document = @DocumentProjection(collection = "...")`.
 7. **Server-side Search Logic**: Keep filtering and sorting in Fluxzero search calls (`match`, `any/all`, `sortBy`,
    etc.). Avoid re-implementing filtering/sorting in client app code.
 
@@ -56,8 +57,8 @@ To enable search for a model or any object, use the appropriate annotation.
 [//]: # (@formatter:off)
 ```java
 @Model(
-        searchable = true,
-        searchProjection = @Searchable(collection = "active_projects"))
+        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        document = @DocumentProjection(collection = "active_projects"))
 public record Project(...) {}
 
 @Searchable(collection = "custom_docs")
@@ -233,7 +234,8 @@ CompletableFuture<List<FacetStats>> handle(ProjectFacetQuery query) {
 
 ## Consistency & The Window
 
-Direct searchable-model documents are **synchronous with model-commit completion**.
+Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are **synchronous with Model-commit
+completion**.
 
 - **Direct model guarantee**: `sendCommandAndWait` followed by a direct model search observes the committed direct
   document.

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -21,7 +21,7 @@ Fluxzero 1.x compatibility surfaces and are scheduled for deprecation in 2.0.
 ## Define a model
 
 ```kotlin
-@Model(searchable = true)
+@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -34,12 +34,13 @@ definitions unless the user asks for them.
 
 Important settings:
 
-- `eventSourced`: controls the current-state load route. Events are still stored when `false`.
+- `persistence`: selects exactly one durable/load contract:
+  - `EVENT_SOURCED` (default): reconstruct from Model events, without a direct public document.
+  - `EVENT_SOURCED_WITH_DOCUMENT`: reconstruct from events and maintain a direct searchable current document.
+  - `DOCUMENT`: load authoritative current state from the direct document.
 - `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
-- `searchable`: maintains an independently searchable synchronous current-state document. `false` suppresses only the
-  model's own collection; an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true` still retains the
-  private graph-component document needed for composition.
-- `searchProjection`: optional `Searchable` configuration for the direct collection and timestamp paths.
+- `document`: optional `DocumentProjection` configuration for the direct collection and timestamp paths. It is valid
+  only when `persistence` stores a direct document.
 - `eventPublication`: controls whether unchanged transitions create an event.
 - `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
@@ -50,11 +51,13 @@ Important settings:
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `GraphProjection` configuration; its collection defaults to the resolved direct
-  Model collection plus `-graphs` when searchable, or `<simple model name>-graphs` otherwise, and materializes the
-  complete finite graph without implicit size limits.
+  Model collection plus `-graphs` when a direct document exists, or `<simple model name>-graphs` otherwise, and
+  materializes the complete finite graph without implicit size limits.
 
-`eventSourced = false` does not disable event storage or publication. It means current state loads from the direct
-document. Historical event-boundary loads still use stored model events.
+Persistence does not control event storage or publication. Those remain owned by `eventPublication`,
+`publicationStrategy` and per-apply overrides. Internal Graph-component documents are also orthogonal: they neither
+make an `EVENT_SOURCED` Model directly searchable nor change its load path. Event-sourcing-only options such as
+`ignoreUnknownEvents`, snapshots and replay checkpoints are rejected on `DOCUMENT` Models.
 
 ## Apply actions
 
@@ -204,7 +207,7 @@ that order is a domain requirement.
 ## Relationships
 
 ```kotlin
-@Model(searchable = true)
+@Model
 data class Task(
     @EntityId val taskId: TaskId,
     @Parent(pathInParent = "tasks")
@@ -256,7 +259,7 @@ not modify direct Models, histories or relationships.
 `@Model` plus `@Member` is the intentional shared-stream option:
 
 ```kotlin
-@Model(searchable = true)
+@Model
 data class Invoice(
     @EntityId val invoiceId: InvoiceId,
     @Member val lines: List<InvoiceLine>
@@ -394,9 +397,9 @@ forced-live nested-path filter when the child type is known. Use
 It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` for explicit raw
 JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Enable `searchable` separately only for direct public Model search. A blank projection
-collection appends `-graphs` to the direct Model collection when searchable, or to the simple root-model name otherwise;
-explicit lower-level composition limits fail rather than returning a partial graph.
+`@Model(materializeGraph = true)`. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` separately only for direct public
+Model search. A blank projection collection appends `-graphs` to the direct Model collection when one exists, or to the
+simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy
 

--- a/project-files/kotlin/agents/rules/guidelines.md
+++ b/project-files/kotlin/agents/rules/guidelines.md
@@ -202,7 +202,8 @@ Use this tree to find the correct manual for your current task, ordered by the r
     `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Direct searchable Model documents complete with the Model commit. Materialized Graph
+21. **The Consistency Window**: Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`
+    complete with the Model commit. Materialized Graph
     projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
     side effects remain eventually consistent.
 22. **Let go of Sequentialism**: Don't try to build long sequential scripts. Let handlers respond to the results of

--- a/project-files/kotlin/agents/rules/runtime-interaction.md
+++ b/project-files/kotlin/agents/rules/runtime-interaction.md
@@ -46,9 +46,9 @@ sequenceDiagram
 
 ### Command Followed by Query
 
-For searchable models, the direct document is part of model-commit completion. A command followed by a direct model
-query therefore reads committed state. Whole-graph projections and documents written by event handlers remain
-asynchronous unless their own completion boundary is awaited.
+For Models using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+A command followed by a direct Model query therefore reads committed state. Whole-Graph projections and documents
+written by event handlers remain asynchronous unless their own completion boundary is awaited.
 
 ---
 

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -31,13 +31,14 @@ data through a unified document store, leveraging automatic indexing and a rich 
 ## Core Rules
 
 1. **No SQL**: Data retrieval is performed exclusively via the `Fluxzero.search()` API or by loading entities.
-2. **Automatic Indexing**: Models with `searchable = true` maintain a direct current-state document.
+2. **Automatic Indexing**: Models with `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` persistence maintain a direct
+   current-state document.
 3. **Stateful Handlers**: `@Stateful` handlers are automatically searchable as they are backed by the document store.
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
    historical, search is optimized for current data.
 6. **Collection Naming**: By default, collections are named after the class (e.g., `Project`). Configure a Model's
-   direct collection through `searchProjection = Searchable(collection = "...")`.
+   direct collection through `document = DocumentProjection(collection = "...")`.
 7. **Server-side Search Logic**: Keep filtering and sorting in Fluxzero search calls (`match`, `any/all`, `sortBy`,
    etc.). Avoid re-implementing filtering/sorting in client app code.
 
@@ -55,8 +56,8 @@ To enable search for a model or any object, use the appropriate annotation.
 
 ```kotlin
 @Model(
-    searchable = true,
-    searchProjection = Searchable(collection = "active_projects"),
+    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    document = DocumentProjection(collection = "active_projects"),
 )
 data class Project(...)
 
@@ -219,7 +220,8 @@ fun handle(query: ProjectFacetQuery): CompletableFuture<List<FacetStats>> =
 
 ## Consistency & The Window
 
-Direct searchable-model documents are **synchronous with model-commit completion**.
+Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are **synchronous with Model-commit
+completion**.
 
 - **Direct model guarantee**: `sendCommandAndWait` followed by a direct model search observes the committed direct
   document.

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.modeling;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures the direct current-state document maintained by a {@link Model} whose
+ * {@link Model#persistence() persistence} stores a document.
+ */
+@Documented
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DocumentProjection {
+
+    /** Collection receiving current Model documents. Blank defaults to the Model's simple class name. */
+    String collection() default "";
+
+    /** Optional property path used as the document's start timestamp. */
+    String timestampPath() default "";
+
+    /** Optional property path used as the document's end timestamp. */
+    String endPath() default "";
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
@@ -217,6 +217,9 @@ public final class EntityMetadata {
         if (model != null && aggregate != null) {
             throw invalid("%s cannot be annotated with both @Model and @Aggregate".formatted(type.getName()));
         }
+        if (model != null) {
+            validateModelPersistence(type, model);
+        }
         return model == null
                 ? aggregate == null ? null : RootConfiguration.aggregate(aggregate)
                 : RootConfiguration.model(model);
@@ -508,8 +511,8 @@ public final class EntityMetadata {
     /**
      * Whether this model is placed in an automatically composed graph through at least one explicit parent path.
      * <p>
-     * Graph participation is independent from {@link Model#searchable()}: a model can supply a current document for
-     * composition without exposing that document through its own searchable collection.
+     * Graph participation is independent from {@link Model#persistence()}: a Model can supply an internal current
+     * document for composition without exposing a direct document through its own collection.
      */
     public boolean participatesInGraphComposition() {
         return parentReferences.stream()
@@ -521,7 +524,7 @@ public final class EntityMetadata {
         if (model == null) {
             return Optional.empty();
         }
-        if (rootConfiguration.searchable()) {
+        if (rootConfiguration.directDocument()) {
             return Optional.of(configuredModelDocumentCollection());
         }
         return participatesInGraphComposition() || rootConfiguration.materializeGraph()
@@ -560,7 +563,7 @@ public final class EntityMetadata {
                 () -> new IllegalStateException(
                         "Graph projection root %s has no current-document collection"
                                 .formatted(type.getName())));
-        String publicCollectionBase = rootConfiguration.searchable()
+        String publicCollectionBase = rootConfiguration.directDocument()
                 ? rootCollection : type.getSimpleName();
         String collection = projection.collection().isEmpty()
                 ? publicCollectionBase + "-graphs"
@@ -838,6 +841,36 @@ public final class EntityMetadata {
                 throw invalid("Multiple graph projection paths on %s project to '%s'"
                                       .formatted(type.getName(), override.projectionPath()));
             }
+        }
+    }
+
+    private static void validateModelPersistence(Class<?> type, Model annotation) {
+        ModelPersistence persistence = annotation.persistence();
+        if (!persistence.isEventSourced()) {
+            if (annotation.ignoreUnknownEvents()) {
+                throw invalid("@Model.ignoreUnknownEvents on %s requires event-sourced persistence"
+                                      .formatted(type.getName()));
+            }
+            if (annotation.snapshotPeriod() != 0) {
+                throw invalid("@Model.snapshotPeriod on %s requires event-sourced persistence"
+                                      .formatted(type.getName()));
+            }
+            if (annotation.maxSnapshotCount() != 1) {
+                throw invalid("@Model.maxSnapshotCount on %s requires event-sourced persistence"
+                                      .formatted(type.getName()));
+            }
+            if (annotation.checkpointPeriod() != 100) {
+                throw invalid("@Model.checkpointPeriod on %s requires event-sourced persistence"
+                                      .formatted(type.getName()));
+            }
+        }
+        DocumentProjection document = annotation.document();
+        if (!persistence.storesDocument()
+            && (!document.collection().isEmpty()
+                || !document.timestampPath().isEmpty()
+                || !document.endPath().isEmpty())) {
+            throw invalid("@Model.document on %s requires persistence that stores a direct document"
+                                  .formatted(type.getName()));
         }
     }
 
@@ -1424,7 +1457,7 @@ public final class EntityMetadata {
             CommitPolicy commitPolicy,
             EventPublication eventPublication,
             EventPublicationStrategy publicationStrategy,
-            boolean searchable,
+            boolean directDocument,
             boolean materializeGraph,
             GraphProjection graphProjection,
             String collection,
@@ -1441,13 +1474,13 @@ public final class EntityMetadata {
         static RootConfiguration model(Model annotation) {
             return new RootConfiguration(
                     RootKind.MODEL, annotation.conflictPolicy(), annotation.automaticHandling(),
-                    annotation.eventSourced(), annotation.ignoreUnknownEvents(),
+                    annotation.persistence().isEventSourced(), annotation.ignoreUnknownEvents(),
                     annotation.snapshotPeriod(), annotation.maxSnapshotCount(), annotation.cached(),
                     annotation.cachingDepth(), annotation.checkpointPeriod(), annotation.commitPolicy(),
                     annotation.eventPublication(), annotation.publicationStrategy(),
-                    annotation.searchable(), annotation.materializeGraph(), annotation.graphProjection(),
-                    annotation.searchProjection().collection(), annotation.searchProjection().timestampPath(),
-                    annotation.searchProjection().endPath());
+                    annotation.persistence().storesDocument(), annotation.materializeGraph(), annotation.graphProjection(),
+                    annotation.document().collection(), annotation.document().timestampPath(),
+                    annotation.document().endPath());
         }
 
         static RootConfiguration aggregate(Aggregate annotation) {
@@ -1496,7 +1529,7 @@ public final class EntityMetadata {
             return new RootConfiguration(
                     kind, conflictPolicy, automaticHandling, eventSourced, ignoreUnknownEvents,
                     snapshotPeriod, maxSnapshotCount, cached, cachingDepth, checkpointPeriod, commitPolicy,
-                    eventPublication, publicationStrategy, searchable, materializeGraph,
+                    eventPublication, publicationStrategy, directDocument, materializeGraph,
                     graphProjection, collection, timestampPath, endPath);
         }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphProjection.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
  * <p>
  * Configure this through {@link Model#graphProjection()} and enable it with {@link Model#materializeGraph()}. Without
  * an explicit {@link #collection()}, Fluxzero appends {@code -graphs} to the resolved direct-model collection when the
- * root is searchable, or to the simple model name otherwise. An explicit collection remains available when that
- * durable public search contract needs a custom name.
+ * root has a direct document, or to the simple Model name otherwise. An explicit collection remains available when
+ * that durable public search contract needs a custom name.
  */
 @Documented
 @Target({})

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
@@ -18,7 +18,6 @@ package io.fluxzero.sdk.modeling;
 
 import io.fluxzero.common.api.modeling.ModelConflictPolicy;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
-import io.fluxzero.sdk.persisting.search.Searchable;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -50,18 +49,17 @@ import java.lang.annotation.Target;
  * invalid for model applies because it does not identify a stored result. Legacy mutable aggregate applies remain
  * supported.
  *
- * <h2>Event-sourced and document-based loading</h2>
- * {@link #eventSourced()} selects the normal load path, not whether applied events are stored or published. An
- * event-sourced model is reconstructed from its model stream, optionally from a snapshot. A document-based model is
- * loaded directly from its current document. In both cases, event storage and publication are controlled independently
- * by {@link #eventPublication()}, {@link #publicationStrategy()}, and per-apply overrides. Choose this persistence
- * strategy after choosing the lifecycle boundary. Splitting independently living children into their own models often
- * makes their individual streams small enough for straightforward event sourcing even when the former shared root had
- * a very large event history.
+ * <h2>Persistence</h2>
+ * {@link #persistence()} makes the durable representation and authoritative load path explicit. Event-sourced models
+ * are reconstructed from their model stream, optionally from a snapshot. They may additionally maintain a direct
+ * current document for search. Document-authoritative models load directly from that current document. Event storage
+ * and publication remain independent and are controlled by {@link #eventPublication()},
+ * {@link #publicationStrategy()}, and per-apply overrides. Internal component documents used for Graph composition are
+ * likewise orthogonal and never change the selected load path.
  *
  * <h2>Example</h2>
  * <pre>{@code
- * @Model(searchable = true)
+ * @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
  * public record Product(@EntityId ProductId productId, String name) {
  *     @Apply
  *     Product rename(RenameProduct command) {
@@ -80,13 +78,13 @@ import java.lang.annotation.Target;
  * @see Parent
  * @see Apply
  * @see EntityId
- * @see Searchable
+ * @see ModelPersistence
+ * @see DocumentProjection
  */
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Searchable
 public @interface Model {
 
     /**
@@ -100,16 +98,15 @@ public @interface Model {
     AutomaticModelHandling automaticHandling() default AutomaticModelHandling.DEFAULT;
 
     /**
-     * Whether normal loads reconstruct the model from its event stream.
+     * Durable representation and authoritative load path for this Model.
      * <p>
-     * When disabled, the current model is loaded directly from its document through the configured
-     * {@link io.fluxzero.sdk.persisting.search.DocumentSerializer}. This setting does not suppress storing or publishing
-     * events produced by {@link Apply} methods. A state-changing event-sourced model apply must store its reconstructing
-     * event; a {@code PUBLISH_ONLY} or {@link EventPublication#NEVER NEVER} transition that would change state is
-     * rejected before commit. A publish-only no-op remains a valid domain notification when publication is explicitly
-     * set to {@link EventPublication#ALWAYS ALWAYS}.
+     * This setting does not suppress storing or publishing events produced by {@link Apply} methods. A state-changing
+     * event-sourced Model apply must store its reconstructing event; a {@code PUBLISH_ONLY} or
+     * {@link EventPublication#NEVER NEVER} transition that would change state is rejected before commit. A publish-only
+     * no-op remains a valid domain notification when publication is explicitly set to
+     * {@link EventPublication#ALWAYS ALWAYS}.
      */
-    boolean eventSourced() default true;
+    ModelPersistence persistence() default ModelPersistence.EVENT_SOURCED;
 
     /**
      * Whether unknown events should be ignored while reconstructing an event-sourced model.
@@ -180,35 +177,22 @@ public @interface Model {
     EventPublicationStrategy publicationStrategy() default EventPublicationStrategy.DEFAULT;
 
     /**
-     * Whether the model should expose a synchronous current document through its ordinary class-based search
-     * collection.
+     * Advanced configuration for the Model's direct current document.
      * <p>
-     * Successful commit completion makes the directly changed model searchable in its own collection. This setting
-     * does not control graph participation: a model connected through an explicit {@link Parent#pathInParent()} still
-     * supplies an internal current document for virtual and materialized graph composition. Private component
-     * documents are isolated per model type and can be selected through relationship constraints such as
-     * {@link io.fluxzero.sdk.persisting.search.Search#whereDescendant(Object,
-     * io.fluxzero.common.api.search.Constraint...)}, without exposing the model through its ordinary class-based
-     * search collection. Composed root documents are separate projections.
+     * Select a {@link ModelPersistence} that stores a document to enable this projection. The document store makes the
+     * resulting current state searchable. The collection defaults to the Model's simple class name; timestamps default
+     * to the applied event timestamp when no paths are configured.
      */
-    boolean searchable() default false;
-
-    /**
-     * Advanced configuration for the model's direct search document.
-     * <p>
-     * This configuration does not enable indexing by itself; set {@link #searchable()} to {@code true}. Defaults to
-     * the model's simple class name as collection and to event timestamps when no timestamp paths are configured.
-     */
-    Searchable searchProjection() default @Searchable;
+    DocumentProjection document() default @DocumentProjection;
 
     /**
      * Whether Fluxzero should asynchronously materialize the complete model graph as a separate search document.
      * <p>
-     * Fluxzero retains the root's current document in its direct collection when {@link #searchable()} is enabled and
-     * otherwise in the same type-isolated private component storage used by non-searchable children. Only the
-     * separately named graph collection is allowed to lag; its high-watermark is exposed through the model repository.
-     * The collection defaults to the resolved direct-model collection plus {@code -graphs} when searchable, or to
-     * {@code <simple model name>-graphs} otherwise.
+     * Fluxzero retains the root's current document in its direct collection when {@link #persistence()} stores a
+     * document and otherwise in the same type-isolated private component storage used by other Graph-only Models. Only
+     * the separately named graph collection is allowed to lag; its high-watermark is exposed through the model
+     * repository. The collection defaults to the resolved direct-model collection plus {@code -graphs} when present,
+     * or to {@code <simple model name>-graphs} otherwise.
      */
     boolean materializeGraph() default false;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPersistence.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPersistence.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.modeling;
+
+/**
+ * Defines the durable representation and authoritative load path of a {@link Model}.
+ * <p>
+ * This choice is independent from event publication and from internal documents used to compose model graphs.
+ */
+public enum ModelPersistence {
+
+    /** Reconstruct state from the model event stream and do not maintain a directly searchable current document. */
+    EVENT_SOURCED(true, false),
+
+    /** Reconstruct state from the event stream and also maintain a directly searchable current document. */
+    EVENT_SOURCED_WITH_DOCUMENT(true, true),
+
+    /**
+     * Treat the current document as authoritative and load state directly through the configured document serializer.
+     */
+    DOCUMENT(false, true);
+
+    private final boolean eventSourced;
+    private final boolean storesDocument;
+
+    ModelPersistence(boolean eventSourced, boolean storesDocument) {
+        this.eventSourced = eventSourced;
+        this.storesDocument = storesDocument;
+    }
+
+    /** Whether normal loads reconstruct state from stored model events. */
+    public boolean isEventSourced() {
+        return eventSourced;
+    }
+
+    /** Whether commits maintain a directly searchable current document. */
+    public boolean storesDocument() {
+        return storesDocument;
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
@@ -435,7 +435,8 @@ final class ModelPipeline {
                         () -> commit(
                                 repositoryCommit, message.getMessageId(), evaluation,
                                 effectiveConflictPolicy, retry,
-                                migration, existingEvent, transportBatch, transportSlot));
+                                migration, existingEvent, transportBatch, transportSlot,
+                                !localHandlingEnabled.getAsBoolean()));
         return committed.handle((commitResult, failure) ->
                 finishEvaluation(evaluation, effectiveConflictPolicy, failure));
     }
@@ -447,10 +448,12 @@ final class ModelPipeline {
             ModelConflictPolicy conflictPolicy,
             Retry retry,
             ModelCommitBatchingClient.ModelCommitBatch batch,
-            int batchSlot) {
+            int batchSlot,
+            boolean asynchronousReevaluation) {
         return commit(
                 repositoryCommit, commitId, evaluation, conflictPolicy,
-                retry, false, false, batch, batchSlot);
+                retry, false, false, batch, batchSlot,
+                asynchronousReevaluation);
     }
 
     private static CompletableFuture<Optional<CommitModelsResult>> commit(
@@ -462,14 +465,16 @@ final class ModelPipeline {
             boolean migration,
             boolean existingEvent,
             ModelCommitBatchingClient.ModelCommitBatch batch,
-            int batchSlot) {
+            int batchSlot,
+            boolean asynchronousReevaluation) {
         Objects.requireNonNull(retry, "retry");
         Commit.Outcome original = repositoryCommit.prepare(
                 commitId, evaluation, conflictPolicy, migration, existingEvent);
         return commit(
                 repositoryCommit, commitId, evaluation, conflictPolicy,
                 original, original, retry,
-                ThreadLocalContext.capture(), 0, batch, batchSlot);
+                ThreadLocalContext.capture(), 0, batch, batchSlot,
+                asynchronousReevaluation);
     }
 
     private static CompletableFuture<Optional<CommitModelsResult>> commit(
@@ -483,7 +488,8 @@ final class ModelPipeline {
             ThreadLocalContext.Snapshot context,
             int attempts,
             ModelCommitBatchingClient.ModelCommitBatch batch,
-            int batchSlot) {
+            int batchSlot,
+            boolean asynchronousReevaluation) {
         return repositoryCommit.commitPrepared(prepared, batch, batchSlot)
                 .thenCompose(optional -> {
                     if (optional.isEmpty()) {
@@ -503,11 +509,12 @@ final class ModelPipeline {
                         return CompletableFuture.completedFuture(optional);
                     }
                     return retryDecision(result, attempts, retry, context)
-                            .thenCompose(ignored -> invokeAsync(
+                            .thenCompose(ignored -> invoke(
                                     context,
                                     () -> retry.evaluator().reevaluate(
                                             result, evaluation),
-                                    "Model commit reevaluation returned null"))
+                                    "Model commit reevaluation returned null",
+                                    asynchronousReevaluation))
                             .thenCompose(next -> {
                                 if (retry.accepting()
                                     && next.readStateIndex() != result.getRebaseStateIndex()) {
@@ -527,9 +534,26 @@ final class ModelPipeline {
                                 return commit(
                                         repositoryCommit, commitId, next, conflictPolicy,
                                         original, nextPrepared, retry,
-                                        context, attempts + 1, null, -1);
+                                        context, attempts + 1, null, -1,
+                                        asynchronousReevaluation);
                             });
                 });
+    }
+
+    private static <T> CompletableFuture<T> invoke(
+            ThreadLocalContext.Snapshot context,
+            Supplier<CompletableFuture<T>> operation,
+            String nullMessage,
+            boolean asynchronous) {
+        if (asynchronous) {
+            return invokeAsync(context, operation, nullMessage);
+        }
+        try {
+            return context.supply(() ->
+                    Objects.requireNonNull(operation.get(), nullMessage));
+        } catch (Throwable failure) {
+            return CompletableFuture.failedFuture(failure);
+        }
     }
 
     private static CompletableFuture<Void> retryDecision(

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Parent.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Parent.java
@@ -47,10 +47,10 @@ import java.lang.annotation.Target;
  * bundles available without silently deriving a durable document path from a Java class name. The path names a
  * list-valued collection: the runtime appends deterministic numeric child positions, so numeric path segments are not
  * allowed.
- * Graph placement is independent from {@link Model#searchable()}: a non-searchable child with an explicit path is
- * retained in a type-isolated private current-document collection for composition and indexed relationship
- * selection, but is not exposed through its own collection. Parent and graph searches can therefore select matching
- * children first and traverse their current relationship edges without composing unrelated roots.
+ * Graph placement is independent from {@link Model#persistence()}: a child without a direct document but with an
+ * explicit path is retained in a type-isolated private current-document collection for composition and indexed
+ * relationship selection, but is not exposed through its own collection. Parent and Graph searches can therefore
+ * select matching children first and traverse their current relationship edges without composing unrelated roots.
  * {@link #apiDoc()} optionally describes the list-valued property created at that path when the graph is used as a
  * documented web response. It has no effect unless {@link #pathInParent()} is set.
  * <p>

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
@@ -82,8 +82,8 @@ public class SearchParameters implements Substitutable<SearchParameters> {
     /**
      * Resolves the effective search configuration for a model or searchable document type.
      *
-     * <p>Models own their direct-document projection through {@link Model#searchProjection()}; other document types
-     * continue to use {@link Searchable}. An unspecified collection resolves to the type's simple name.</p>
+     * <p>Models own their direct-document projection through {@link Model#document()}; other document types continue
+     * to use {@link Searchable}. An unspecified collection resolves to the type's simple name.</p>
      */
     public static SearchParameters forType(Class<?> type) {
         EntityMetadata.RootConfiguration model = EntityMetadata.rootConfiguration(type)
@@ -91,7 +91,7 @@ public class SearchParameters implements Substitutable<SearchParameters> {
                 .orElse(null);
         if (model != null) {
             return new SearchParameters(
-                    model.searchable(), model.resolvedCollection(type),
+                    model.directDocument(), model.resolvedCollection(type),
                     model.timestampPath(), model.endPath());
         }
         return io.fluxzero.common.reflection.ReflectionUtils

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/caching/SoftReferenceCache.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/caching/SoftReferenceCache.java
@@ -198,75 +198,26 @@ public class SoftReferenceCache implements Cache, AutoCloseable {
             BiFunction<? super T, ? super T, ? extends T> mergeFunction) {
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(mergeFunction, "mergeFunction");
-        synchronized (valueMap) {
-            if (valueMap.isEmpty()) {
-                Map<Object, CacheReference> additions =
-                        new LinkedHashMap<>(
-                                (int) Math.min(
-                                        (long) values.size()
-                                        * 4L / 3L + 1L,
-                                        maxSize));
-                values.forEach(
-                        (id, candidate) -> {
-                            CacheReference next =
-                                    wrap(
-                                            id,
-                                            mergeFunction.apply(
-                                                    null,
-                                                    candidate));
-                            if (next != null) {
-                                additions.put(id, next);
-                            }
-                        });
-                valueMap.putAll(additions);
-                return;
-            }
-            values.forEach(
-                    (id, candidate) -> {
-                        CacheReference previous =
-                                valueMap.get(id);
-                        CacheReference next =
-                                wrap(
-                                        id,
+        values.forEach(
+                (id, candidate) ->
+                        this.<T>compute(
+                                id,
+                                (ignored, current) ->
                                         mergeFunction.apply(
-                                                unwrap(previous),
-                                                candidate));
-                        if (next == null) {
-                            valueMap.remove(id);
-                            if (previous != null
-                                && previous.get() != null) {
-                                registerEviction(
-                                        previous, manual);
-                            }
-                        } else {
-                            valueMap.put(id, next);
-                        }
-                    });
-        }
+                                                current,
+                                                candidate)));
     }
 
     @Override
     public <T> void updateAll(
             Map<?, ? extends Function<? super T, ? extends T>> updates) {
         Objects.requireNonNull(updates, "updates");
-        synchronized (valueMap) {
-            updates.forEach(
-                    (id, update) -> {
-                        CacheReference previous = valueMap.get(id);
-                        CacheReference next = wrap(
+        updates.forEach(
+                (id, update) ->
+                        this.<T>compute(
                                 id,
-                                update.apply(unwrap(previous)));
-                        if (next == null) {
-                            valueMap.remove(id);
-                            if (previous != null
-                                && previous.get() != null) {
-                                registerEviction(previous, manual);
-                            }
-                        } else {
-                            valueMap.put(id, next);
-                        }
-                    });
-        }
+                                (ignored, current) ->
+                                        update.apply(current)));
     }
 
     private static Object computeLock(Object id) {

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultAggregateRepository.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultAggregateRepository.java
@@ -398,7 +398,7 @@ public class DefaultAggregateRepository extends AbstractNamespaced<AggregateRepo
                     ? DefaultAggregateRepository.this.relationshipsCache : RelationshipsCache.noOp();
             this.commitPolicy = resolveCommitPolicy(configuration);
             this.snapshotSettings = configuration.snapshotSettings(
-                    !configuration.eventSourced() && !configuration.searchable());
+                    !configuration.eventSourced() && !configuration.directDocument());
             this.snapshotStore = snapshotSettings.enabled()
                     ? DefaultAggregateRepository.this.snapshotStore : NoOpSnapshotStore.INSTANCE;
             this.collection = Optional.of(configuration.collection())
@@ -437,7 +437,7 @@ public class DefaultAggregateRepository extends AbstractNamespaced<AggregateRepo
                     new RepairRelationships(aggregateId, type.getName(), Collections.emptySet(), STORED)));
             futures.add(eventStoreClient.deleteEvents(aggregateId, STORED));
             futures.add(snapshotStore.deleteSnapshot(id));
-            if (configuration.searchable()) {
+            if (configuration.directDocument()) {
                 futures.add(documentStore.deleteDocument(id, collection));
             }
             return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
@@ -469,7 +469,7 @@ public class DefaultAggregateRepository extends AbstractNamespaced<AggregateRepo
                             .idProperty(idProperty)
                             .entityHelper(entityHelper).serializer(serializer)
                             .eventStore(eventStore);
-            return (configuration.searchable() && !configuration.eventSourced()
+            return (configuration.directDocument() && !configuration.eventSourced()
                     ? documentStore.<T>fetchDocument(id, collection)
                     .map(d -> builder.value(d).build())
                     : snapshotStore.<T>getSnapshot(id).map(
@@ -603,7 +603,7 @@ public class DefaultAggregateRepository extends AbstractNamespaced<AggregateRepo
                         futures.add(eventsStored.thenCompose(ignored -> snapshotStore.storeSnapshot(after)));
                     }
                 }
-                if (stateChanged && configuration.searchable()) {
+                if (stateChanged && configuration.directDocument()) {
                     Object value = after.get();
                     if (value == null) {
                         futures.add(eventsStored.thenCompose(

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Searchable.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Searchable.java
@@ -30,9 +30,8 @@ import java.lang.annotation.Target;
  * it to be stored and queried using {@link io.fluxzero.sdk.persisting.search.DocumentStore}.
  * <p>
  * This annotation can also be used as a meta-annotation to define custom searchable types with preconfigured values.
- * Independent models use the same collection and timestamp configuration through
- * {@link io.fluxzero.sdk.modeling.Model#searchProjection()}; {@link io.fluxzero.sdk.modeling.Model#searchable()} remains
- * the activation switch in that context.
+ * Independent Models use their dedicated {@link io.fluxzero.sdk.modeling.DocumentProjection} configuration instead;
+ * their {@link io.fluxzero.sdk.modeling.ModelPersistence} determines whether a direct document exists.
  *
  * <h2>Usage</h2>
  * <pre>{@code

--- a/sdk/src/test/java/io/fluxzero/sdk/benchmark/ModelCacheBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/benchmark/ModelCacheBenchmark.java
@@ -359,6 +359,7 @@ public class ModelCacheBenchmark {
                 .targets(List.of(
                         ModelCommitTarget.builder()
                                 .modelId(id.toString())
+                                .modelType(Counter.class.getName())
                                 .storeEvent(true)
                                 .updateState(true)
                                 .relationships(List.of())

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -242,7 +242,7 @@ class DefaultModelRepositoryCommitTest {
                     assertEquals(51L, result.getRebaseStateIndex());
                     assertEquals(1, current.steps().size());
                     return CompletableFuture.completedFuture(rebased);
-                }), null, -1).join();
+                }), null, -1, true).join();
 
         assertTrue(accepted.orElseThrow().isAccepted());
         ArgumentCaptor<CommitModels> requests =
@@ -258,6 +258,49 @@ class DefaultModelRepositoryCommitTest {
         assertEquals(
                 merged,
                 serializer.deserialize(direct.target(id.toString()).getState()));
+    }
+
+    @Test
+    void localAcceptRebaseReevaluatesInline() {
+        OrderId id = new OrderId("local-rebase");
+        Order before = new Order(id, null, "before", Instant.EPOCH);
+        Order stale = new Order(id, null, "stale", Instant.EPOCH.plusMillis(1));
+        Order after = new Order(id, null, "after", Instant.EPOCH.plusSeconds(1));
+        UpdateOrder event = new UpdateOrder(id);
+        var original = evaluation(
+                List.of(id.toString()),
+                substep(event, Change.applied(
+                        id.toString(), Order.class, 0L, null,
+                        before, stale, null, current -> current, false)),
+                Map.of(id.toString(), stale));
+        var rebased = evaluation(
+                51L, List.of(id.toString()), Map.of(id.toString(), Order.class),
+                List.of(substep(event, Change.applied(
+                        id.toString(), Order.class, 0L, null,
+                        before, after, null, current -> current, false))),
+                Map.of(id.toString(), after));
+        AtomicInteger commits = new AtomicInteger();
+        when(eventStoreClient.commitModels(any())).thenAnswer(invocation -> {
+            CommitModels request = invocation.getArgument(0);
+            return commits.getAndIncrement() == 0
+                    ? CompletableFuture.completedFuture(CommitModelsResult.rebase(
+                            request.getRequestId(), request.getCommitId(),
+                            List.of(new ModelCommitConflict(id.toString(), 51L, 0L)), 51L))
+                    : CompletableFuture.completedFuture(result(request));
+        });
+        String callerThread = Thread.currentThread().getName();
+        AtomicReference<String> rebaseThread = new AtomicReference<>();
+
+        CompletableFuture<Optional<CommitModelsResult>> completion = ModelPipeline.commit(
+                protocol, "local-rebase", original, ModelConflictPolicy.ACCEPT,
+                ModelPipeline.Retry.accepting((result, current) -> {
+                    rebaseThread.set(Thread.currentThread().getName());
+                    return CompletableFuture.completedFuture(rebased);
+                }), null, -1, false);
+
+        assertTrue(completion.isDone());
+        assertTrue(completion.join().orElseThrow().isAccepted());
+        assertEquals(callerThread, rebaseThread.get());
     }
 
     @Test
@@ -600,7 +643,7 @@ class DefaultModelRepositoryCommitTest {
                         (conflict, current) -> {
                     reloads.incrementAndGet();
                     return CompletableFuture.completedFuture(reloadedEvaluation);
-                }), null, -1).join();
+                }), null, -1, true).join();
 
         assertTrue(result.orElseThrow().isAccepted());
         assertEquals(2, commits.get());
@@ -645,7 +688,7 @@ class DefaultModelRepositoryCommitTest {
                         (conflict, current) -> {
                     reloads.incrementAndGet();
                     return CompletableFuture.completedFuture(evaluation);
-                }), null, -1).join());
+                }), null, -1, true).join());
 
         assertInstanceOf(ModelCommitConflictException.class, bounded.getCause());
         assertEquals(1, reloads.get());
@@ -660,7 +703,7 @@ class DefaultModelRepositoryCommitTest {
                         }, 0,
                         (conflict, current) ->
                                 CompletableFuture.completedFuture(evaluation)),
-                null, -1).join());
+                null, -1, true).join());
         assertEquals(applicationError, mapped.getCause());
     }
 
@@ -943,7 +986,7 @@ class DefaultModelRepositoryCommitTest {
                     assertEquals(1, current.steps().size());
                     return CompletableFuture.completedFuture(
                             rebased);
-                }), null, -1).join();
+                }), null, -1, true).join();
 
         assertTrue(accepted.orElseThrow().isAccepted());
         ArgumentCaptor<CommitModels> requests =
@@ -1034,7 +1077,7 @@ class DefaultModelRepositoryCommitTest {
                                                 .getName());
                                 return CompletableFuture.completedFuture(
                                         rebased);
-                            }), null, -1);
+                            }), null, -1, true);
         } finally {
             Fluxzero.instance.remove();
         }

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -1319,8 +1319,9 @@ class DefaultModelRepositoryCommitTest {
     }
 
     @Revision(7)
-    @Model(eventSourced = false, searchable = true,
-            searchProjection = @Searchable(collection = "orders", timestampPath = "changedAt"))
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(collection = "orders", timestampPath = "changedAt"))
     private record Order(
             @EntityId OrderId orderId,
             @Parent(value = Customer.class, pathInParent = "orders") CustomerId customerId,
@@ -1354,7 +1355,7 @@ class DefaultModelRepositoryCommitTest {
         }
     }
 
-    @Model(eventSourced = false)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record PolymorphicContact(
             @EntityId String id,
             @Parent(types = {Customer.class, AlternateCustomer.class}, pathInParent = "contacts") Id<?> parentId) {
@@ -1409,10 +1410,7 @@ class DefaultModelRepositoryCommitTest {
         }
     }
 
-    @Model(
-            eventSourced = false,
-            searchable = true,
-            searchProjection = @Searchable(collection = "privateDocuments"),
+    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "privateDocuments"),
             eventPublication = EventPublication.NEVER)
     private record PrivateDocument(@EntityId PrivateDocumentId documentId, String value) {
     }
@@ -1430,7 +1428,7 @@ class DefaultModelRepositoryCommitTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record ConditionalModel(@EntityId ConditionalId conditionalId, String value) {
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
@@ -286,21 +286,24 @@ class EntityMetadataTest {
                 .collect(toSet());
 
         Set<String> expectedSharedSettings = new java.util.HashSet<>(aggregateSettings);
-        expectedSharedSettings.removeAll(Set.of("collection", "timestampPath", "endPath", "eventRouting"));
+        expectedSharedSettings.removeAll(Set.of(
+                "collection", "timestampPath", "endPath", "eventRouting", "eventSourced", "searchable"));
         assertEquals(expectedSharedSettings,
                      modelSettings.stream()
                              .filter(name ->
                                              !Set.of(
                                                      "automaticHandling",
                                                      "conflictPolicy",
+                                                     "document",
                                                      "graphProjection",
                                                      "materializeGraph",
-                                                     "searchProjection")
+                                                     "persistence")
                                                      .contains(name))
                              .collect(toSet()));
         Set<String> expectedConfiguration = new java.util.HashSet<>(modelSettings);
-        expectedConfiguration.remove("searchProjection");
-        expectedConfiguration.addAll(Set.of("collection", "timestampPath", "endPath"));
+        expectedConfiguration.removeAll(Set.of("document", "persistence"));
+        expectedConfiguration.addAll(Set.of(
+                "eventSourced", "directDocument", "collection", "timestampPath", "endPath"));
         assertEquals(expectedConfiguration, configurationSettings);
     }
 
@@ -581,14 +584,15 @@ class EntityMetadataTest {
     private record ParentModel(@EntityId ParentModelId parentId) {
     }
 
-    @Model(eventSourced = false, searchable = true,
-            searchProjection = @Searchable(collection = "models"))
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(collection = "models"))
     private record ConfiguredModel(@EntityId String id) {
     }
 
     @Model(
-            searchable = true,
-            searchProjection = @Searchable(collection = "projected-models"),
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            document = @DocumentProjection(collection = "projected-models"),
             materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "projected-graphs",
@@ -627,23 +631,23 @@ class EntityMetadataTest {
     }
 
     @Model(
-            searchable = true,
-            searchProjection = @Searchable(collection = "default-projected-models"),
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            document = @DocumentProjection(collection = "default-projected-models"),
             materializeGraph = true)
     private record DefaultProjectedModel(
             @EntityId String id) {
     }
 
     @Model(
-            searchable = true,
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
             graphProjection = @GraphProjection(collection = "ignored-graphs"))
     private record ConfiguredUnmaterializedModel(
             @EntityId String id) {
     }
 
     @Model(
-            searchable = true,
-            searchProjection = @Searchable(collection = "same-collection"),
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            document = @DocumentProjection(collection = "same-collection"),
             materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "same-collection"))
@@ -652,8 +656,8 @@ class EntityMetadataTest {
     }
 
     @Model(
-            searchable = true,
-            searchProjection = @Searchable(collection = "${graphRootCollection}"),
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            document = @DocumentProjection(collection = "${graphRootCollection}"),
             materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "${graphProjectionCollection}"))

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
@@ -2473,7 +2473,7 @@ class ModelCommitHandlerIntegrationTest {
         throw lastError;
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record Account(@EntityId AccountId accountId, int balance) {
         @Apply
         Account apply(SetExplicitValue command) {
@@ -2959,7 +2959,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record Inventory(
             @EntityId InventoryId inventoryId, int available) {
     }
@@ -2987,7 +2987,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(eventSourced = false)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record FixedDocument(
             @EntityId FixedDocumentId id, int value) {
         private FixedDocument(int value) {
@@ -2998,6 +2998,11 @@ class ModelCommitHandlerIntegrationTest {
     private static final class FixedDocumentId extends Id<FixedDocument> {
         private FixedDocumentId() {
             super("fixed-document");
+        }
+
+        @SuppressWarnings("unused")
+        private FixedDocumentId(String ignored) {
+            this();
         }
     }
 
@@ -3040,10 +3045,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(
-            eventSourced = false,
-            searchable = true,
-            eventPublication = EventPublication.NEVER)
+    @Model(persistence = ModelPersistence.DOCUMENT, eventPublication = EventPublication.NEVER)
     private record PrivateInventory(
             @EntityId PrivateInventoryId inventoryId, int available) {
     }
@@ -3165,7 +3167,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record FamilyRoot(
             @EntityId FamilyRootId familyRootId,
             String name) {
@@ -3336,7 +3338,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record AffixedRoot(
             @EntityId(prefix = "move-", postfix = "-state") AffixedRootId affixedRootId) {
     }
@@ -3450,7 +3452,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record FamilyChild(
             @EntityId FamilyChildId familyChildId,
             @Parent(pathInParent = "children")
@@ -3476,7 +3478,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record DocumentFamilyChild(
             @EntityId DocumentFamilyChildId documentFamilyChildId,
             @Parent(pathInParent = "documentChildren")
@@ -3502,7 +3504,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(cached = false, searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, cached = false)
     private record FamilyGrandchild(
             @EntityId FamilyGrandchildId familyGrandchildId,
             @Parent(pathInParent = "primaryGrandchildren")
@@ -3638,9 +3640,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "projectionRoots",
                     pathOverrides = @GraphPathOverride(

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
@@ -2036,9 +2036,7 @@ class ModelCommitHandlerRegistryTest {
                 null, false);
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "retryRoots"))
     private record RetryRoot(
@@ -2061,7 +2059,7 @@ class ModelCommitHandlerRegistryTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record RetryBoundaryModel(
             @EntityId String id,
             String value) {
@@ -2426,9 +2424,7 @@ class ModelCommitHandlerRegistryTest {
             String batchId) {
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "awaited-graphs",
                     completion = GraphProjectionCompletion.AWAIT))
@@ -2450,18 +2446,14 @@ class ModelCommitHandlerRegistryTest {
             ProjectionRootId rootId) {
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "default-graphs"))
     private record DefaultProjectionRoot(
             @EntityId String id) {
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "async-graphs",
                     completion = GraphProjectionCompletion.ASYNC))

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelEntityParameterResolverTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelEntityParameterResolverTest.java
@@ -1087,7 +1087,7 @@ class ModelEntityParameterResolverTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record Inventory(
             @EntityId InventoryId inventoryId, int quantity) {
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
@@ -169,7 +169,7 @@ class ModelGraphComponentSearchTest {
                                  .fetchAll()));
     }
 
-    @Model(searchable = true, materializeGraph = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true)
     private record SearchRoot(@EntityId SearchRootId searchRootId) {
     }
 
@@ -273,7 +273,7 @@ class ModelGraphComponentSearchTest {
         }
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record SearchLeaf(
             @EntityId SearchLeafId searchLeafId,
             @Parent(pathInParent = "searchLeaves") PrivateChildId privateChildId) {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
@@ -20,7 +20,6 @@ import io.fluxzero.common.api.modeling.ModelConflictPolicy;
 import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.sdk.common.ClientUtils;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
-import io.fluxzero.sdk.persisting.search.Searchable;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -43,7 +42,7 @@ class ModelTest {
     void exposesIndependentStorageDefaults() {
         Model model = DefaultModel.class.getAnnotation(Model.class);
 
-        assertTrue(model.eventSourced());
+        assertEquals(ModelPersistence.EVENT_SOURCED, model.persistence());
         assertFalse(model.ignoreUnknownEvents());
         assertEquals(0, model.snapshotPeriod());
         assertEquals(1, model.maxSnapshotCount());
@@ -55,11 +54,10 @@ class ModelTest {
         assertEquals(EventPublicationStrategy.DEFAULT, model.publicationStrategy());
         assertEquals(ModelConflictPolicy.DEFAULT, model.conflictPolicy());
         assertEquals(AutomaticModelHandling.DEFAULT, model.automaticHandling());
-        assertFalse(model.searchable());
         assertFalse(model.materializeGraph());
-        assertEquals("", model.searchProjection().collection());
-        assertEquals("", model.searchProjection().timestampPath());
-        assertEquals("", model.searchProjection().endPath());
+        assertEquals("", model.document().collection());
+        assertEquals("", model.document().timestampPath());
+        assertEquals("", model.document().endPath());
     }
 
     @Test
@@ -78,7 +76,7 @@ class ModelTest {
     void exposesAggregateEquivalentConfiguration() {
         Model model = ConfiguredModel.class.getAnnotation(Model.class);
 
-        assertFalse(model.eventSourced());
+        assertEquals(ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, model.persistence());
         assertTrue(model.ignoreUnknownEvents());
         assertEquals(20, model.snapshotPeriod());
         assertEquals(3, model.maxSnapshotCount());
@@ -90,10 +88,9 @@ class ModelTest {
         assertEquals(STORE_ONLY, model.publicationStrategy());
         assertEquals(ModelConflictPolicy.FAIL, model.conflictPolicy());
         assertEquals(AutomaticModelHandling.DISABLED, model.automaticHandling());
-        assertTrue(model.searchable());
-        assertEquals("configured-models", model.searchProjection().collection());
-        assertEquals("createdAt", model.searchProjection().timestampPath());
-        assertEquals("expiresAt", model.searchProjection().endPath());
+        assertEquals("configured-models", model.document().collection());
+        assertEquals("createdAt", model.document().timestampPath());
+        assertEquals("expiresAt", model.document().endPath());
     }
 
     @Test
@@ -107,16 +104,17 @@ class ModelTest {
                 Set.of(
                         "automaticHandling",
                         "conflictPolicy",
+                        "document",
                         "graphProjection",
                         "materializeGraph",
-                        "searchProjection"),
+                        "persistence"),
                 modelSettings.stream()
                         .filter(setting ->
                                         !aggregateSettings
                                                 .contains(setting))
                         .collect(
                                 Collectors.toSet()));
-        assertEquals(Set.of("collection", "timestampPath", "endPath", "eventRouting"),
+        assertEquals(Set.of("collection", "timestampPath", "endPath", "eventRouting", "eventSourced", "searchable"),
                      aggregateSettings.stream()
                              .filter(setting -> !modelSettings.contains(setting))
                              .collect(Collectors.toSet()));
@@ -128,12 +126,12 @@ class ModelTest {
         Model annotation = ReflectionUtils.getTypeMetadata(InheritedModel.class).typeAnnotation(Model.class);
 
         assertNotNull(annotation);
-        assertTrue(annotation.searchable());
-        assertEquals("base-models", annotation.searchProjection().collection());
+        assertEquals(ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, annotation.persistence());
+        assertEquals("base-models", annotation.document().collection());
     }
 
     @Test
-    void resolvesNestedSearchProjectionConfiguration() {
+    void resolvesDocumentProjectionConfiguration() {
         SearchParameters searchable = ClientUtils.getSearchParameters(ConfiguredModel.class);
 
         assertTrue(searchable.isSearchable());
@@ -143,11 +141,24 @@ class ModelTest {
     }
 
     @Test
-    void searchProjectionConfigurationDoesNotEnableSearch() {
-        SearchParameters searchable = ClientUtils.getSearchParameters(ConfiguredUnsearchableModel.class);
+    void documentConfigurationRequiresDirectDocumentPersistence() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> EntityMetadata.validate(InvalidDocumentConfiguration.class));
 
-        assertFalse(searchable.isSearchable());
-        assertEquals("inactive-models", searchable.getCollection());
+        assertTrue(exception.getMessage().contains("requires persistence that stores a direct document"));
+    }
+
+    @Test
+    void documentPersistenceRejectsEventSourcingOptions() {
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(DocumentWithUnknownEventPolicy.class));
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(DocumentWithSnapshots.class));
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(DocumentWithSnapshotRetention.class));
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(DocumentWithReplayCheckpoints.class));
     }
 
     @Test
@@ -188,8 +199,7 @@ class ModelTest {
     private static class DefaultModel {
     }
 
-    @Model(
-            eventSourced = false,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
             ignoreUnknownEvents = true,
             snapshotPeriod = 20,
             maxSnapshotCount = 3,
@@ -201,20 +211,37 @@ class ModelTest {
             publicationStrategy = STORE_ONLY,
             conflictPolicy = ModelConflictPolicy.FAIL,
             automaticHandling = AutomaticModelHandling.DISABLED,
-            searchable = true,
-            searchProjection = @Searchable(
+            document = @DocumentProjection(
                     collection = "configured-models",
                     timestampPath = "createdAt",
                     endPath = "expiresAt"))
     private static class ConfiguredModel {
     }
 
-    @Model(searchable = true, searchProjection = @Searchable(collection = "base-models"))
+    @Model(
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            document = @DocumentProjection(collection = "base-models"))
     private static class BaseModel {
     }
 
-    @Model(searchProjection = @Searchable(collection = "inactive-models"))
-    private static class ConfiguredUnsearchableModel {
+    @Model(document = @DocumentProjection(collection = "inactive-models"))
+    private static class InvalidDocumentConfiguration {
+    }
+
+    @Model(persistence = ModelPersistence.DOCUMENT, ignoreUnknownEvents = true)
+    private static class DocumentWithUnknownEventPolicy {
+    }
+
+    @Model(persistence = ModelPersistence.DOCUMENT, snapshotPeriod = 1)
+    private static class DocumentWithSnapshots {
+    }
+
+    @Model(persistence = ModelPersistence.DOCUMENT, maxSnapshotCount = 2)
+    private static class DocumentWithSnapshotRetention {
+    }
+
+    @Model(persistence = ModelPersistence.DOCUMENT, checkpointPeriod = 10)
+    private static class DocumentWithReplayCheckpoints {
     }
 
     private static class InheritedModel extends BaseModel {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/PersistenceRootParityTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/PersistenceRootParityTest.java
@@ -873,7 +873,8 @@ class PersistenceRootParityTest {
     }
 
     @Model(
-            searchable = true, cachingDepth = 1,
+            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            cachingDepth = 1,
             snapshotPeriod = 2)
     private record ParityModel(
             @EntityId ParityModelId id, String value) {
@@ -968,7 +969,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(eventSourced = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT)
     private record DocumentModel(
             @EntityId DocumentModelId id, String value) {
     }
@@ -1011,9 +1012,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(
-            eventSourced = false, searchable = true,
-            eventPublication = EventPublication.NEVER)
+    @Model(persistence = ModelPersistence.DOCUMENT, eventPublication = EventPublication.NEVER)
     private record SilentModel(
             @EntityId SilentModelId id, String value) {
     }
@@ -1049,9 +1048,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(
-            searchable = true,
-            publicationStrategy =
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, publicationStrategy =
                     EventPublicationStrategy.STORE_ONLY)
     private record StoreOnlyModel(
             @EntityId StoreOnlyModelId id,
@@ -1106,7 +1103,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     private record EmbeddedModel(
             @EntityId EmbeddedModelId id,
             @Member List<EmbeddedValue> members) {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/RecursiveModelRelationshipTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/RecursiveModelRelationshipTest.java
@@ -135,9 +135,7 @@ class RecursiveModelRelationshipTest {
         return folders.stream().map(RecursiveFolder::folderId).toList();
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(collection = "recursiveFolderGraphs"))
     private record RecursiveFolder(
             @EntityId RecursiveFolderId folderId,

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/caching/SoftReferenceCacheTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/caching/SoftReferenceCacheTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import java.time.Duration;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 import static io.fluxzero.common.caching.CacheEviction.Reason.expiry;
 import static io.fluxzero.common.caching.CacheEviction.Reason.manual;
@@ -137,6 +139,57 @@ class SoftReferenceCacheTest {
                 (current, candidate) -> null);
 
         assertNull(subject.get("remove"));
+    }
+
+    @Test
+    @Timeout(10)
+    void mergeAllWaitsForAnInFlightComputeOnTheSameKey() throws InterruptedException {
+        assertBulkUpdateWaitsForCompute(
+                cache -> cache.mergeAll(
+                        Map.of("id", 20),
+                        (current, candidate) -> Math.max(current, candidate)));
+    }
+
+    @Test
+    @Timeout(10)
+    void updateAllWaitsForAnInFlightComputeOnTheSameKey() throws InterruptedException {
+        assertBulkUpdateWaitsForCompute(
+                cache -> cache.updateAll(
+                        Map.of("id", ignored -> 20)));
+    }
+
+    private void assertBulkUpdateWaitsForCompute(
+            Consumer<SoftReferenceCache> bulkUpdate) throws InterruptedException {
+        subject.put("id", 0);
+        CountDownLatch computeStarted = new CountDownLatch(1);
+        CountDownLatch completeCompute = new CountDownLatch(1);
+        Thread compute = Thread.ofPlatform().unstarted(
+                () -> subject.compute(
+                        "id",
+                        (ignored, current) -> ObjectUtils.call(() -> {
+                            computeStarted.countDown();
+                            completeCompute.await();
+                            return 10;
+                        })));
+        compute.start();
+        computeStarted.await();
+
+        Thread bulk = Thread.ofPlatform().unstarted(() -> bulkUpdate.accept(subject));
+        Thread.State blockedState;
+        try {
+            bulk.start();
+            while (bulk.isAlive() && bulk.getState() != Thread.State.BLOCKED) {
+                Thread.onSpinWait();
+            }
+            blockedState = bulk.getState();
+        } finally {
+            completeCompute.countDown();
+            compute.join();
+            bulk.join();
+        }
+
+        assertEquals(Thread.State.BLOCKED, blockedState);
+        assertEquals(20, subject.<Integer>get("id"));
     }
 
     @Test

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -81,7 +81,7 @@ import io.fluxzero.sdk.persisting.eventsourcing.Apply;
 import io.fluxzero.sdk.persisting.eventsourcing.EventSourcingException;
 import io.fluxzero.sdk.persisting.eventsourcing.InterceptApply;
 import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
-import io.fluxzero.sdk.persisting.caching.DefaultCache;
+import io.fluxzero.sdk.persisting.caching.SoftReferenceCache;
 import io.fluxzero.sdk.persisting.search.DocumentSerializer;
 import io.fluxzero.sdk.persisting.search.DocumentStore;
 import io.fluxzero.sdk.persisting.search.Searchable;
@@ -90,6 +90,7 @@ import io.fluxzero.sdk.publishing.DispatchInterceptor;
 import io.fluxzero.sdk.tracking.client.TrackingClient;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -103,6 +104,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1499,40 +1502,49 @@ class DefaultModelRepositoryTest {
 
     @Test
     void olderCommitCompletionCannotOverwriteANewerCachedModel() {
-        JacksonSerializer serializer =
-                new JacksonSerializer();
-        Cache cache = new DefaultCache();
-        DefaultModelRepository repository =
-                new DefaultModelRepository(
+        modelCaches().forEach(cache -> {
+            try {
+                JacksonSerializer serializer = new JacksonSerializer();
+                DefaultModelRepository repository = new DefaultModelRepository(
                         client, documentStore, serializer,
                         mock(EntityHelper.class), null,
                         cache, List.of());
-        AccountId id = new AccountId("fenced");
-        repository.updateAfterCommit(List.of(
-                committed(repository, id, 20, 1L, 20L)));
-        repository.updateAfterCommit(List.of(
-                committed(repository, id, 10, 0L, 10L)));
-        AtomicReference<Entity<?>> cached =
-                new AtomicReference<>();
-        cache.<Object>modifyEach((ignored, value) -> {
-            if (value instanceof Entity<?> entity) {
-                cached.set(entity);
-            }
-            return value;
-        });
+                AccountId id = new AccountId("fenced");
+                repository.updateAfterCommit(List.of(
+                        committed(repository, id, 20, 1L, 20L)));
+                repository.updateAfterCommit(List.of(
+                        committed(repository, id, 10, 0L, 10L)));
+                AtomicReference<Entity<?>> cached = new AtomicReference<>();
+                cache.<Object>modifyEach((ignored, value) -> {
+                    if (value instanceof Entity<?> entity) {
+                        cached.set(entity);
+                    }
+                    return value;
+                });
 
-        assertNotNull(cached.get());
-        assertEquals(
-                new Account(id, 20),
-                cached.get().get());
-        assertEquals(20L,
-                     ((ModelRoot<?>) cached.get())
-                             .stateIndex());
-        cache.close();
+                assertNotNull(cached.get());
+                assertEquals(new Account(id, 20), cached.get().get());
+                assertEquals(20L, ((ModelRoot<?>) cached.get()).stateIndex());
+            } finally {
+                cache.close();
+            }
+        });
     }
 
     @Test
+    @Timeout(20)
     void olderReconstructionCompletionCannotOverwriteANewerCachedModel()
+            throws InterruptedException {
+        for (Cache cache : modelCaches()) {
+            try {
+                verifyOlderReconstructionCannotOverwriteNewerCommit(cache);
+            } finally {
+                cache.close();
+            }
+        }
+    }
+
+    private void verifyOlderReconstructionCannotOverwriteNewerCommit(Cache cache)
             throws InterruptedException {
         AccountId id = new AccountId("reconstruction-fence");
         LocalClient localClient = LocalClient.newInstance(null);
@@ -1541,10 +1553,12 @@ class DefaultModelRepositoryTest {
         LocalClient client = spy(localClient);
         doReturn(eventStoreClient)
                 .when(client).getEventStoreClient();
-        try (Fluxzero fluxzero = withModelHandlers(
+        try (ExecutorService reconstructionExecutor = Executors.newSingleThreadExecutor();
+             Fluxzero fluxzero = withModelHandlers(
                      DefaultFluxzero.builder()
                              .disableKeepalive()
                              .disableShutdownHook()
+                             .withModelCache(cache)
                              .build(client))) {
             fluxzero.commandGateway().send(
                     new CreateAccount(id, 5)).join();
@@ -1570,11 +1584,7 @@ class DefaultModelRepositoryTest {
                         true, false)) {
                     reconstructionLoaded
                             .countDown();
-                    assertTrue(
-                            allowReconstructionCompletion
-                                    .await(
-                                            5,
-                                            TimeUnit.SECONDS));
+                    allowReconstructionCompletion.await();
                 }
                 return result;
             }).when(eventStoreClient)
@@ -1583,10 +1593,9 @@ class DefaultModelRepositoryTest {
             CompletableFuture<Entity<Account>>
                     olderReconstruction =
                     CompletableFuture.supplyAsync(
-                            () -> repository.load(id));
-            assertTrue(
-                    reconstructionLoaded.await(
-                            5, TimeUnit.SECONDS));
+                            () -> repository.load(id),
+                            reconstructionExecutor);
+            reconstructionLoaded.await();
 
             repository.updateAfterCommit(
                     List.of(committed(
@@ -1602,6 +1611,12 @@ class DefaultModelRepositoryTest {
                     new Account(id, 20),
                     repository.load(id).get());
         }
+    }
+
+    private static List<Cache> modelCaches() {
+        return List.of(
+                new SoftReferenceCache(100),
+                new AdaptiveObjectCache(100));
     }
 
     private static DefaultModelRepository.Commit.Outcome

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -63,11 +63,13 @@ import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.Alias;
 import io.fluxzero.sdk.modeling.CommitAttempt;
 import io.fluxzero.sdk.modeling.DefaultEntityHelper;
+import io.fluxzero.sdk.modeling.DocumentProjection;
 import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.EntityHelper;
 import io.fluxzero.sdk.modeling.EventPublicationStrategy;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.GraphProjection;
 import io.fluxzero.sdk.modeling.GraphProjectionCompletion;
@@ -2362,8 +2364,9 @@ class DefaultModelRepositoryTest {
     private record CommitEvent(Object payload, String targetId, Class<?> modelType) {
     }
 
-    @Model(eventSourced = false, searchable = true,
-            searchProjection = @Searchable(collection = "products"))
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(collection = "products"))
     private record Product(@EntityId ProductId productId, String name) {
     }
 
@@ -2438,9 +2441,7 @@ class DefaultModelRepositoryTest {
         }
     }
 
-    @Model(
-            eventSourced = false, searchable = true,
-            searchProjection = @Searchable(collection = "aliasedAccounts"))
+    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "aliasedAccounts"))
     private record AliasedAccount(
             @EntityId AliasedAccountId accountId,
             int balance) {
@@ -2571,10 +2572,7 @@ class DefaultModelRepositoryTest {
         }
     }
 
-    @Model(
-            eventSourced = false,
-            searchable = true,
-            searchProjection = @Searchable(collection = "documentInventory"))
+    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "documentInventory"))
     private record DocumentInventory(
             @EntityId DocumentInventoryId inventoryId,
             int available) {
@@ -2777,11 +2775,9 @@ class DefaultModelRepositoryTest {
     }
 
     @Revision(1)
-    @Model(
-            eventSourced = false,
-            cached = true,
-            searchable = true,
-            searchProjection = @Searchable(
+    @Model(persistence = ModelPersistence.DOCUMENT, cached = true,
+
+            document = @DocumentProjection(
                     collection = "evolvedDocuments"))
     private record EvolvedDocument(
             @EntityId EvolvedDocumentId id,
@@ -2956,9 +2952,7 @@ class DefaultModelRepositoryTest {
             @EntityId GraphRootId graphRootId, String name) {
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "repository-graphs"))
     private record ProjectedRoot(
@@ -2973,9 +2967,7 @@ class DefaultModelRepositoryTest {
             String rootId) {
     }
 
-    @Model(
-            searchable = true,
-            materializeGraph = true,
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "repository-graphs"))
     private record AlternateProjectedRoot(

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
@@ -29,9 +29,11 @@ import io.fluxzero.common.api.modeling.ModelHeadState;
 import io.fluxzero.common.api.modeling.ModelReadBoundary;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import io.fluxzero.sdk.modeling.EntityId;
+import io.fluxzero.sdk.modeling.DocumentProjection;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.ImmutableModelRoot;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.persisting.eventsourcing.EventSourcingException;
 import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
 import io.fluxzero.sdk.persisting.eventsourcing.client.LocalEventStoreClient;
@@ -140,10 +142,7 @@ class ModelReplayCursorTest {
                 sequenceNumber, stateIndex, true, false);
     }
 
-    @Model(
-            eventSourced = false,
-            searchable = true,
-            searchProjection = @Searchable(collection = "currentDocuments"))
+    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "currentDocuments"))
     private record CurrentDocument(
             @EntityId String id,
             String value) {

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
@@ -23,6 +23,7 @@ import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.AssertLegal;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.modeling.Parent;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
 import io.fluxzero.sdk.persisting.eventsourcing.InterceptApply;
@@ -307,7 +308,7 @@ class TestFixtureModelApiTest {
         }
     }
 
-    @Model(eventSourced = false, cached = false, searchable = true)
+    @Model(persistence = ModelPersistence.DOCUMENT, cached = false)
     private record UncachedDocument(@EntityId String id, int value) {
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
@@ -30,10 +30,12 @@ import io.fluxzero.sdk.common.Message;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
 import io.fluxzero.sdk.modeling.EntityId;
+import io.fluxzero.sdk.modeling.DocumentProjection;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.GraphProjection;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.Model;
+import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.persisting.search.DocumentStore;
 import io.fluxzero.sdk.persisting.search.Searchable;
 import io.fluxzero.sdk.search.SearchTest.SomeDocument;
@@ -426,15 +428,13 @@ public class HandleDocumentTest {
         }
     }
 
-    @Model(
-            searchable = true,
-            searchProjection = @Searchable(collection = "graph-roots"),
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, document = @DocumentProjection(collection = "graph-roots"),
             materializeGraph = true)
     @Revision(1)
     record GraphRoot(@EntityId String id) {
     }
 
-    @Model(searchable = true)
+    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
     record DirectOnlyModel(@EntityId String id) {
     }
 


### PR DESCRIPTION
## Summary
- replace the provisional `eventSourced`/`searchable` Model boolean matrix with `ModelPersistence`
- keep direct documents, event publication, and internal Graph component storage as separate responsibilities
- reject meaningless persistence configurations during metadata validation
- update Javadoc, human manuals, agent manuals, and Java/Kotlin downstream examples

## Compatibility
This deliberately finalizes branch-only/2.0-RC Model API before GA. Persisted data, wire contracts, Aggregate behavior, and the underlying repository paths remain unchanged.