### PR TITLE
docs(modeling): align final Model guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3736,13 +3736,14 @@ Model commit history remains available for replay, repair and an application-spe
 legacy state, but such a reverse projection is not a generic migration guarantee. Do not treat changing `@Aggregate`
 to `@Model` as a persistence migration.
 
-## Legacy aggregate API (existing Fluxzero 1.x applications only)
+## Legacy aggregate API (existing persisted applications only)
 
 The following section documents the shared-root API for applications that already persist aggregate streams. Do not
-introduce it in new code. `@Model` plus `@Member` covers the intentional single-stream case; the aggregate API is
-scheduled for Java deprecation in Fluxzero 2.0. Migrating an existing aggregate requires a deliberate persistence
-migration and is not an annotation-only refactor. Do not copy an old aggregate's embedded shape into new Models: first
-re-evaluate every nested value by lifecycle and promote independently living children to `@Model` plus `@Parent`.
+introduce it in new code. `@Model` plus `@Member` covers the intentional single-stream case; the aggregate API remains
+available as the compatibility boundary for existing persisted state. Migrating an existing aggregate requires a
+deliberate persistence migration and is not an annotation-only refactor. Do not copy an old aggregate's embedded shape
+into new Models: first re-evaluate every nested value by lifecycle and promote independently living children to
+`@Model` plus `@Parent`.
 
 ### Defining a legacy aggregate
 
@@ -4766,9 +4767,10 @@ documentStore.bulkUpdate("customCollection")
 
 ---
 
-### Searchable Domain Models
+### Model documents and searchable values
 
-Many domain objects in Flux (e.g. models or stateful handlers) are automatically indexable:
+Models choose whether to maintain a direct document through `ModelPersistence`. Other values use the document-store
+annotations that own automatic indexing:
 
 - `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
 - `@Stateful` (implicitly `@Searchable`)

--- a/docs/developer/getting-started/core-concepts.mdx
+++ b/docs/developer/getting-started/core-concepts.mdx
@@ -348,7 +348,7 @@ run the same flow against a real Fluxzero runtime.
 
 ## Legacy applications
 
-Fluxzero 1.x continues to support `@Aggregate` and its loading APIs for existing persisted applications. New
-applications and new domain state should use `@Model`; `@Model` with `@Member` covers the intentional single-stream
-case too. The aggregate API is scheduled for Java deprecation in Fluxzero 2.0 because migrating existing aggregate
-streams is a persistence migration, not a source-only annotation change.
+Fluxzero continues to support `@Aggregate` and its loading APIs for existing persisted applications. New applications
+and new domain state should use `@Model`; `@Model` with `@Member` covers the intentional single-stream case too. The
+aggregate API remains the compatibility boundary for existing state because migrating aggregate streams is a
+persistence migration, not a source-only annotation change.

--- a/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
+++ b/docs/developer/guides/Modeling & persistence/170-entity-loading.mdx
@@ -364,6 +364,6 @@ the intended ownership. Use a separate `@Model` plus `@Parent` when a child must
 have its own lifecycle or be changed without loading the root.
 
 <Aside type="note" title="Legacy aggregate API">
-`@Aggregate`, `loadAggregate(...)` and `loadAggregateFor(...)` remain available for existing Fluxzero 1.x
-applications. New code should use `@Model`; the aggregate API is scheduled for deprecation in Fluxzero 2.0.
+`@Aggregate`, `loadAggregate(...)` and `loadAggregateFor(...)` remain available for existing persisted applications.
+New code should use `@Model`; the aggregate API remains the compatibility boundary for existing aggregate state.
 </Aside>

--- a/docs/developer/guides/Modeling & persistence/180-updating-entities.mdx
+++ b/docs/developer/guides/Modeling & persistence/180-updating-entities.mdx
@@ -272,7 +272,7 @@ Publish follow-up messages from handlers or event handlers instead.
 </Aside>
 
 <Aside type="note" title="Legacy aggregate API">
-Existing Fluxzero 1.x applications may continue to use `@Aggregate` and
-`Fluxzero.loadAggregate(...).assertAndApply(...)`. New code should use model commits; the aggregate API is scheduled for
-deprecation in Fluxzero 2.0.
+Existing persisted applications may continue to use `@Aggregate` and
+`Fluxzero.loadAggregate(...).assertAndApply(...)`. New code should use Model commits; the aggregate API remains the
+compatibility boundary for existing aggregate state.
 </Aside>

--- a/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
+++ b/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
@@ -301,6 +301,6 @@ has been deleted. Globally published audit events are outside the model-stream h
 
 <Aside type="note" title="Legacy aggregate trees">
 `@Aggregate`, `loadEntity(...)` and `loadAggregateFor(...)` describe the old shared-root storage model. They remain
-supported for existing 1.x applications but should not be used for new trees. Use `@Model` with optional embedded
-`@Member` values instead; the aggregate API is scheduled for deprecation in Fluxzero 2.0.
+supported for existing persisted applications but should not be used for new trees. Use `@Model` with optional embedded
+`@Member` values instead; the aggregate API remains the compatibility boundary for existing aggregate state.
 </Aside>

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -247,7 +247,7 @@ Use a model with embedded `@Member` values when one small object graph genuinely
 Split independently changing or searchable children into their own models.
 
 <Aside type="note" title="Legacy aggregate persistence">
-`@Aggregate` persists an older shared-root representation. It remains compatible throughout Fluxzero 1.x so existing
-streams keep loading, but new manuals and examples use `@Model` exclusively. The aggregate API is scheduled for
-deprecation in Fluxzero 2.0.
+`@Aggregate` persists an older shared-root representation. It remains compatible so existing streams keep loading,
+but new manuals and examples use `@Model` exclusively. It remains the compatibility boundary for existing persisted
+aggregate state rather than a pattern for new domain code.
 </Aside>

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -61,9 +61,10 @@ You can also specify the collection in which the object should be stored directl
 
 ---
 
-## Domain Models with direct documents
+## Model documents and searchable values
 
-Many domain models and stateful handlers in Fluxzero are automatically indexable:
+Models choose whether to maintain a direct document through `ModelPersistence`. Other values use the document-store
+annotations that own automatic indexing:
 
 - `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
 - `@Stateful` (implicitly `@Searchable`)
@@ -109,7 +110,7 @@ settings themselves:
     ```kotlin
     @Model(
         persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
-        document = @DocumentProjection(
+        document = DocumentProjection(
             collection = "users",
             timestampPath = "profile/createdAt"
         )

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -1,7 +1,7 @@
 # Models and state
 
-Use `@Model` for persisted domain state. Do not introduce `@Aggregate` in new code. Existing aggregate APIs are legacy
-Fluxzero 1.x compatibility surfaces and are scheduled for deprecation in 2.0.
+Use `@Model` for persisted domain state. Do not introduce `@Aggregate` in new code. Existing aggregate APIs remain the
+compatibility boundary for already persisted aggregate state.
 
 ## Core rules
 
@@ -298,7 +298,7 @@ retention and deletion all belong to the root. If any of those concerns can dive
 `@Parent`. A list-shaped field, frequent updates, or convenient whole-document storage is never sufficient reason to
 use `@Member`.
 
-## Loading
+## Loading and event parameters
 
 ```java
 Project project = Fluxzero.loadModel(projectId).get();

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -9,7 +9,7 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 - [Core Principles](#core-rules)
 - [Configuration & Indexing](#configuration)
-    - [@Searchable & @Model](#searchable)
+    - [Model documents and @Searchable values](#searchable)
     - [Facets & Sorting (@Facet, @Sortable)](#facets-sorting)
     - [Exclusion & Inclusion (@SearchExclude, @SearchInclude)](#exclude-include)
 - [Searching for Data](#searching)
@@ -50,9 +50,10 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 <a name="searchable"></a>
 
-### @Searchable & @Model
+### Model documents and @Searchable values
 
-To enable search for a model or any object, use the appropriate annotation.
+Choose a Model persistence option that stores a direct document. Use `@Searchable` for an ordinary document value;
+do not annotate a Model with it.
 
 [//]: # (@formatter:off)
 ```java
@@ -136,7 +137,7 @@ List<Task> results = Fluxzero.search(Task.class)
 
 Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Depth-bounded overloads support grandparents
 and further traversal. Class-based constraints use the related Model's actual current-document collection, including
-the type-isolated private collection of a non-searchable Graph component. They select matching related IDs before
+the type-isolated private collection of a Graph-only Model component. They select matching related IDs before
 relationship traversal, so prefer `searchGraph(Root.class).whereDescendant(Child.class, constraint)` for selective
 live Graph search based on children. `searchGraph(Root.class).stream()` returns typed lazy `Graph<Root>` values through
 explicit `@Parent(pathInParent = "...")` paths. It prefers a configured materialized graph projection and otherwise stitches

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -1,7 +1,7 @@
 # Models and state
 
-Use `@Model` for persisted domain state. Do not introduce `@Aggregate` in new code. Existing aggregate APIs are legacy
-Fluxzero 1.x compatibility surfaces and are scheduled for deprecation in 2.0.
+Use `@Model` for persisted domain state. Do not introduce `@Aggregate` in new code. Existing aggregate APIs remain the
+compatibility boundary for already persisted aggregate state.
 
 ## Core rules
 

--- a/project-files/kotlin/agents/rules/handling.md
+++ b/project-files/kotlin/agents/rules/handling.md
@@ -312,11 +312,6 @@ annotated with `@Searchable(collection = "...")`, that collection is used; other
 used. Use `@HandleDocument(documentClass = OrderDocument::class)` when the document type cannot be inferred from the
 first parameter, and `@HandleDocument("orders")` when binding directly to a collection name.
 
-### Retroactive Updates
-
-If you need to retroactively update a collection of documents or handle errors in historical data, you can use the
-Replay mechanism. See [Tracking: Replays](tracking.md#replays) for more details.
-
 #### @HandleError
 
 Used for error monitoring or handling.

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -9,7 +9,7 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 - [Core Principles](#core-rules)
 - [Configuration & Indexing](#configuration)
-    - [@Searchable & @Model](#searchable)
+    - [Model documents and @Searchable values](#searchable)
     - [Facets & Sorting (@Facet, @Sortable)](#facets-sorting)
     - [Exclusion & Inclusion (@SearchExclude, @SearchInclude)](#exclude-include)
 - [Searching for Data](#searching)
@@ -50,9 +50,10 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 <a name="searchable"></a>
 
-### @Searchable & @Model
+### Model documents and @Searchable values
 
-To enable search for a model or any object, use the appropriate annotation.
+Choose a Model persistence option that stores a direct document. Use `@Searchable` for an ordinary document value;
+do not annotate a Model with it.
 
 ```kotlin
 @Model(
@@ -130,7 +131,7 @@ val results = Fluxzero.search(Task::class.java)
 
 Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Depth-bounded overloads support grandparents
 and further traversal. Class-based constraints use the related Model's actual current-document collection, including
-the type-isolated private collection of a non-searchable Graph component. They select matching related IDs before
+the type-isolated private collection of a Graph-only Model component. They select matching related IDs before
 relationship traversal, so prefer `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` for
 selective live Graph search based on children. `searchGraph(Root::class.java).stream()` returns typed lazy `Graph<Root>` values through
 explicit `@Parent(pathInParent = "...")` paths. It prefers a configured materialized graph projection and otherwise stitches

--- a/project-files/kotlin/agents/rules/troubleshooting.md
+++ b/project-files/kotlin/agents/rules/troubleshooting.md
@@ -124,7 +124,7 @@ This guide helps you quickly resolve common issues encountered when building Flu
 - Use `Fluxzero.scheduleCommand(MyCmd(id), Duration.parse(ApplicationProperties.getProperty("key", "PT10M")))`.
 - See: [Sending: Schedules](./sending.md#schedules)
 
-### Validation errors on valid-looking data
+### Missing validation errors on invalid data
 
 **Cause**:
 - Missing `@field:Valid` on nested objects or collections in the command/query data class.

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
@@ -126,7 +126,7 @@ public @interface Model {
     /**
      * Whether the latest model state should be stored in the shared application cache.
      * <p>
-     * Models participating in an commit may additionally be retained in an commit-local cache until the commit
+     * Models participating in a commit may additionally be retained in a commit-local cache until the commit
      * completes.
      */
     boolean cached() default true;

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Search.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Search.java
@@ -383,9 +383,9 @@ public interface Search<R> {
      * Adds advanced current-state model relationship constraints using logical AND.
      * <p>
      * Class-based related queries use the model's actual current-document collection. This includes the private,
-     * type-isolated collection of a model that participates in graph composition without being independently
-     * searchable. Related documents are selected before relationship traversal and target search, so a selective
-     * child constraint does not require live composition of unrelated roots.
+     * type-isolated collection of a model that participates in graph composition without maintaining a direct public
+     * document. Related documents are selected before relationship traversal and target search, so a selective child
+     * constraint does not require live composition of unrelated roots.
      * <p>
      * Implementations that do not support independent-model graph search fail when this method is called.
      */


### PR DESCRIPTION
## Summary
- distinguish Model document persistence from ordinary `@Searchable` values
- describe `@Aggregate` as an existing-state compatibility boundary without claiming an API deprecation that is not present
- align Java/Kotlin agent manuals and correct the Kotlin `DocumentProjection` example
- clarify public Model/Search Javadoc without changing runtime behavior

## Verification
- `./mvnw -B site -Pjavadoc`
- stale branch-only Model API scan
- Java/Kotlin agent heading parity audit