### PR TITLE
fix(modeling): delete eventless document models

### DIFF
--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
@@ -1097,14 +1097,48 @@ final class ModelReplayCursor {
         GetModelGraphResult response = getModelGraph(request);
         GetModelEventsResult graphEvents = response.getEvents();
         long stateIndex = graphEvents.getStateIndex();
-        List<MutationPlan.ResolvedModel> targets = new ArrayList<>(graphEvents.getStreams().size());
+        List<ModelEventStream> streams = graphEvents.getStreams();
         LinkedHashMap<String, ModelHeadState> heads = new LinkedHashMap<>();
-        for (ModelEventStream stream : graphEvents.getStreams()) {
-            Class<?> modelType = graphModelType(stream, rootId, rootType);
+        streams.forEach(stream -> heads.put(stream.getModelId(), stream.getHead()));
+        List<String> missingHeads = streams.stream()
+                .filter(stream -> stream.getHead() == null)
+                .map(ModelEventStream::getModelId)
+                .toList();
+        if (!missingHeads.isEmpty()) {
+            LoadResult loaded = loadHeads(
+                    missingHeads, ModelReadBoundary.at(stateIndex));
+            if (loaded.stateIndex() != stateIndex) {
+                throw new GraphBoundaryMovedException(
+                        "Model graph moved from state index %d to %d while resolving heads"
+                                .formatted(stateIndex, loaded.stateIndex()));
+            }
+            heads.putAll(loaded.heads());
+        }
+        List<MutationPlan.ResolvedModel> targets = new ArrayList<>(streams.size());
+        for (ModelEventStream stream : streams) {
+            Class<?> modelType = graphModelType(
+                    stream, heads.get(stream.getModelId()), rootId, rootType);
             targets.add(new MutationPlan.ResolvedModel(
                     stream.getModelId(), modelType, MutationPlan.Access.READ_ONLY,
                     List.of(EntityMetadata.validate(modelType).entityId().orElseThrow().name())));
-            heads.put(stream.getModelId(), stream.getHead());
+        }
+        List<String> unresolvedDocumentHeads = targets.stream()
+                .filter(target -> !EntityMetadata.validate(target.modelType())
+                        .rootConfiguration().orElseThrow().eventSourced())
+                .map(MutationPlan.ResolvedModel::modelId)
+                .filter(modelId -> heads.get(modelId) == null
+                                   || heads.get(modelId).isHistoryComplete())
+                .toList();
+        if (!unresolvedDocumentHeads.isEmpty()) {
+            LoadResult loaded = loadHeads(
+                    unresolvedDocumentHeads, ModelReadBoundary.at(stateIndex));
+            if (loaded.stateIndex() != stateIndex) {
+                throw new GraphBoundaryMovedException(
+                        "Model graph moved from state index %d to %d while resolving document heads"
+                                .formatted(stateIndex, loaded.stateIndex()));
+            }
+            unresolvedDocumentHeads.forEach(heads::remove);
+            heads.putAll(loaded.heads());
         }
         boolean historicalBoundary = boundary.historical();
         LinkedHashMap<String, Entity<?>> models = reconstructProjection(targets, heads, stateIndex, historicalBoundary);
@@ -1135,7 +1169,8 @@ final class ModelReplayCursor {
             boolean historicalBoundary) {
         List<MutationPlan.ResolvedModel> replayTargets = new ArrayList<>();
         List<MutationPlan.ResolvedModel> documentTargets = new ArrayList<>();
-        targets.forEach(target -> (requiresReplay(target, historicalBoundary)
+        targets.forEach(target -> (requiresReplay(
+                target, historicalBoundary, heads.get(target.modelId()))
                 ? replayTargets : documentTargets).add(target));
         LinkedHashMap<String, Entity<?>> result = new LinkedHashMap<>();
         if (!replayTargets.isEmpty()) {
@@ -1149,18 +1184,32 @@ final class ModelReplayCursor {
             result.putAll(reconstructed.entities());
         }
         for (MutationPlan.ResolvedModel target : documentTargets) {
-            DocumentVersion document = documentReader.load(
-                    target.modelId(), target.modelType(), false);
-            Entity<?> entity = document.entity();
             ModelHeadState expected = heads.get(target.modelId());
-            if (!Objects.equals(expected, document.head())) {
-                throw new GraphBoundaryMovedException(
-                        "Document model '%s' moved while reconstructing graph boundary"
-                                .formatted(target.modelId()));
-            }
-            result.put(target.modelId(), entity);
+            result.put(target.modelId(), loadGraphDocument(target, expected));
         }
         return result;
+    }
+
+    private Entity<?> loadGraphDocument(
+            MutationPlan.ResolvedModel target,
+            ModelHeadState expected) {
+        DocumentVersion document = documentReader.load(
+                target.modelId(), target.modelType(), false);
+        ModelHeadState actual = document.head();
+        if (!Objects.equals(expected, actual)
+            && expected != null && !expected.isHistoryComplete()
+            && (actual == null || actual.getStateIndex() < expected.getStateIndex())
+            && awaitMaterializedBoundary(expected.getStateIndex())
+               >= expected.getStateIndex()) {
+            document = documentReader.load(
+                    target.modelId(), target.modelType(), false);
+        }
+        if (!Objects.equals(expected, document.head())) {
+            throw new GraphBoundaryMovedException(
+                    "Document model '%s' moved while reconstructing graph boundary"
+                            .formatted(target.modelId()));
+        }
+        return document.entity();
     }
 
     private static final class GraphBoundaryMovedException extends EventSourcingException {
@@ -1170,15 +1219,27 @@ final class ModelReplayCursor {
     }
 
     private static boolean requiresReplay(MutationPlan.ResolvedModel target, boolean historicalBoundary) {
-        return historicalBoundary || EntityMetadata.validate(target.modelType()).rootConfiguration()
-                .orElseThrow().eventSourced();
+        return requiresReplay(target, historicalBoundary, null);
+    }
+
+    /**
+     * An incomplete durable head identifies an authoritative document without replayable history. Its exactness is
+     * proven immediately afterwards by comparing that head with the document that was actually loaded.
+     */
+    private static boolean requiresReplay(
+            MutationPlan.ResolvedModel target,
+            boolean historicalBoundary,
+            ModelHeadState head) {
+        return EntityMetadata.validate(target.modelType()).rootConfiguration()
+                       .orElseThrow().eventSourced()
+               || historicalBoundary && (head == null || head.isHistoryComplete());
     }
 
     private Class<?> graphModelType(
             ModelEventStream stream,
+            ModelHeadState head,
             String rootId,
             Class<?> rootType) {
-        ModelHeadState head = stream.getHead();
         String storedType = head == null ? null : head.getModelType();
         if (storedType == null) {
             if (stream.getModelId().equals(rootId)) {

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1557,16 +1557,13 @@ class DefaultModelRepositoryTest {
                 new CountDownLatch(1);
         CountDownLatch allowReconstructionCompletion =
                 new CountDownLatch(1);
-        AtomicReference<Thread> reconstructionThread =
-                new AtomicReference<>();
         AtomicBoolean intercept =
-                new AtomicBoolean(true);
+                new AtomicBoolean();
         doAnswer(invocation -> {
             GetModelEventsResult result =
                     (GetModelEventsResult)
                             invocation.callRealMethod();
-            if (Thread.currentThread() == reconstructionThread.get()
-                && intercept.compareAndSet(true, false)) {
+            if (intercept.compareAndSet(true, false)) {
                 reconstructionLoaded.countDown();
                 allowReconstructionCompletion.await();
             }
@@ -1589,17 +1586,14 @@ class DefaultModelRepositoryTest {
                             fluxzero.modelRepository();
             repository.invalidateModels(
                     List.of(id.toString()));
+            intercept.set(true);
 
             CompletableFuture<Entity<Account>>
                     olderReconstruction =
                     CompletableFuture.supplyAsync(
-                            () -> {
-                                reconstructionThread.set(
-                                        Thread.currentThread());
-                                return repository.load(id);
-                            },
+                            () -> repository.load(id),
                             reconstructionExecutor);
-            reconstructionLoaded.await();
+            assertTrue(reconstructionLoaded.await(5L, TimeUnit.SECONDS));
 
             repository.updateAfterCommit(
                     List.of(committed(
@@ -1614,6 +1608,8 @@ class DefaultModelRepositoryTest {
             assertEquals(
                     new Account(id, 20),
                     repository.load(id).get());
+        } finally {
+            allowReconstructionCompletion.countDown();
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -255,10 +256,21 @@ class ModelReplayCursorTest {
         String modelId = "current-document";
         ModelHeadState firstHead = documentHead(modelId, 0L, 1L);
         ModelHeadState currentHead = documentHead(modelId, 1L, 2L);
+        ModelHeadState currentDocumentHead = directDocumentHead(modelId, 1L, 2L);
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelGraph(any())).thenReturn(
                 graphResponse(modelId, firstHead, 1L),
                 graphResponse(modelId, currentHead, 2L));
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            long stateIndex = request.getBoundary().stateIndex();
+            ModelHeadState head = stateIndex == 1L
+                    ? directDocumentHead(modelId, 0L, 1L)
+                    : directDocumentHead(modelId, 1L, 2L);
+            return new GetModelEventsResult(
+                    request.getRequestId(), stateIndex, List.of(),
+                    List.of(new ModelEventStream(modelId, head, List.of())));
+        });
         ModelReplayCursor.DocumentReader documentReader = mock(
                 ModelReplayCursor.DocumentReader.class);
         when(documentReader.load(modelId, CurrentDocument.class, false))
@@ -266,7 +278,7 @@ class ModelReplayCursorTest {
                         ImmutableModelRoot.initial(
                                 modelId, CurrentDocument.class, "id",
                                 new CurrentDocument(modelId, "current")),
-                        currentHead));
+                        currentDocumentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
                 documentReader, mock(ModelRepository.class));
@@ -281,6 +293,180 @@ class ModelReplayCursorTest {
     }
 
     @Test
+    void exactGraphUsesUnchangedAuthoritativeDocumentWhenHistoryIsIncomplete() {
+        String modelId = "exact-document";
+        long boundary = 42L;
+        ModelHeadState head = directDocumentHead(modelId, 2L, boundary);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelGraph(any())).thenReturn(
+                graphResponse(modelId, head, boundary));
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id", value),
+                        head));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+
+        Graph<CurrentDocument> result = loader.graph(
+                modelId, CurrentDocument.class, Graph.Options.DEFAULT,
+                ModelReadBoundary.at(boundary), "test", Map.of());
+
+        assertEquals(value, result.get());
+        assertEquals(boundary, result.stateIndex());
+        verify(client, never()).getModelEvents(any());
+    }
+
+    @Test
+    void exactGraphResolvesAMissingInlineHeadBeforeChoosingDocumentReconstruction() {
+        String modelId = "exact-document-with-deferred-head";
+        long boundary = 42L;
+        ModelHeadState head = directDocumentHead(modelId, 2L, boundary);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelGraph(any())).thenReturn(
+                graphResponse(modelId, null, boundary));
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(modelId, head, List.of())));
+        });
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id", value),
+                        head));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+
+        Graph<CurrentDocument> result = loader.graph(
+                modelId, CurrentDocument.class, Graph.Options.DEFAULT,
+                ModelReadBoundary.at(boundary), "test", Map.of());
+
+        assertEquals(value, result.get());
+        assertEquals(boundary, result.stateIndex());
+        verify(client).getModelEvents(any());
+    }
+
+    @Test
+    void exactGraphUsesTheDurableDocumentHeadInsteadOfAReplayableInlineStreamHead() {
+        String modelId = "exact-document-with-event-stream-head";
+        long boundary = 42L;
+        ModelHeadState streamHead = documentHead(modelId, -1L, boundary);
+        ModelHeadState documentHead = directDocumentHead(modelId, 2L, boundary);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelGraph(any())).thenReturn(
+                graphResponse(modelId, streamHead, boundary));
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), boundary, List.of(),
+                    List.of(new ModelEventStream(
+                            modelId, documentHead, List.of())));
+        });
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id", value),
+                        documentHead));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+
+        Graph<CurrentDocument> result = loader.graph(
+                modelId, CurrentDocument.class, Graph.Options.DEFAULT,
+                ModelReadBoundary.at(boundary), "test", Map.of());
+
+        assertEquals(value, result.get());
+        assertEquals(boundary, result.stateIndex());
+        verify(client).getModelEvents(any());
+    }
+
+    @Test
+    void exactGraphWaitsForLaggingAuthoritativeDocument() {
+        String modelId = "lagging-exact-document";
+        long boundary = 42L;
+        ModelHeadState head = directDocumentHead(modelId, 2L, boundary);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelGraph(any())).thenReturn(
+                graphResponse(modelId, head, boundary));
+        when(client.trackModelUpdates(any())).thenReturn(
+                CompletableFuture.completedFuture(
+                        new TrackModelUpdatesResult(
+                                0L, boundary, boundary,
+                                boundary, List.of())));
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        CurrentDocument value = new CurrentDocument(modelId, "current");
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(
+                        new ModelReplayCursor.DocumentVersion(
+                                ImmutableModelRoot.initial(
+                                        modelId, CurrentDocument.class, "id", null),
+                                null),
+                        new ModelReplayCursor.DocumentVersion(
+                                ImmutableModelRoot.initial(
+                                        modelId, CurrentDocument.class, "id", value),
+                                head));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+
+        Graph<CurrentDocument> result = loader.graph(
+                modelId, CurrentDocument.class, Graph.Options.DEFAULT,
+                ModelReadBoundary.at(boundary), "test", Map.of());
+
+        assertEquals(value, result.get());
+        verify(documentReader, times(2)).load(
+                modelId, CurrentDocument.class, false);
+        verify(client).trackModelUpdates(any());
+        verify(client, never()).getModelEvents(any());
+    }
+
+    @Test
+    void exactGraphRejectsAuthoritativeDocumentThatMovedPastIncompleteHistory() {
+        String modelId = "moved-exact-document";
+        long boundary = 42L;
+        ModelHeadState historicalHead = directDocumentHead(modelId, 1L, boundary);
+        ModelHeadState currentHead = directDocumentHead(modelId, 2L, boundary + 1L);
+        EventStoreClient client = mock(EventStoreClient.class);
+        when(client.getModelGraph(any())).thenReturn(
+                graphResponse(modelId, historicalHead, boundary));
+        ModelReplayCursor.DocumentReader documentReader = mock(
+                ModelReplayCursor.DocumentReader.class);
+        when(documentReader.load(modelId, CurrentDocument.class, false))
+                .thenReturn(new ModelReplayCursor.DocumentVersion(
+                        ImmutableModelRoot.initial(
+                                modelId, CurrentDocument.class, "id",
+                                new CurrentDocument(modelId, "moved")),
+                        currentHead));
+        ModelReplayCursor loader = new ModelReplayCursor(
+                client, new JacksonSerializer(), null, null, null, null,
+                documentReader, mock(ModelRepository.class));
+
+        EventSourcingException failure = assertThrows(
+                EventSourcingException.class,
+                () -> loader.graph(
+                        modelId, CurrentDocument.class, Graph.Options.DEFAULT,
+                        ModelReadBoundary.at(boundary), "test", Map.of()));
+
+        assertTrue(failure.getMessage().contains(
+                "moved while reconstructing graph boundary"));
+        verify(client, never()).getModelEvents(any());
+    }
+
+    @Test
     void boundsCurrentGraphRetriesWhenADocumentKeepsAdvancing() {
         String modelId = "moving-document";
         ModelHeadState graphHead = documentHead(modelId, 0L, 1L);
@@ -288,6 +474,13 @@ class ModelReplayCursorTest {
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelGraph(any())).thenReturn(
                 graphResponse(modelId, graphHead, 1L));
+        when(client.getModelEvents(any())).thenAnswer(invocation -> {
+            GetModelEvents request = invocation.getArgument(0);
+            return new GetModelEventsResult(
+                    request.getRequestId(), 1L, List.of(),
+                    List.of(new ModelEventStream(
+                            modelId, directDocumentHead(modelId, 0L, 1L), List.of())));
+        });
         ModelReplayCursor.DocumentReader documentReader = mock(
                 ModelReplayCursor.DocumentReader.class);
         when(documentReader.load(modelId, CurrentDocument.class, false))
@@ -327,6 +520,15 @@ class ModelReplayCursorTest {
         return new ModelHeadState(
                 modelId, CurrentDocument.class.getName(),
                 sequenceNumber, stateIndex, true, false);
+    }
+
+    private static ModelHeadState directDocumentHead(
+            String modelId,
+            long sequenceNumber,
+            long stateIndex) {
+        return new ModelHeadState(
+                modelId, CurrentDocument.class.getName(),
+                sequenceNumber, stateIndex, false, false);
     }
 
     @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "currentDocuments"))

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
@@ -20,6 +20,7 @@ import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.Message;
 import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.EntityId;
+import io.fluxzero.sdk.modeling.EventPublication;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.AssertLegal;
 import io.fluxzero.sdk.modeling.Model;
@@ -159,6 +160,46 @@ class TestFixtureModelApiTest {
                 .whenApplying(ignored -> Fluxzero.loadModel(
                         "document-1", UncachedDocument.class).get())
                 .expectResult(new UncachedDocument("document-1", 3));
+    }
+
+    @Test
+    void cachelessEventlessDocumentModelSupportsItsCompleteLifecycle() {
+        String id = "document-lifecycle";
+
+        TestFixture.create(UncachedDocument.class)
+                .whenExecuting(ignored -> Fluxzero.loadGraph(id, UncachedDocument.class)
+                        .update(current -> new UncachedDocument(id, 1))
+                        .commit())
+                .expectSuccessfulResult()
+                .expectNoEvents()
+                .andThen()
+                .whenExecuting(ignored -> Fluxzero.loadGraph(id, UncachedDocument.class)
+                        .update(current -> new UncachedDocument(id, current.value() + 1))
+                        .commit())
+                .expectSuccessfulResult()
+                .expectNoEvents()
+                .andThen()
+                .whenExecuting(ignored -> Fluxzero.loadGraph(id, UncachedDocument.class)
+                        .update(current -> new UncachedDocument(id, current.value() + 1))
+                        .commit())
+                .expectSuccessfulResult()
+                .expectNoEvents()
+                .andThen()
+                .whenExecuting(ignored -> Fluxzero.loadGraph(id, UncachedDocument.class)
+                        .update(current -> null)
+                        .commit())
+                .expectSuccessfulResult()
+                .expectNoEvents()
+                .expectTrue(ignored -> Fluxzero.loadModel(id, UncachedDocument.class).isEmpty())
+                .andThen()
+                .whenExecuting(ignored -> Fluxzero.loadGraph(id, UncachedDocument.class)
+                        .update(current -> new UncachedDocument(id, 4))
+                        .commit())
+                .expectSuccessfulResult()
+                .expectNoEvents()
+                .andThen()
+                .whenApplying(ignored -> Fluxzero.loadModel(id, UncachedDocument.class).get())
+                .expectResult(new UncachedDocument(id, 4));
     }
 
     @Test
@@ -308,7 +349,10 @@ class TestFixtureModelApiTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.DOCUMENT, cached = false)
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            eventPublication = EventPublication.NEVER,
+            cached = false)
     private record UncachedDocument(@EntityId String id, int value) {
     }
 


### PR DESCRIPTION
## Summary
- resolve authoritative durable document heads at the exact Graph boundary, including when inline stream heads are absent or only describe published history
- reconstruct document-authoritative Models from their exact stored document without requiring an event stream
- preserve historical event replay when the durable Model head proves that history is complete
- await a committed document that is still materializing, while rejecting documents that already moved past the boundary
- cover cacheless create, repeated update, delete, recreation, and owned-child cascade deletion
- make the existing cache-reconstruction ordering test deterministic across batched worker threads