### PR TITLE
fix(modeling): harden in-memory commits and document rebases

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
@@ -527,6 +527,7 @@ final class ModelPipeline {
                                 Commit.Outcome nextPrepared =
                                         retry.accepting()
                                         && !original.hasCascadedDeletion()
+                                        && evaluation.cascadeRootIds().isEmpty()
                                                 ? repositoryCommit.prepareRebased(commitId, original, next)
                                                 : repositoryCommit.prepare(
                                                         commitId, next, conflictPolicy,

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPipeline.java
@@ -419,7 +419,7 @@ final class ModelPipeline {
                 ? Retry.accepting((result, current) -> {
                     try {
                         return CompletableFuture.completedFuture(
-                                rebase(current.steps(), result.getRebaseStateIndex(), migration));
+                                rebase(current, result.getRebaseStateIndex(), migration));
                     } catch (Throwable failure) {
                         return CompletableFuture.failedFuture(failure);
                     }
@@ -517,7 +517,9 @@ final class ModelPipeline {
                                     asynchronousReevaluation))
                             .thenCompose(next -> {
                                 if (retry.accepting()
-                                    && next.readStateIndex() != result.getRebaseStateIndex()) {
+                                    && !validRebaseBoundary(
+                                            evaluation, result.getRebaseStateIndex(),
+                                            next.readStateIndex())) {
                                     return CompletableFuture.failedFuture(new IllegalStateException(
                                             "Model commit '%s' rebase loaded state index %d instead of requested %d"
                                                     .formatted(
@@ -539,6 +541,22 @@ final class ModelPipeline {
                                         asynchronousReevaluation);
                             });
                 });
+    }
+
+    private static boolean validRebaseBoundary(
+            CommitAttempt evaluation,
+            long requestedStateIndex,
+            long loadedStateIndex) {
+        return loadedStateIndex == requestedStateIndex
+               || loadedStateIndex > requestedStateIndex
+                  && readsDocumentModel(evaluation);
+    }
+
+    private static boolean readsDocumentModel(
+            CommitAttempt evaluation) {
+        return evaluation.readModelTypes().values().stream()
+                .anyMatch(modelType -> !EntityMetadata.validate(modelType)
+                        .rootConfiguration().orElseThrow().eventSourced());
     }
 
     private static <T> CompletableFuture<T> invoke(
@@ -669,13 +687,16 @@ final class ModelPipeline {
         return expandCascadeDeletes(
                 ModelReducer.apply(
                         attempt, List.of(initialMessage),
-                        new CommitLoader(null, false, false, initialMessage, prefetched)));
+                        new CommitLoader(
+                                null, false, false, false,
+                                initialMessage, prefetched)));
     }
 
     private CommitAttempt rebase(
-            List<CommitAttempt.Step> steps,
+            CommitAttempt evaluation,
             long stateIndex,
             boolean migration) {
+        List<CommitAttempt.Step> steps = evaluation.steps();
         return ModelBatchScope.withMessageDependency(
                 steps.getFirst().message(),
                 () -> expandCascadeDeletes(ModelReducer.reapplySteps(
@@ -684,7 +705,9 @@ final class ModelPipeline {
                                 .filter(step -> !(step.message().getPayload()
                                         instanceof CascadedModelDeletion))
                                 .toList(),
-                        new CommitLoader(stateIndex, true, migration))));
+                        new CommitLoader(
+                                stateIndex, true, migration,
+                                readsDocumentModel(evaluation)))));
     }
 
     /**
@@ -851,9 +874,10 @@ final class ModelPipeline {
     }
 
     private final class CommitLoader implements ModelReducer.SubstepResolver {
-        private final Long pinnedStateIndex;
+        private Long pinnedStateIndex;
         private final boolean applyOnly;
         private final boolean migration;
+        private final boolean advanceIncompleteDocumentBoundary;
         private final DeserializingMessage directMessage;
         private final PrefetchSlot prefetched;
         private final Map<String, Entity<?>> commitEntities = new LinkedHashMap<>();
@@ -861,29 +885,42 @@ final class ModelPipeline {
                 new LinkedHashMap<>();
 
         private CommitLoader(Long pinnedStateIndex) {
-            this(pinnedStateIndex, false, false, null, null);
+            this(pinnedStateIndex, false, false, false, null, null);
         }
 
         private CommitLoader(Long pinnedStateIndex, boolean applyOnly) {
-            this(pinnedStateIndex, applyOnly, false, null, null);
+            this(pinnedStateIndex, applyOnly, false, false, null, null);
         }
 
         private CommitLoader(
                 Long pinnedStateIndex,
                 boolean applyOnly,
                 boolean migration) {
-            this(pinnedStateIndex, applyOnly, migration, null, null);
+            this(pinnedStateIndex, applyOnly, migration, false, null, null);
         }
 
         private CommitLoader(
                 Long pinnedStateIndex,
                 boolean applyOnly,
                 boolean migration,
+                boolean advanceIncompleteDocumentBoundary) {
+            this(
+                    pinnedStateIndex, applyOnly, migration,
+                    advanceIncompleteDocumentBoundary, null, null);
+        }
+
+        private CommitLoader(
+                Long pinnedStateIndex,
+                boolean applyOnly,
+                boolean migration,
+                boolean advanceIncompleteDocumentBoundary,
                 DeserializingMessage directMessage,
                 PrefetchSlot prefetched) {
             this.pinnedStateIndex = pinnedStateIndex;
             this.applyOnly = applyOnly;
             this.migration = migration;
+            this.advanceIncompleteDocumentBoundary =
+                    advanceIncompleteDocumentBoundary;
             this.directMessage = directMessage;
             this.prefetched = prefetched;
         }
@@ -1014,17 +1051,22 @@ final class ModelPipeline {
                 MutationPlan.Resolution resolution,
                 Long boundary,
                 Map<String, Object> stagedValues) {
-            CommitAttempt loaded = migration
-                    ? repository.loadContext(
-                            resolution, boundary, stagedValues,
-                            true, true)
-                    : repository.loadContext(
-                            resolution, boundary, stagedValues,
-                            true);
+            CommitAttempt loaded = advanceIncompleteDocumentBoundary
+                    ? repository.loadRebaseContext(
+                            resolution, boundary, stagedValues, true, migration)
+                    : migration
+                            ? repository.loadContext(
+                                    resolution, boundary, stagedValues, true, true)
+                            : repository.loadContext(
+                                    resolution, boundary, stagedValues, true);
             if (boundary != null && loaded.readStateIndex() != boundary) {
-                throw new IllegalStateException(
-                        "Model commit requested state index %d but loaded %d"
-                                .formatted(boundary, loaded.readStateIndex()));
+                if (!advanceIncompleteDocumentBoundary
+                    || loaded.readStateIndex() < boundary) {
+                    throw new IllegalStateException(
+                            "Model commit requested state index %d but loaded %d"
+                                    .formatted(boundary, loaded.readStateIndex()));
+                }
+                pinnedStateIndex = loaded.readStateIndex();
             }
             for (String modelId : loaded.modelIds()) {
                 commitEntities.put(modelId, loaded.entity(modelId));

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
@@ -535,6 +535,10 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
         if (!modelCommitMaterializations.remove(commitId, pending)) {
             return;
         }
+        modelUpdateGeneration.incrementAndGet();
+        synchronized (modelUpdateMonitor) {
+            modelUpdateMonitor.notifyAll();
+        }
         synchronized (this) {
             if (publication != null) {
                 modelMaterializationPublications.add(publication);
@@ -595,8 +599,19 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
                 request.getRequestId(),
                 lastStateIndex,
                 modelStateIndex,
-                modelStateIndex,
+                materializedModelStateIndex(),
                 updates);
+    }
+
+    private long materializedModelStateIndex() {
+        return modelCommitMaterializations.values().stream()
+                .flatMap(pending -> pending.assignedUpdates().stream())
+                .mapToLong(ModelUpdate::getStateIndex)
+                .min()
+                .stream()
+                .map(stateIndex -> stateIndex - 1L)
+                .findFirst()
+                .orElse(modelStateIndex);
     }
 
     @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
@@ -224,7 +224,10 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
     @Override
     public CompletableFuture<CommitModelsResult> commitModels(CommitModels commit) {
         try {
-            ModelCommitOutcome outcome = commitModelsSynchronized(commit);
+            ModelCommitOutcome outcome;
+            synchronized (monitorNotificationLock()) {
+                outcome = commitModelsSynchronized(commit);
+            }
             completeModelCommitMaterialization(
                     commit.getCommitId());
             if (!outcome.publishedEvents().isEmpty()) {

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
@@ -980,7 +980,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
         return loadContext(
                 resolution,
                 ModelReadBoundary.at(maxStateIndex),
-                stagedValues, includeMessageBatch, false);
+                stagedValues, includeMessageBatch, false, false);
     }
 
     public CommitAttempt loadContext(
@@ -990,9 +990,24 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             boolean includeMessageBatch,
             boolean migration) {
         return loadContext(
+                resolution, ModelReadBoundary.at(maxStateIndex), stagedValues,
+                includeMessageBatch, migration, false);
+    }
+
+    /**
+     * Reloads an ACCEPT rebase while allowing an incomplete authoritative document to advance the exact boundary.
+     * Ordinary historical reads never enable this retry mode.
+     */
+    public CommitAttempt loadRebaseContext(
+            MutationPlan.Resolution resolution,
+            Long maxStateIndex,
+            Map<String, Object> stagedValues,
+            boolean includeMessageBatch,
+            boolean migration) {
+        return loadContext(
                 resolution,
                 ModelReadBoundary.at(maxStateIndex),
-                stagedValues, includeMessageBatch, migration);
+                stagedValues, includeMessageBatch, migration, true);
     }
 
     private String messageBatchNamespace() {
@@ -1029,7 +1044,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             boolean includeMessageBatch) {
         return loadContext(
                 resolution, boundary, stagedValues,
-                includeMessageBatch, false);
+                includeMessageBatch, false, false);
     }
 
     private CommitAttempt loadContext(
@@ -1037,7 +1052,8 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             ModelReadBoundary boundary,
             Map<String, Object> stagedValues,
             boolean includeMessageBatch,
-            boolean migration) {
+            boolean migration,
+            boolean advanceIncompleteDocumentBoundary) {
         String namespace = includeMessageBatch ? messageBatchNamespace() : null;
         Map<String, Object> effectiveStagedValues = stagedValues;
         if (includeMessageBatch) {
@@ -1059,7 +1075,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                         ? modelId -> ModelBatchScope.currentValue(namespace, modelId)
                         : null,
                 migration ? null : modelCacheTracker, true,
-                migration);
+                migration, advanceIncompleteDocumentBoundary);
         return includeMessageBatch
                 ? ModelBatchScope.overlayCurrent(namespace, context)
                 : context;

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
@@ -29,6 +29,8 @@ import io.fluxzero.common.api.modeling.ModelEventStream;
 import io.fluxzero.common.api.modeling.ModelEventStreamRequest;
 import io.fluxzero.common.api.modeling.ModelGraphEdge;
 import io.fluxzero.common.api.modeling.ModelHeadState;
+import io.fluxzero.common.api.modeling.TrackModelUpdates;
+import io.fluxzero.common.api.modeling.TrackModelUpdatesResult;
 import io.fluxzero.common.caching.Cache;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.common.serialization.Serializer;
@@ -91,6 +93,10 @@ final class ModelReplayCursor {
     private static final int COMMIT_ANCESTOR_MAX_DEPTH = 64;
     private static final int COMMIT_ANCESTOR_MAX_MODELS = 10_000;
     private static final int MAX_CURRENT_GRAPH_RECONSTRUCTION_ATTEMPTS = 8;
+    private static final int MAX_DOCUMENT_REBASE_ATTEMPTS = 8;
+    private static final long DOCUMENT_MATERIALIZATION_TIMEOUT_NANOS =
+            5_000_000_000L;
+    private static final long DOCUMENT_MATERIALIZATION_POLL_MILLIS = 50L;
     static final Settings DEFAULT_SETTINGS =
             new Settings(32_768, 131_072, 128, 64L * 1_024L * 1_024L);
 
@@ -668,6 +674,91 @@ final class ModelReplayCursor {
             ModelCacheTracker cacheTracker,
             boolean requireBoundary,
             boolean migration) {
+        return context(
+                resolution, boundary, stagedValues, pendingAncestor,
+                cacheTracker, requireBoundary, migration, false);
+    }
+
+    CommitAttempt context(
+            MutationPlan.Resolution resolution,
+            ModelReadBoundary boundary,
+            Map<String, Object> stagedValues,
+            Function<String, Entity<?>> pendingAncestor,
+            ModelCacheTracker cacheTracker,
+            boolean requireBoundary,
+            boolean migration,
+            boolean advanceIncompleteDocumentBoundary) {
+        if (!advanceIncompleteDocumentBoundary) {
+            return contextAtBoundary(
+                    resolution, boundary, stagedValues, pendingAncestor,
+                    cacheTracker, requireBoundary, migration);
+        }
+        ModelReadBoundary candidate = boundary;
+        long provenMaterializedBoundary = -1L;
+        for (int attempt = 0;
+             attempt < MAX_DOCUMENT_REBASE_ATTEMPTS;
+             attempt++) {
+            try {
+                return contextAtBoundary(
+                        resolution, candidate, stagedValues, pendingAncestor,
+                        cacheTracker, requireBoundary, migration);
+            } catch (IncompleteDocumentBoundaryException failure) {
+                Long previous = candidate.stateIndex();
+                if (previous == null
+                    || failure.stateIndex < previous
+                    || attempt + 1 >= MAX_DOCUMENT_REBASE_ATTEMPTS) {
+                    throw failure;
+                }
+                if (failure.stateIndex == previous) {
+                    if (provenMaterializedBoundary >= previous) {
+                        throw failure;
+                    }
+                    provenMaterializedBoundary = awaitMaterializedBoundary(
+                            previous);
+                    if (provenMaterializedBoundary < previous) {
+                        throw failure;
+                    }
+                } else {
+                    candidate = ModelReadBoundary.state(
+                            failure.stateIndex, false);
+                    provenMaterializedBoundary = -1L;
+                }
+            }
+        }
+        throw new IllegalStateException("Unreachable document boundary retry state");
+    }
+
+    private long awaitMaterializedBoundary(
+            long requiredStateIndex) {
+        long deadline = System.nanoTime()
+                        + DOCUMENT_MATERIALIZATION_TIMEOUT_NANOS;
+        long cursor = requiredStateIndex;
+        TrackModelUpdatesResult position = eventStoreClient.trackModelUpdates(
+                new TrackModelUpdates(cursor, 1, 0L)).join();
+        while (position.getMaterializedStateIndex() < requiredStateIndex) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0L) {
+                return position.getMaterializedStateIndex();
+            }
+            cursor = Math.max(cursor, position.getCurrentStateIndex());
+            long waitMillis = Math.max(
+                    1L, Math.min(
+                            DOCUMENT_MATERIALIZATION_POLL_MILLIS,
+                            remainingNanos / 1_000_000L));
+            position = eventStoreClient.trackModelUpdates(
+                    new TrackModelUpdates(cursor, 1, waitMillis)).join();
+        }
+        return position.getMaterializedStateIndex();
+    }
+
+    private CommitAttempt contextAtBoundary(
+            MutationPlan.Resolution resolution,
+            ModelReadBoundary boundary,
+            Map<String, Object> stagedValues,
+            Function<String, Entity<?>> pendingAncestor,
+            ModelCacheTracker cacheTracker,
+            boolean requireBoundary,
+            boolean migration) {
         Objects.requireNonNull(resolution, "resolution");
         Objects.requireNonNull(boundary, "boundary");
         Objects.requireNonNull(stagedValues, "stagedValues");
@@ -691,8 +782,38 @@ final class ModelReplayCursor {
 
         List<MutationPlan.ResolvedModel> replayTargets = new ArrayList<>();
         List<MutationPlan.ResolvedModel> documentTargets = new ArrayList<>();
+        Map<String, ModelHeadState> incompleteHistoricalDocumentHeads = new LinkedHashMap<>();
+        long historicalDocumentStateIndex = -1L;
+        if (historicalBoundary) {
+            List<MutationPlan.ResolvedModel> historicalDocuments = resolution.models().stream()
+                    .filter(target -> !EntityMetadata.validate(target.modelType())
+                            .rootConfiguration().orElseThrow().eventSourced())
+                    .toList();
+            if (!historicalDocuments.isEmpty()) {
+                LoadResult heads = loadHeads(
+                        historicalDocuments.stream()
+                                .map(MutationPlan.ResolvedModel::modelId)
+                                .toList(),
+                        boundary);
+                historicalDocumentStateIndex = heads.stateIndex();
+                for (MutationPlan.ResolvedModel target : historicalDocuments) {
+                    ModelHeadState head = heads.heads().get(target.modelId());
+                    if (head != null
+                        && !head.isHistoryComplete()
+                        && target.modelId().equals(head.getModelId())) {
+                        incompleteHistoricalDocumentHeads.put(target.modelId(), head);
+                    }
+                }
+            }
+        }
         for (MutationPlan.ResolvedModel target : resolution.models()) {
-            (requiresReplay(target, historicalBoundary) ? replayTargets : documentTargets).add(target);
+            if (incompleteHistoricalDocumentHeads.containsKey(target.modelId())) {
+                documentTargets.add(target);
+            } else if (requiresReplay(target, historicalBoundary)) {
+                replayTargets.add(target);
+            } else {
+                documentTargets.add(target);
+            }
         }
 
         Map<String, Entity<?>> loaded = new LinkedHashMap<>();
@@ -707,10 +828,12 @@ final class ModelReplayCursor {
                         current.entities());
             }
             stateIndex = ancestorStateIndex == null
-                    ? requireBoundary && documentTargets.isEmpty()
-                            ? load(Map.of(), boundary, ignored -> {
-                            }).stateIndex()
-                            : -1L
+                    ? historicalDocumentStateIndex >= 0L
+                            ? historicalDocumentStateIndex
+                            : requireBoundary && documentTargets.isEmpty()
+                                    ? load(Map.of(), boundary, ignored -> {
+                                    }).stateIndex()
+                                    : -1L
                     : ancestorStateIndex;
         } else {
             CurrentProjection current = !historicalBoundary && ancestorStateIndex == null
@@ -740,6 +863,21 @@ final class ModelReplayCursor {
             DocumentVersion document = documentReader.load(
                     target.modelId(), target.modelType(), migration);
             Entity<?> entity = document.entity();
+            ModelHeadState historicalHead = incompleteHistoricalDocumentHeads.get(
+                    target.modelId());
+            if (historicalHead != null
+                && !historicalHead.equals(document.head())) {
+                if (document.head() != null
+                    && document.head().getStateIndex() > stateIndex) {
+                    throw new IncompleteDocumentBoundaryException(
+                            target.modelId(), stateIndex,
+                            document.head().getStateIndex(),
+                            historicalHead, document.head());
+                }
+                throw new IncompleteDocumentBoundaryException(
+                        target.modelId(), stateIndex, stateIndex,
+                        historicalHead, document.head());
+            }
             if (entity.isEmpty() && metadata.hasAliases()) {
                 LoadResult alias = loadHeads(
                         List.of(target.modelId()),
@@ -838,6 +976,25 @@ final class ModelReplayCursor {
             }
         }
         return CommitAttempt.create(stateIndex, resolution, loaded);
+    }
+
+    private static final class IncompleteDocumentBoundaryException
+            extends EventSourcingException {
+        private final long stateIndex;
+
+        private IncompleteDocumentBoundaryException(
+                String modelId,
+                long requestedStateIndex,
+                long stateIndex,
+                ModelHeadState historicalHead,
+                ModelHeadState documentHead) {
+            super(("Document model '%s' does not match incomplete historical head %s at boundary %d "
+                   + "(document head: %s)")
+                          .formatted(
+                                  modelId, historicalHead,
+                                  requestedStateIndex, documentHead));
+            this.stateIndex = stateIndex;
+        }
     }
 
     /** Advances cache projections through this cursor's current replay boundary. */

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -1039,7 +1039,7 @@ class DefaultModelRepositoryCommitTest {
                         Order.class)),
                 Map.of(id.toString(), stale));
         var rebased = evaluation(
-                51L, List.of(id.toString()),
+                53L, List.of(id.toString()),
                 Map.of(id.toString(), Order.class),
                 List.of(substep(event, transition(
                         id, Order.class, stale, merged,
@@ -1090,7 +1090,7 @@ class DefaultModelRepositoryCommitTest {
                         .getData(),
                 retried.getSubsteps().getFirst().getEvent()
                         .getData());
-        assertEquals(51L, retried.getReadStateIndex());
+        assertEquals(53L, retried.getReadStateIndex());
         assertEquals(
                 merged,
                 serializer.fromDocument(

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -49,6 +49,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -301,6 +302,92 @@ class DefaultModelRepositoryCommitTest {
         assertTrue(completion.isDone());
         assertTrue(completion.join().orElseThrow().isAccepted());
         assertEquals(callerThread, rebaseThread.get());
+    }
+
+    @Test
+    void acceptRebaseMayAddANewlyDiscoveredCascadeTarget()
+            throws Exception {
+        OrderId rootId = new OrderId("cascade-rebase");
+        Order root = new Order(
+                rootId, null, "before", Instant.EPOCH);
+        GraphOnlyChildId childId =
+                new GraphOnlyChildId("cascade-rebase");
+        GraphOnlyChild child = new GraphOnlyChild(
+                childId, new CustomerId("cascade-rebase"),
+                "child");
+        DeleteOrder event = new DeleteOrder(rootId);
+        Change rootDeletion = transition(
+                rootId, Order.class, root, null,
+                DeleteOrder.class, "apply", Order.class);
+        CommitAttempt original = evaluation(
+                List.of(rootId.toString()),
+                substep(event, rootDeletion),
+                java.util.Collections.singletonMap(
+                        rootId.toString(), null));
+        original.cascadeRoots(Set.of(rootId.toString()));
+
+        Change childDeletion = Change.applied(
+                childId.toString(), GraphOnlyChild.class,
+                0L, null, child, null, null, null, true);
+        CommitAttempt rebased = evaluation(
+                51L,
+                List.of(rootId.toString(), childId.toString()),
+                Map.of(
+                        rootId.toString(), Order.class,
+                        childId.toString(), GraphOnlyChild.class),
+                List.of(
+                        substep(event, rootDeletion),
+                        substep(
+                                new CascadedModelDeletion(
+                                        List.of(rootId.toString())),
+                                childDeletion)),
+                java.util.Collections.singletonMap(
+                        rootId.toString(), null));
+        rebased.cascadeRoots(Set.of(rootId.toString()));
+        AtomicInteger commits = new AtomicInteger();
+        when(eventStoreClient.commitModels(any()))
+                .thenAnswer(invocation -> {
+                    CommitModels request = invocation.getArgument(0);
+                    return commits.getAndIncrement() == 0
+                            ? CompletableFuture.completedFuture(
+                                    CommitModelsResult.rebase(
+                                            request.getRequestId(),
+                                            request.getCommitId(),
+                                            List.of(new ModelCommitConflict(
+                                                    rootId.toString(),
+                                                    51L, 0L)),
+                                            51L))
+                            : CompletableFuture.completedFuture(
+                                    result(request));
+                });
+
+        Optional<CommitModelsResult> accepted = ModelPipeline.commit(
+                protocol, "cascade-rebase", original,
+                ModelConflictPolicy.ACCEPT,
+                ModelPipeline.Retry.accepting(
+                        (ignored, current) ->
+                                CompletableFuture.completedFuture(
+                                        rebased)),
+                null, -1, true).join();
+
+        assertTrue(accepted.orElseThrow().isAccepted());
+        ArgumentCaptor<CommitModels> requests =
+                ArgumentCaptor.forClass(CommitModels.class);
+        verify(eventStoreClient, times(2))
+                .commitModels(requests.capture());
+        CommitModels initial = requests.getAllValues().getFirst();
+        CommitModels retried = requests.getAllValues().getLast();
+        assertEquals(2, retried.getSubsteps().size());
+        assertEquals(
+                initial.getSubsteps().getFirst().getEvent().getData(),
+                retried.getSubsteps().getFirst().getEvent().getData());
+        assertEquals(
+                childId.toString(),
+                retried.getSubsteps().getLast()
+                        .getTargets().getFirst().getModelId());
+        assertTrue(
+                retried.getSubsteps().getFirst()
+                        .getTargets().getFirst().isCascadeDelete());
     }
 
     @Test

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
@@ -599,6 +599,10 @@ class InMemoryEventStoreModelCommitTest {
                 () -> store.commitModels(
                                 commit)
                         .join());
+        var pendingPosition = store.trackModelUpdates(
+                new TrackModelUpdates(-1L, 1, 0L)).join();
+        assertEquals(0L, pendingPosition.getCurrentStateIndex());
+        assertEquals(-1L, pendingPosition.getMaterializedStateIndex());
         CommitModels retryCommit =
                 commit(
                         "commit-1",
@@ -617,6 +621,9 @@ class InMemoryEventStoreModelCommitTest {
 
         assertEquals(2, attempts.get());
         assertTrue(retry.isDuplicate());
+        var completedPosition = store.trackModelUpdates(
+                new TrackModelUpdates(-1L, 1, 0L)).join();
+        assertEquals(0L, completedPosition.getMaterializedStateIndex());
         assertEquals(
                 1,
                 store.getEvents("order-1")

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
@@ -44,9 +44,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -654,6 +656,44 @@ class InMemoryEventStoreModelCommitTest {
                 () -> store.commitModels(outer).join());
         assertNotNull(modelStream(store, "outer-model").getHead());
         assertNotNull(modelStream(store, "nested-model").getHead());
+    }
+
+    @Test
+    void concurrentAppendAndPublishingModelCommitUseConsistentLockOrder() {
+        BlockingNotificationEventStore store = new BlockingNotificationEventStore();
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            CompletableFuture<Void> append = CompletableFuture.runAsync(
+                    () -> store.append(List.of(event("ordinary-event"))).join());
+            try {
+                store.notificationStarted.await();
+                AtomicReference<Thread> commitThread = new AtomicReference<>();
+                CompletableFuture<Void> commit = CompletableFuture.runAsync(() -> {
+                    commitThread.set(Thread.currentThread());
+                    store.commitModels(commit(
+                            "model-commit",
+                            ModelCommitStep.builder()
+                                    .event(event("model-event"))
+                                    .publishEvent(true)
+                                    .targets(List.of(storedTarget("model-1")))
+                                    .build())).join();
+                });
+                while (commitThread.get() == null
+                       || commitThread.get().getState() != Thread.State.BLOCKED) {
+                    Thread.onSpinWait();
+                }
+                store.continueNotification.countDown();
+                append.join();
+                commit.join();
+            } finally {
+                store.continueNotification.countDown();
+            }
+        });
+
+        assertEquals(List.of("ordinary-event", "model-event"),
+                     store.getBatch(null, 10, true).stream()
+                             .map(SerializedMessage::getMessageId)
+                             .toList());
+        assertNotNull(modelStream(store, "model-1").getHead());
     }
 
     @Test
@@ -1635,5 +1675,30 @@ class InMemoryEventStoreModelCommitTest {
         return new SerializedMessage(
                 new Data<>(messageId.getBytes(), "event", 0),
                 Metadata.empty(), messageId, 1L);
+    }
+
+    private static class BlockingNotificationEventStore extends InMemoryEventStore {
+
+        private final AtomicBoolean blockNotification = new AtomicBoolean(true);
+        private final CountDownLatch notificationStarted = new CountDownLatch(1);
+        private final CountDownLatch continueNotification = new CountDownLatch(1);
+
+        private BlockingNotificationEventStore() {
+            super(Duration.ofMinutes(2), () -> 0L);
+        }
+
+        @Override
+        protected void notifyMonitors(List<SerializedMessage> messages) {
+            if (blockNotification.compareAndSet(true, false)) {
+                notificationStarted.countDown();
+                try {
+                    continueNotification.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+            }
+            super.notifyMonitors(messages);
+        }
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1553,6 +1553,26 @@ class DefaultModelRepositoryTest {
         LocalClient client = spy(localClient);
         doReturn(eventStoreClient)
                 .when(client).getEventStoreClient();
+        CountDownLatch reconstructionLoaded =
+                new CountDownLatch(1);
+        CountDownLatch allowReconstructionCompletion =
+                new CountDownLatch(1);
+        AtomicReference<Thread> reconstructionThread =
+                new AtomicReference<>();
+        AtomicBoolean intercept =
+                new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            GetModelEventsResult result =
+                    (GetModelEventsResult)
+                            invocation.callRealMethod();
+            if (Thread.currentThread() == reconstructionThread.get()
+                && intercept.compareAndSet(true, false)) {
+                reconstructionLoaded.countDown();
+                allowReconstructionCompletion.await();
+            }
+            return result;
+        }).when(eventStoreClient)
+                .getModelEvents(any());
         try (ExecutorService reconstructionExecutor = Executors.newSingleThreadExecutor();
              Fluxzero fluxzero = withModelHandlers(
                      DefaultFluxzero.builder()
@@ -1570,30 +1590,14 @@ class DefaultModelRepositoryTest {
             repository.invalidateModels(
                     List.of(id.toString()));
 
-            CountDownLatch reconstructionLoaded =
-                    new CountDownLatch(1);
-            CountDownLatch allowReconstructionCompletion =
-                    new CountDownLatch(1);
-            AtomicBoolean intercept =
-                    new AtomicBoolean(true);
-            doAnswer(invocation -> {
-                GetModelEventsResult result =
-                        (GetModelEventsResult)
-                                invocation.callRealMethod();
-                if (intercept.compareAndSet(
-                        true, false)) {
-                    reconstructionLoaded
-                            .countDown();
-                    allowReconstructionCompletion.await();
-                }
-                return result;
-            }).when(eventStoreClient)
-                    .getModelEvents(any());
-
             CompletableFuture<Entity<Account>>
                     olderReconstruction =
                     CompletableFuture.supplyAsync(
-                            () -> repository.load(id),
+                            () -> {
+                                reconstructionThread.set(
+                                        Thread.currentThread());
+                                return repository.load(id);
+                            },
                             reconstructionExecutor);
             reconstructionLoaded.await();
 

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelCacheTrackerTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelCacheTrackerTest.java
@@ -528,14 +528,13 @@ class ModelCacheTrackerTest {
                                                             "sample-1",
                                                             1L,
                                                             true))))));
+            awaitUnavailable(
+                    tracker, "sample-1",
+                    SampleModel.class);
             CompletableFuture<TrackModelUpdatesResult>
                     materializationPoll =
                     awaitNext(polls);
 
-            assertNull(
-                    tracker.current(
-                            "sample-1",
-                            SampleModel.class));
             assertEquals(
                     0,
                     refreshCount.get());
@@ -1294,6 +1293,22 @@ class ModelCacheTrackerTest {
         }
         assertTrue(current != null);
         return current;
+    }
+
+    private static void awaitUnavailable(
+            ModelCacheTracker tracker,
+            String modelId,
+            Class<?> modelType) {
+        long deadline =
+                System.nanoTime()
+                + TimeUnit.SECONDS.toNanos(5L);
+        while (tracker.current(modelId, modelType) != null
+               && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertNull(
+                tracker.current(modelId, modelType),
+                "tracker did not fence the stale cache entry");
     }
 
     private static void completeNext(

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
@@ -27,13 +27,16 @@ import io.fluxzero.common.api.modeling.ModelEventPayload;
 import io.fluxzero.common.api.modeling.ModelEventStream;
 import io.fluxzero.common.api.modeling.ModelHeadState;
 import io.fluxzero.common.api.modeling.ModelReadBoundary;
+import io.fluxzero.common.api.modeling.TrackModelUpdatesResult;
 import io.fluxzero.sdk.common.serialization.jackson.JacksonSerializer;
-import io.fluxzero.sdk.modeling.EntityId;
+import io.fluxzero.sdk.modeling.CommitAttempt;
 import io.fluxzero.sdk.modeling.DocumentProjection;
+import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.ImmutableModelRoot;
 import io.fluxzero.sdk.modeling.Model;
 import io.fluxzero.sdk.modeling.ModelPersistence;
+import io.fluxzero.sdk.modeling.MutationPlan;
 import io.fluxzero.sdk.persisting.eventsourcing.EventSourcingException;
 import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
 import io.fluxzero.sdk.persisting.eventsourcing.client.LocalEventStoreClient;
@@ -45,6 +48,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +66,189 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ModelReplayCursorTest {
+
+    @Test
+    void exactContextUsesUnchangedAuthoritativeDocumentWhenHistoryIsIncomplete() {
+        String modelId = "incomplete-document";
+        long boundary = 42L;
+        ModelHeadState head = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                1L, 40L, false, false);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(modelId, head, List.of())));
+        });
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id", value),
+                        head));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+        MutationPlan.Resolution resolution = new MutationPlan.Resolution(
+                List.of(new MutationPlan.ResolvedModel(
+                        modelId, CurrentDocument.class,
+                        MutationPlan.Access.READ_WRITE, List.of("id"))),
+                List.of());
+
+        CommitAttempt context = loader.context(
+                resolution, ModelReadBoundary.state(boundary, false),
+                Map.of(), null, null, true, false);
+
+        assertEquals(boundary, context.readStateIndex());
+        assertEquals(value, context.entity(modelId).get());
+    }
+
+    @Test
+    void exactContextRejectsAuthoritativeDocumentThatMovedPastIncompleteHistory() {
+        String modelId = "moved-incomplete-document";
+        long boundary = 42L;
+        ModelHeadState historicalHead = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                1L, 40L, false, false);
+        ModelHeadState currentHead = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                2L, 43L, false, false);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(
+                            modelId, historicalHead, List.of())));
+        });
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id",
+                                new CurrentDocument(modelId, "moved")),
+                        currentHead));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+        MutationPlan.Resolution resolution = new MutationPlan.Resolution(
+                List.of(new MutationPlan.ResolvedModel(
+                        modelId, CurrentDocument.class,
+                        MutationPlan.Access.READ_WRITE, List.of("id"))),
+                List.of());
+
+        EventSourcingException failure = assertThrows(
+                EventSourcingException.class,
+                () -> loader.context(
+                        resolution, ModelReadBoundary.state(boundary, false),
+                        Map.of(), null, null, true, false));
+
+        assertTrue(failure.getMessage().contains(
+                "does not match incomplete historical head"));
+    }
+
+    @Test
+    void acceptRebaseAdvancesToMovedAuthoritativeDocument() {
+        String modelId = "advanced-incomplete-document";
+        long requestedBoundary = 42L;
+        long currentBoundary = 43L;
+        ModelHeadState historicalHead = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                1L, 40L, false, false);
+        ModelHeadState currentHead = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                2L, currentBoundary, false, false);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            long boundary = request.getBoundary().stateIndex();
+            ModelHeadState head = boundary == requestedBoundary
+                    ? historicalHead : currentHead;
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(modelId, head, List.of())));
+        });
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id", value),
+                        currentHead));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+        MutationPlan.Resolution resolution = new MutationPlan.Resolution(
+                List.of(new MutationPlan.ResolvedModel(
+                        modelId, CurrentDocument.class,
+                        MutationPlan.Access.READ_WRITE, List.of("id"))),
+                List.of());
+
+        CommitAttempt context = loader.context(
+                resolution, ModelReadBoundary.state(requestedBoundary, false),
+                Map.of(), null, null, true, false, true);
+
+        assertEquals(currentBoundary, context.readStateIndex());
+        assertEquals(value, context.entity(modelId).get());
+        verify(client, times(2)).getModelEvents(any());
+    }
+
+    @Test
+    void acceptRebaseWaitsForLaggingAuthoritativeDocument() {
+        String modelId = "lagging-incomplete-document";
+        long boundary = 42L;
+        ModelHeadState head = new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                1L, 40L, false, false);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(modelId, head, List.of())));
+        });
+        when(client.trackModelUpdates(any())).thenReturn(
+                CompletableFuture.completedFuture(
+                        new TrackModelUpdatesResult(
+                                0L, boundary, boundary,
+                                boundary, List.of())));
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                                ImmutableModelRoot.initial(
+                                        modelId, CurrentDocument.class, "id", null),
+                                null),
+                            new ModelReplayCursor.DocumentVersion(
+                                    ImmutableModelRoot.initial(
+                                            modelId, CurrentDocument.class, "id", value),
+                                    head));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+        MutationPlan.Resolution resolution = new MutationPlan.Resolution(
+                List.of(new MutationPlan.ResolvedModel(
+                        modelId, CurrentDocument.class,
+                        MutationPlan.Access.READ_WRITE, List.of("id"))),
+                List.of());
+
+        CommitAttempt context = loader.context(
+                resolution, ModelReadBoundary.state(boundary, false),
+                Map.of(), null, null, true, false, true);
+
+        assertEquals(boundary, context.readStateIndex());
+        assertEquals(value, context.entity(modelId).get());
+        verify(client, times(2)).getModelEvents(any());
+        verify(documentReader, times(2)).load(
+                modelId, CurrentDocument.class, false);
+        verify(client).trackModelUpdates(any());
+    }
 
     @Test
     void retriesCurrentGraphWhenADocumentAdvancesDuringReconstruction() {

--- a/test-server/src/main/java/io/fluxzero/testserver/websocket/SearchEndpoint.java
+++ b/test-server/src/main/java/io/fluxzero/testserver/websocket/SearchEndpoint.java
@@ -166,6 +166,9 @@ public class SearchEndpoint extends WebsocketEndpoint {
     @Handle
     GetDocumentResult handle(GetDocument request) {
         try {
+            if (request.isIncludeModelHead()) {
+                return store.fetchModelDocument(request);
+            }
             return new GetDocumentResult(request.getRequestId(), store.fetch(request).orElse(null));
         } catch (Exception e) {
             log.error("Failed to handle {}", request, e);

--- a/test-server/src/test/java/io/fluxzero/testserver/TestServerWebsocketContractTest.java
+++ b/test-server/src/test/java/io/fluxzero/testserver/TestServerWebsocketContractTest.java
@@ -456,6 +456,12 @@ class TestServerWebsocketContractTest {
                                                   + UUID.randomUUID(),
                                                   -1L,
                                                   root)));
+            var rootDocument = search.fetchModelDocument(
+                    new GetDocument(rootId, roots));
+            assertEquals(rootId, rootDocument.getDocument().getId());
+            assertEquals(
+                    rootResult.getUpdates().getFirst().getStateIndex(),
+                    rootDocument.getModelHead().getStateIndex());
             var rootChange = eventStore.getModelChange(
                     new GetModelChange(rootResult.getCommitId(), 0));
             assertEquals(rootResult.getCommitId(), rootChange.getCommitId());


### PR DESCRIPTION
## Summary
- enforce monitor-notification-before-store lock ordering for in-memory Model commits that publish events
- allow cascade ACCEPT rebases to include owned descendants discovered at a newer relation boundary while retaining the original domain event
- keep historical document Model reads exact and let only ACCEPT rebases advance after durable document materialization catches up
- expose atomically stored direct Model heads through the test-server websocket and report pending in-memory materialization honestly
- make the lock, cache-fence, cascade, document-boundary, and websocket regressions deterministic

## Compatibility
- no supported public API, persisted-data, or wire-format changes
- ordinary historical reads and event-sourced rebases retain exact-boundary semantics
- ordinary non-cascade ACCEPT rebases keep their existing fixed-shape validation
- event publication, atomic storage, deferred materialization, and callbacks retain their completion contracts
- the extra document-head lookup is limited to historical document reads; materialization waiting is limited to the rare incomplete-document rebase slow path

## Verification
- deterministic forced concurrency and boundary regressions
- focused in-memory store, Model repository, pipeline, and websocket contract suites
- full SDK reactor including test-server, proxy, and Java/Kotlin downstream checks
- full external application reactor and local server/proxy/application startup smoke