### PR TITLE
fix(tracking): filter self handlers before deserialization

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.5.7-15</version>
+            <version>1.5.7-16</version>
         </dependency>
 
         <!--logging API used by Lombok @Slf4j and common logging hooks-->

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>6.1.3</junit.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
         <maven.compiler.version>3.15.0</maven.compiler.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>

--- a/kotlin-downstream-project/pom.xml
+++ b/kotlin-downstream-project/pom.xml
@@ -20,7 +20,7 @@
         <junit.version>6.1.3</junit.version>
         <kotlin.version>2.4.10</kotlin.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <junit.parallelism>2</junit.parallelism>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <fluxzero.maven.plugin.version>1.16.1</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
         <fluxzero.package.channel-tag>latest</fluxzero.package.channel-tag>
         <fluxzero.package.base-image>gcr.io/distroless/java25-debian13:nonroot@sha256:9ccf2b8bce700d9f450523e2055afabe4d4ee795e6d69a0647a2dcd6e180e411</fluxzero.package.base-image>
         <argLine/>

--- a/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/DefaultHandlerFactory.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/tracking/handling/DefaultHandlerFactory.java
@@ -250,7 +250,10 @@ public class DefaultHandlerFactory implements HandlerFactory {
                                     message.getPayloadClass()) && !hasMoreSpecificTrackSelfHandlerType(
                                     targetClass, message.getPayloadClass());
                     config = config.toBuilder().messageFilter(selfFilter.and(config.messageFilter())).build();
-                    return createDefaultHandler(targetClass, DeserializingMessage::getPayload, config);
+                    return createDefaultHandler(targetClass,
+                                                message -> targetClass.isAssignableFrom(message.getPayloadClass())
+                                                        ? message.getPayload() : null,
+                                                config);
                 }
             }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
@@ -21,6 +21,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.fluxzero.common.MessageType;
 import io.fluxzero.common.Registration;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.api.modeling.CommitModels;
 import io.fluxzero.common.api.modeling.CommitModelsResult;
 import io.fluxzero.common.api.modeling.ModelCommitConflict;
@@ -67,6 +70,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -691,6 +695,26 @@ class ModelCommitHandlerRegistryTest {
 
             assertTrue(subject.canHandle(
                     message(new TimingCreateCommand("fixture"))));
+        } finally {
+            subject.close();
+        }
+    }
+
+    @Test
+    void automaticModelHandlerDoesNotDeserializeNonMatchingPayload() {
+        ModelCommitHandlerRegistry subject =
+                subject(AutomaticModelHandling.ENABLED);
+        try {
+            Handler<DeserializingMessage> handler = subject.createHandler(
+                    TimingCreateCommand.class,
+                    HandlerFilter.ALWAYS_HANDLE,
+                    List.of()).orElseThrow();
+            AtomicInteger deserializationAttempts = new AtomicInteger();
+
+            assertNull(handler.getInvokerOrNull(malformedMessage(
+                    CrossApplicationCommand.class,
+                    deserializationAttempts)));
+            assertEquals(0, deserializationAttempts.get());
         } finally {
             subject.close();
         }
@@ -1997,6 +2021,21 @@ class ModelCommitHandlerRegistryTest {
         DeserializingMessage result = message(payload);
         result.getSerializedObject().setSegment(segment);
         return result;
+    }
+
+    private static DeserializingMessage malformedMessage(
+            Class<?> payloadClass,
+            AtomicInteger deserializationAttempts) {
+        SerializedMessage serializedMessage = new SerializedMessage(
+                new Data<>(new byte[0], payloadClass.getName(), 0),
+                Metadata.empty(), "message-id", 0L);
+        return new DeserializingMessage(
+                serializedMessage,
+                ignored -> {
+                    deserializationAttempts.incrementAndGet();
+                    throw new IllegalStateException("malformed payload");
+                },
+                MessageType.COMMAND, null, null);
     }
 
     private static CommitAttempt evaluation(

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/TrackSelfHandlerSelectionTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/TrackSelfHandlerSelectionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.tracking.handling;
+
+import io.fluxzero.common.MessageType;
+import io.fluxzero.common.api.Data;
+import io.fluxzero.common.api.Metadata;
+import io.fluxzero.common.api.SerializedMessage;
+import io.fluxzero.common.handling.Handler;
+import io.fluxzero.common.handling.MethodInvocationValidator;
+import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.tracking.TrackSelf;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TrackSelfHandlerSelectionTest {
+
+    @Test
+    void doesNotDeserializeNonMatchingPayload() {
+        AtomicInteger deserializationAttempts = new AtomicInteger();
+        DeserializingMessage message = malformedMessage(OtherCommand.class, deserializationAttempts);
+
+        assertNull(handler(TrackedCommand.class).getInvokerOrNull(message));
+        assertEquals(0, deserializationAttempts.get());
+    }
+
+    @Test
+    void matchingSubtypeStillDeserializesAndFailsNormally() {
+        AtomicInteger deserializationAttempts = new AtomicInteger();
+        DeserializingMessage message = malformedMessage(ConcreteTrackedCommand.class, deserializationAttempts);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class, () -> handler(TrackedCommand.class).getInvokerOrNull(message));
+
+        assertEquals("malformed payload", error.getMessage());
+        assertEquals(1, deserializationAttempts.get());
+    }
+
+    private static Handler<DeserializingMessage> handler(Class<?> targetClass) {
+        return new DefaultHandlerFactory(
+                MessageType.COMMAND, HandlerDecorator.noOp, List.of(), MethodInvocationValidator.noOp(),
+                ignored -> null, null, false, null)
+                .createHandler(targetClass, (type, executable) -> true, List.of()).orElseThrow();
+    }
+
+    private static DeserializingMessage malformedMessage(Class<?> payloadClass,
+                                                          AtomicInteger deserializationAttempts) {
+        SerializedMessage serializedMessage = new SerializedMessage(
+                new Data<>(new byte[0], payloadClass.getName(), 0), Metadata.empty(), "message-id", 0L);
+        return new DeserializingMessage(serializedMessage, ignored -> {
+            deserializationAttempts.incrementAndGet();
+            throw new IllegalStateException("malformed payload");
+        }, MessageType.COMMAND, null, null);
+    }
+
+    @TrackSelf
+    interface TrackedCommand {
+        @HandleCommand
+        default void handle() {
+        }
+    }
+
+    record ConcreteTrackedCommand() implements TrackedCommand {
+    }
+
+    record OtherCommand() {
+    }
+}


### PR DESCRIPTION
## Summary
- merge the current SDK `main` into `next/2.0`
- reject unrelated `@TrackSelf` payload types before deserialization
- prove automatic Model command handlers already preserve the same selection order

Malformed payloads now fail only in consumers whose tracked type actually matches. Interface and subtype specialization remain unchanged.