### PR TITLE
test(modeling): preserve graph during nested replay

### DIFF
--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
@@ -402,6 +402,7 @@ class ModelCommitHandlerIntegrationTest {
                 .registerHandlers(new Object() {
                     @HandleNotification
                     void handle(Graph<FamilyRoot> graph) {
+                        assertEquals(rootId.toString(), graph.id().toString());
                         Fluxzero.get().cache().clear();
                         loaded.set(Fluxzero.<Account>loadModel(accountId).get());
                     }


### PR DESCRIPTION
## Summary
- assert that graph-change handlers retain their selected Graph during invocation
- cover nested Model replay in the same handler invocation

This runs the full release-line build against the final SDK tree.