### PR TITLE
feat(search): select Models by relation identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3258,13 +3258,13 @@ Every model ID is an independent persistence and lifecycle boundary. Depending o
 event stream, cache entry, snapshots and direct search document. Commands can own their assertions and transitions
 directly:
 
-Choose one explicit persistence contract:
+Choose one non-empty set of durable representations:
 
-| `ModelPersistence` | Authoritative load path | Direct searchable document |
+| `ModelPersistence[]` | Authoritative load path | Current document |
 |---|---|---|
-| `EVENT_SOURCED` (default) | Model event stream, optionally from snapshots | No |
-| `EVENT_SOURCED_WITH_DOCUMENT` | Model event stream, optionally from snapshots | Yes |
-| `DOCUMENT` | Current document through the configured `DocumentSerializer` | Yes |
+| `{EVENT_SOURCED}` (default) | Model event stream, optionally from snapshots | No |
+| `{EVENT_SOURCED, DOCUMENT}` | Model event stream, optionally from snapshots | Yes |
+| `{DOCUMENT}` | Current document through the configured `DocumentSerializer` | Yes |
 
 Event storage and publication remain controlled independently by `eventPublication`, `publicationStrategy` and
 per-apply overrides. Internal type-isolated documents required for Graph composition are likewise independent: they do
@@ -3283,6 +3283,22 @@ public record UserAccount(
         boolean accountClosed) {
 }
 ```
+
+Current documents are publicly searchable by default. Keep a document available only through Model identity, aliases,
+parent relationships and Graph composition by making its projection reference-only:
+
+```java
+@Model(
+        persistence = ModelPersistence.DOCUMENT,
+        document = @DocumentProjection(searchable = false))
+public record UserPreferences(
+        @EntityId UserId userId,
+        Preferences preferences) {
+}
+```
+
+Reference-only documents use the same type-isolated private Model storage as Graph components. They remain durable and
+directly loadable, but `Fluxzero.search(UserPreferences.class)` does not expose them.
 
 Event-sourcing-only settings such as `ignoreUnknownEvents`, `snapshotPeriod`, `maxSnapshotCount` and
 `checkpointPeriod` are rejected on `DOCUMENT` Models instead of being silently ignored.
@@ -3471,8 +3487,9 @@ public record User(@EntityId UserId userId, String name) {
 ```
 
 `materializeGraph` is sufficient: Fluxzero keeps the private root document needed for composition without exposing a
-direct Model collection. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` only when callers should also be able to
-search the root Model itself. Use `document = @DocumentProjection(...)` or
+direct Model collection. Add `DOCUMENT` to an event-sourced Model only when callers should also be able to search its
+current state directly. Select document-only persistence when that document should be authoritative; set
+`document.searchable = false` when it should remain reference-only. Use `document = @DocumentProjection(...)` or
 `graphProjection = @GraphProjection(...)` only for advanced configuration. The graph collection is `User-graphs` by
 default; for a root with a direct document Fluxzero appends `-graphs` to the resolved direct collection. Set
 `GraphProjection.collection` only when a custom durable name is needed. Projection is asynchronous unless completion
@@ -4771,19 +4788,20 @@ documentStore.bulkUpdate("customCollection")
 
 ### Model documents and searchable values
 
-Models choose whether to maintain a direct document through `ModelPersistence`. Other values use the document-store
+Models choose whether to maintain a current document through their `ModelPersistence[]` set. Other values use the document-store
 annotations that own automatic indexing:
 
-- `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
+- `@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})`
 - `@Stateful` (implicitly `@Searchable`)
 - Directly annotate any POJO with `@Searchable`
 
-This enables automatic indexing after updates or message handling, without needing to call `Fluxzero.index(...)`
-manually.
+Adding `DOCUMENT` enables automatic document maintenance after updates without needing to call
+`Fluxzero.index(...)` manually. Its `DocumentProjection.searchable` setting determines whether that document is placed
+in the public Model collection or retained in type-isolated private storage.
 
 ```java
 
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record UserAccount(@EntityId UserId userId,
                           UserProfile profile,
                           boolean accountClosed) {
@@ -4795,7 +4813,7 @@ unless explicitly overridden through `Model.document`, `@Stateful`, `@Searchable
 
 ```java
 @Model(
-        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
         document = @DocumentProjection(
                 collection = "users",
                 timestampPath = "profile/createdAt"))
@@ -5156,7 +5174,7 @@ Fluxzero.search("expiredTokens")
 
 - Use `Fluxzero.index(...)` to manually index documents.
 - Use `@Searchable` to configure the collection name or time range for an object.
-- Use `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)` or `@Stateful` for automatic indexing.
+- Use `@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})` or `@Stateful` for automatic indexing.
 - Use `Fluxzero.search(...)` to query, stream, sort, and aggregate your documents.
 
 ---

--- a/README.md
+++ b/README.md
@@ -3395,10 +3395,42 @@ public record Address(
 
 Changing `userId` moves the address without loading or rewriting either parent. Parents and further ancestors can be
 injected into `@AssertLegal`, `@InterceptApply` and `@Apply`. Search supports current relationship constraints through
-`whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. These selectors first search the related Model's
-own indexed current-document collection and only then traverse the matching IDs to their targets. Non-public Graph
-components use a private collection per Model type, so they remain available for efficient parent selection without
-being mixed with other component types or exposed by `Fluxzero.search(Component.class)`.
+`whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Use a typed ID when the related identity is already
+known; Fluxzero then starts directly from the durable relationship index, so that parent or ancestor does not need a
+current-state document:
+
+```java
+List<Task> projectTasks = Fluxzero.search(Task.class)
+        .whereParent(projectId)
+        .fetch(100);
+
+List<Task> organisationTasks = Fluxzero.search(Task.class)
+        .whereAncestor(organisationId)
+        .fetch(100);
+```
+
+`whereAncestor(organisationId, 2, 2)` restricts traversal to exactly a grandparent. For a functional ID that does not
+extend `Id<T>`, pass its Model type as the second argument. A parent-scoped identity needs its exact persisted identity,
+so pass the already loaded parent or ancestor `Graph` instead.
+
+Use a Model class plus constraints when the related identity is not known and must be selected by current content:
+
+```java
+List<Task> activeProjectTasks = Fluxzero.search(Task.class)
+        .whereParent(Project.class, match("ACTIVE", "status"))
+        .fetch(100);
+```
+
+This form first searches the related Model's own current-document collection and then traverses the matching IDs. A
+public direct document is not required: an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true`
+maintains a type-isolated private current document that can supply the predicate. The materialized whole-Graph
+projection is not used as a substitute for the related Model's own fields.
+
+The returned target also needs a current document because `Search` returns current documents. That may be a public
+`DOCUMENT` projection or a private document maintained for Graph participation; adding a relationship selector makes
+that private target available only within the explicitly bounded relation. Plain `Fluxzero.search(Component.class)`
+still does not expose it. A standalone event-sourced target without a direct document, explicit composition path or
+materialized root has no searchable representation; load that known Model or Graph by identity instead.
 `searchGraph(User.class)` returns a
 `Search<Graph<User>>`, so `stream()`, `fetchAll()`, `fetchFirst()` and other terminal operations remain typed without a
 cast or type witness. It uses a configured materialized projection and otherwise stitches current public or private

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
@@ -30,24 +30,24 @@ import java.util.Objects;
 @Value
 public class ModelDocumentMutation {
 
-    /** Prefix for type-isolated internal graph-component collections. */
-    public static final String GRAPH_COMPONENT_COLLECTION_PREFIX =
+    /** Prefix for type-isolated internal current-Model collections. */
+    public static final String PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX =
             "$modelGraphComponents/";
 
     /**
-     * Returns the private search collection for current graph-component documents of one model type.
+     * Returns the private search collection for current documents of one Model type.
      * <p>
-     * Type isolation lets relationship search use the component's ordinary document indexes without scanning or
-     * mixing unrelated model types. The complete model type name is already part of the persisted model contract and
-     * keeps the collection deterministic across SDK instances.
+     * Type isolation lets direct lookup, relationship search and Graph composition use ordinary document indexes
+     * without scanning or mixing unrelated Model types. The complete Model type name is already part of the persisted
+     * contract and keeps the collection deterministic across SDK instances.
      */
-    public static String graphComponentCollection(String modelType) {
+    public static String privateModelDocumentCollection(String modelType) {
         Objects.requireNonNull(modelType, "Model type");
         if (modelType.isBlank() || !modelType.equals(modelType.trim())) {
             throw new IllegalArgumentException(
                     "Model type must not be blank or have surrounding whitespace");
         }
-        return GRAPH_COMPONENT_COLLECTION_PREFIX + modelType;
+        return PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX + modelType;
     }
 
     /**
@@ -58,8 +58,8 @@ public class ModelDocumentMutation {
             "$modelMigrationDocuments";
 
     /**
-     * Current-document collection. This is either the independently searchable model collection or an internal,
-     * type-isolated graph-component collection.
+     * Current-document collection. This is either the independently searchable Model collection or an internal,
+     * type-isolated current-Model collection.
      */
     String collection;
 

--- a/common/src/main/java/io/fluxzero/common/api/search/ModelRelationConstraint.java
+++ b/common/src/main/java/io/fluxzero/common/api/search/ModelRelationConstraint.java
@@ -16,6 +16,7 @@
 
 package io.fluxzero.common.api.search;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
@@ -28,9 +29,10 @@ import java.util.Objects;
 /**
  * Current-state relationship constraint for independent model documents.
  * <p>
- * The {@link #query} selects related model documents. The runtime then follows temporal model relationships from those
- * matches towards the target documents of a {@link SearchModelDocuments} request. Traversal is always bounded and
- * never changes the ordinary document constraint semantics.
+ * A relation starts either from related model documents selected by {@link #query} or from
+ * {@link #relatedModelIds exact persisted model identities}. The runtime then follows temporal model relationships
+ * from those IDs towards the target documents of a {@link SearchModelDocuments} request. Traversal is always bounded
+ * and never changes the ordinary document constraint semantics.
  */
 @Value
 @Builder(toBuilder = true)
@@ -45,7 +47,17 @@ public class ModelRelationConstraint {
     /**
      * Query that selects the related ancestor or descendant documents.
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     SearchQuery query;
+
+    /**
+     * Exact persisted identities used as relation starting points instead of a related-document query.
+     * <p>
+     * This form does not require the related models to maintain current-state documents.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Singular("relatedModelId")
+    List<String> relatedModelIds;
 
     /**
      * Minimum number of relationship edges between a returned target and a related match.
@@ -66,7 +78,8 @@ public class ModelRelationConstraint {
     List<String> paths;
 
     /**
-     * Maximum number of documents that the related query may match before graph search refuses the request.
+     * Maximum number of documents that a related query may match, or exact related IDs that may be supplied, before
+     * graph search refuses the request.
      */
     @Builder.Default
     int maxRelatedModels = 10_000;
@@ -80,6 +93,7 @@ public class ModelRelationConstraint {
     public ModelRelationConstraint(
             RelationDirection direction,
             SearchQuery query,
+            List<String> relatedModelIds,
             int minDepth,
             int maxDepth,
             List<String> paths,
@@ -87,8 +101,22 @@ public class ModelRelationConstraint {
             int maxTraversedModels) {
         this.direction = Objects.requireNonNull(
                 direction, "Model relation direction");
-        this.query = Objects.requireNonNull(
-                query, "Related model query");
+        LinkedHashSet<String> normalizedIds = new LinkedHashSet<>();
+        if (relatedModelIds != null) {
+            for (String modelId : relatedModelIds) {
+                if (modelId == null || modelId.isBlank()) {
+                    throw new IllegalArgumentException(
+                            "Related model IDs must not be blank");
+                }
+                normalizedIds.add(modelId);
+            }
+        }
+        if ((query == null) == normalizedIds.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Supply either a related model query or exact related model IDs");
+        }
+        this.query = query;
+        this.relatedModelIds = List.copyOf(normalizedIds);
         if (minDepth < 1 || maxDepth < minDepth
             || maxDepth > 64) {
             throw new IllegalArgumentException(
@@ -111,6 +139,10 @@ public class ModelRelationConstraint {
             || maxRelatedModels > 100_000) {
             throw new IllegalArgumentException(
                     "maxRelatedModels must be between 1 and 100000");
+        }
+        if (this.relatedModelIds.size() > maxRelatedModels) {
+            throw new IllegalArgumentException(
+                    "Exact related model IDs exceed maxRelatedModels " + maxRelatedModels);
         }
         if (maxTraversedModels < maxRelatedModels
             || maxTraversedModels > 1_000_000) {

--- a/common/src/test/java/io/fluxzero/common/api/search/ModelRelationConstraintTest.java
+++ b/common/src/test/java/io/fluxzero/common/api/search/ModelRelationConstraintTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.common.api.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.fluxzero.common.api.search.ModelRelationConstraint.RelationDirection.ANCESTOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ModelRelationConstraintTest {
+
+    @Test
+    void acceptsEitherAQueryOrExactModelIds() {
+        ModelRelationConstraint query = ModelRelationConstraint.builder()
+                .direction(ANCESTOR)
+                .query(SearchQuery.builder().collection("parents").build())
+                .build();
+        ModelRelationConstraint ids = ModelRelationConstraint.builder()
+                .direction(ANCESTOR)
+                .relatedModelId("parent-1")
+                .relatedModelId("parent-1")
+                .relatedModelId("parent-2")
+                .build();
+
+        assertEquals(List.of(), query.getRelatedModelIds());
+        assertEquals(List.of("parent-1", "parent-2"), ids.getRelatedModelIds());
+    }
+
+    @Test
+    void rejectsMissingOrAmbiguousRelationSources() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ModelRelationConstraint.builder()
+                             .direction(ANCESTOR)
+                             .build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ModelRelationConstraint.builder()
+                             .direction(ANCESTOR)
+                             .query(SearchQuery.builder().collection("parents").build())
+                             .relatedModelId("parent-1")
+                             .build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ModelRelationConstraint.builder()
+                             .direction(ANCESTOR)
+                             .relatedModelId(" ")
+                             .build());
+    }
+
+    @Test
+    void boundsExactIdsWithTheExistingRelatedModelLimit() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ModelRelationConstraint.builder()
+                             .direction(ANCESTOR)
+                             .relatedModelIds(List.of("parent-1", "parent-2"))
+                             .maxRelatedModels(1)
+                             .build());
+    }
+}

--- a/common/src/test/java/io/fluxzero/common/websocket/WebSocketTransportCodecsTest.java
+++ b/common/src/test/java/io/fluxzero/common/websocket/WebSocketTransportCodecsTest.java
@@ -949,9 +949,36 @@ class WebSocketTransportCodecsTest {
             assertEquals(
                     ModelRelationConstraint.RelationDirection.ANCESTOR,
                     relation.getDirection());
+            assertEquals(List.of(), relation.getRelatedModelIds());
             assertEquals(
                     1,
                     decoded.toMetric().getRelationCount());
+        }
+    }
+
+    @Test
+    void exactModelRelationIdsRoundTripWithoutARelatedDocumentQuery()
+            throws Exception {
+        ModelRelationConstraint relation =
+                ModelRelationConstraint.builder()
+                        .direction(ModelRelationConstraint.RelationDirection.ANCESTOR)
+                        .relatedModelId("project-1")
+                        .relatedModelId("project-2")
+                        .maxRelatedModels(10)
+                        .build();
+        SearchModelDocuments request = new SearchModelDocuments(
+                SearchDocuments.builder()
+                        .query(SearchQuery.builder().collection("tasks").build())
+                        .build(),
+                List.of(relation));
+
+        for (WebSocketTransportCodec codec : List.of(jsonCodec, cborCodec)) {
+            SearchModelDocuments decoded = assertInstanceOf(
+                    SearchModelDocuments.class, roundTrip(codec, request));
+
+            assertEquals(List.of("project-1", "project-2"),
+                         decoded.getRelations().getFirst().getRelatedModelIds());
+            assertNull(decoded.getRelations().getFirst().getQuery());
         }
     }
 

--- a/docs/developer/getting-started/core-concepts.mdx
+++ b/docs/developer/getting-started/core-concepts.mdx
@@ -98,7 +98,7 @@ Use an explicit `@HandleCommand` when the action needs orchestration around the 
   <TabItem label="Java">
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Project(@EntityId ProjectId projectId,
                       ProjectDetails details,
                       UserId ownerId) {
@@ -109,7 +109,7 @@ public record Project(@EntityId ProjectId projectId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT])
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -214,7 +214,7 @@ Account debit(@Association("sourceId") Account source) { ... }
 Use `@Parent` when independently stored models form a navigable graph:
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
                    TaskDetails details,
@@ -248,7 +248,7 @@ Not every value needs an independent lifecycle. Use `@Member` inside a model for
 searches and disappears with that model:
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Invoice(@EntityId InvoiceId invoiceId,
                       @Member List<InvoiceLine> lines) {
 }
@@ -305,7 +305,7 @@ public final class ProjectQueries {
 }
 ```
 
-The direct collection of a Model using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` is synchronous with its Model
+The direct collection of a Model whose persistence set contains `DOCUMENT` is synchronous with its Model
 commit. A whole-tree Graph projection is a separate read optimization and is asynchronous by default. Choose
 `GraphProjectionCompletion.AWAIT` for an operation whose result must not be released until affected root projections
 have crossed its state boundary.

--- a/docs/developer/guides/Messaging/030-message-tracking.mdx
+++ b/docs/developer/guides/Messaging/030-message-tracking.mdx
@@ -75,7 +75,7 @@ If multiple consumers handle the same request message type, multiple results can
 
 ### Command followed by query
 
-For a Model using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+For a Model whose persistence set contains `DOCUMENT`, the current document is part of Model-commit completion.
 A command followed by a direct Model query therefore reads committed state.
 
 Whole-graph projections and documents written by event handlers remain asynchronous. Await their own completion

--- a/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
+++ b/docs/developer/guides/Modeling & persistence/190-nested-entities.mdx
@@ -13,13 +13,13 @@ Domain objects may form a tree without sharing one permanent storage boundary. A
 storing its parent's ID in an `@Parent` property:
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 record Order(
         @EntityId OrderId orderId,
         String customerName) {
 }
 
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 record LineItem(
         @EntityId LineItemId lineItemId,
         @Parent(pathInParent = "lines") OrderId orderId,
@@ -39,7 +39,7 @@ public search collection is absent.
 The relation may point to the same Model type, which makes recursive domains such as folders natural:
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 record Folder(
         @EntityId FolderId folderId,
         @Parent(pathInParent = "folders") FolderId parentFolderId,
@@ -228,8 +228,8 @@ record Order(@EntityId OrderId orderId, String customerName) {
 ```
 
 The runtime consumes durable projection signals, coalesces affected roots, composes each complete graph and writes it
-with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root. Selecting
-`EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` is a separate choice that enables direct `Order` search; it is not
+with a `(configurationVersion, stateIndex)` fence. A move updates both the old and new root. Adding `DOCUMENT` to the
+persistence set is a separate choice that enables direct `Order` search by default; it is not
 required for this whole-Graph projection.
 
 Projection completion is configurable:

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -8,12 +8,12 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-Every `@Model` has an independent persisted identity. `ModelPersistence` makes its durable representation and
+Every `@Model` has an independent persisted identity. Its non-empty `ModelPersistence[]` set makes the durable representations and
 authoritative load path explicit:
 
 ```java
 @Model(
-    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
     snapshotPeriod = 1000)
 record Account(
         @EntityId AccountId accountId,
@@ -35,6 +35,14 @@ record Account(@EntityId AccountId accountId, Money balance) {
 
 Each applied update is stored in this account's model stream. Loading reconstructs the account by replaying its
 `@Apply` methods, optionally starting at a snapshot or checkpoint.
+
+The set supports exactly the meaningful combinations:
+
+- `{EVENT_SOURCED}` reconstructs from events without a current document;
+- `{DOCUMENT}` loads from its authoritative current document;
+- `{EVENT_SOURCED, DOCUMENT}` reconstructs from events and also maintains a current document.
+
+An empty set or duplicate representation is rejected during Model discovery.
 
 By default an event-sourced Model fails when its stream contains an event for which no applicable `@Apply` exists.
 Set `ignoreUnknownEvents = true` only when skipping such historical events is an explicit compatibility decision; it
@@ -61,11 +69,27 @@ record Country(
 `persistence` controls the durable representation and **load path**, not whether updates become events. Applied updates
 are still stored and published by default. This preserves auditing and exact event-handler boundaries.
 
-The direct searchable document is synchronously maintained with the model commit. After a successful command result,
-an immediate direct search can observe the changed model.
+The current document is synchronously maintained with the Model commit. It is publicly searchable by default, so after
+a successful command result an immediate direct search can observe the changed Model.
 
-`DOCUMENT` always maintains this direct document. Its collection and temporal paths can be configured through
+`DOCUMENT` always maintains this current document. Its search visibility, collection and temporal paths are configured through
 `document = @DocumentProjection(...)`.
+
+When state should load from a document but ordinary Model search is unnecessary, keep it reference-only:
+
+```java
+@Model(
+    persistence = ModelPersistence.DOCUMENT,
+    document = @DocumentProjection(searchable = false))
+record UserPreferences(
+        @EntityId UserId userId,
+        Preferences preferences) {
+}
+```
+
+Fluxzero keeps this value in a type-isolated private Model collection. Identity and alias loads, parent relationships
+and Graph composition still use it; `Fluxzero.search(UserPreferences.class)` does not expose it. A custom public
+collection is consequently invalid for a reference-only projection.
 
 ## Event storage and publication
 
@@ -121,12 +145,11 @@ does not split one multi-Model action into separate commits.
 
 ## Direct Model documents
 
-`EVENT_SOURCED_WITH_DOCUMENT` keeps event replay authoritative while also maintaining a directly searchable current
-document:
+Combining `EVENT_SOURCED` and `DOCUMENT` keeps event replay authoritative while also maintaining a current document:
 
 ```java
 @Model(
-    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
     document = @DocumentProjection(
         collection = "line-items"))
 record LineItem(
@@ -136,9 +159,9 @@ record LineItem(
 }
 ```
 
-This document is authoritative for direct search, but event replay remains authoritative for loading the Model. With
-`DOCUMENT`, the same direct document is authoritative for both search and loading. It is never the asynchronously
-stitched root Graph.
+The public document serves direct search, but event replay remains authoritative for loading the Model. With
+document-only persistence, the same current document is authoritative for loading. It is never the asynchronously
+stitched root Graph. Set `document.searchable = false` when the document should remain reference-only instead.
 
 Plain `EVENT_SOURCED` omits only this independent collection. A child with an explicit
 `@Parent(pathInParent = "...")` still supplies a private current document to virtual and materialized Graph composition.

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -169,7 +169,10 @@ Without an explicit path, Fluxzero stores no Graph-component document and perfor
 
 You can additionally:
 
-- join current direct documents through `whereAncestor(...)` and `whereDescendant(...)`;
+- select current target documents directly through a known typed parent or ancestor ID, even when that related Model
+  has no current document;
+- select parents, ancestors, children or descendants by current document content through the class-and-constraint
+  `whereParent(...)`, `whereAncestor(...)`, `whereChild(...)` and `whereDescendant(...)` overloads;
 - search typed complete graphs with `searchGraph(Root.class)`, using a materialized projection when configured and
   otherwise stitching live;
 - set `materializeGraph = true` for a durable whole-root document and optionally configure it with

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -63,17 +63,17 @@ You can also specify the collection in which the object should be stored directl
 
 ## Model documents and searchable values
 
-Models choose whether to maintain a direct document through `ModelPersistence`. Other values use the document-store
+Models choose whether to maintain a current document through their `ModelPersistence[]` set. Other values use the document-store
 annotations that own automatic indexing:
 
-- `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)`
+- `@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})`
 - `@Stateful` (implicitly `@Searchable`)
 - Directly annotate any POJO with `@Searchable`
 
 <Tabs>
   <TabItem label="Java">
     ```java
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     public record UserAccount(@EntityId UserId userId,
                               UserProfile profile,
                               boolean accountClosed) {
@@ -82,7 +82,7 @@ annotations that own automatic indexing:
   </TabItem>
   <TabItem label="Kotlin">
     ```kotlin
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT])
     data class UserAccount(
         @EntityId val userId: UserId,
         val profile: UserProfile,
@@ -100,7 +100,7 @@ settings themselves:
   <TabItem label="Java">
     ```java
     @Model(
-        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
         document = @DocumentProjection(
             collection = "users",
             timestampPath = "profile/createdAt"))
@@ -109,7 +109,7 @@ settings themselves:
   <TabItem label="Kotlin">
     ```kotlin
     @Model(
-        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT],
         document = DocumentProjection(
             collection = "users",
             timestampPath = "profile/createdAt"
@@ -118,6 +118,37 @@ settings themselves:
     ```
   </TabItem>
 </Tabs>
+
+The document is placed in the public Model collection by default. A document-authoritative Model that only needs
+identity-, alias-, relationship- and Graph-based lookup can keep it reference-only:
+
+<Tabs>
+  <TabItem label="Java">
+    ```java
+    @Model(
+        persistence = ModelPersistence.DOCUMENT,
+        document = @DocumentProjection(searchable = false))
+    public record UserPreferences(@EntityId UserId userId,
+                                  Preferences preferences) {
+    }
+    ```
+  </TabItem>
+  <TabItem label="Kotlin">
+    ```kotlin
+    @Model(
+        persistence = [ModelPersistence.DOCUMENT],
+        document = DocumentProjection(searchable = false)
+    )
+    data class UserPreferences(
+        @EntityId val userId: UserId,
+        val preferences: Preferences
+    )
+    ```
+  </TabItem>
+</Tabs>
+
+Fluxzero stores this document in a type-isolated private Model collection. `loadModel(...)`, aliases, parent
+relationships and Graph composition still use it, while `Fluxzero.search(UserPreferences.class)` does not expose it.
 
 ---
 
@@ -150,8 +181,8 @@ Use the fluent `search(...)` API:
 
 ### Consistency after commands
 
-Search is optimized for current state, but indexing still follows the commit path. A Model using `DOCUMENT` or
-`EVENT_SOURCED_WITH_DOCUMENT` synchronously maintains its direct document with the Model commit. Calling
+Search is optimized for current state, but indexing still follows the commit path. A Model whose persistence set
+contains `DOCUMENT` synchronously maintains its current document with the Model commit. Calling
 `sendCommandAndWait(...)` and then querying that Model's direct collection observes the committed state.
 
 This does not automatically wait for a materialized whole-root graph projection. Select
@@ -674,6 +705,6 @@ To remove documents from the index:
 
 - Use `Fluxzero.index(...)` to manually index documents.
 - Use `@Searchable` to configure the collection name or time range for an object.
-- Use `@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)` or `@Stateful` for automatic indexing.
+- Use `@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})` or `@Stateful` for automatic indexing.
 - Use `Fluxzero.search(...)` to query, stream, sort, and aggregate your documents.
 - Use `fetchAsync(...)`, `countAsync()`, `aggregateAsync(...)`, and `facetStatsAsync()` in asynchronous handlers.

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -212,6 +212,59 @@ You can also query by class:
   </TabItem>
 </Tabs>
 
+### Selecting Models by parent or ancestor
+
+When the related identity is already known, pass its typed ID directly. Fluxzero starts from the durable relationship
+index, so the parent or ancestor does not need a searchable or private current-state document:
+
+<Tabs>
+  <TabItem label="Java">
+    ```java
+    List<Task> projectTasks = Fluxzero.search(Task.class)
+            .whereParent(projectId)
+            .fetch(100);
+
+    List<Task> organisationTasks = Fluxzero.search(Task.class)
+            .whereAncestor(organisationId)
+            .fetch(100);
+    ```
+  </TabItem>
+  <TabItem label="Kotlin">
+    ```kotlin
+    val projectTasks = Fluxzero.search(Task::class.java)
+        .whereParent(projectId)
+        .fetch(100)
+
+    val organisationTasks = Fluxzero.search(Task::class.java)
+        .whereAncestor(organisationId)
+        .fetch(100)
+    ```
+  </TabItem>
+</Tabs>
+
+Use `whereAncestor(organisationId, 2, 2)` to require exactly a grandparent. Typed `Id<T>` values supply their Model
+type. For another functional-ID type, use `whereAncestor(id, Organisation.class)` in Java or
+`whereAncestor(id, Organisation::class.java)` in Kotlin. When the related Model has a parent-scoped primary identity,
+pass its already loaded `Graph` so Fluxzero can use the exact persisted identity.
+
+When the related identity must instead be discovered from its current content, pass the Model type and constraints:
+
+```java
+List<Task> activeProjectTasks = Fluxzero.search(Task.class)
+        .whereParent(Project.class, MatchConstraint.match("ACTIVE", "status"))
+        .fetch(100);
+```
+
+This form requires a current document for the related Model. It may be a public direct document or the type-isolated
+private document maintained because the Model has an explicit `@Parent(pathInParent = "...")` or
+`materializeGraph = true`. The predicate applies to that Model's own fields, not to fields nested only in a materialized
+whole-Graph projection.
+
+The returned target also needs a current document. A public `DOCUMENT` projection works, and a private Graph-component
+document becomes available only because the query is explicitly relation-bounded; ordinary typed search still does not
+expose it. A standalone event-sourced target without a direct document, explicit composition path or materialized root
+has no document-search representation. Use `loadModel(...)` or `loadGraph(...)` when its identity is already known.
+
 <Aside type="note">
 You can choose to split path segments with either <code>.</code> or <code>/</code>. Both styles are equivalent.
 </Aside>

--- a/docs/developer/tutorials/first-app.mdx
+++ b/docs/developer/tutorials/first-app.mdx
@@ -40,7 +40,7 @@ value types are assumed below so the example can stay focused on Model behavior:
   <TabItem label="Java">
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Project(@EntityId ProjectId projectId,
                       ProjectDetails details,
                       UserId ownerId,
@@ -52,7 +52,7 @@ public record Project(@EntityId ProjectId projectId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT])
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -65,8 +65,8 @@ data class Project(
 </Tabs>
 
 `@Model` gives each project ID its own persistence and lifecycle boundary. Here
-`EVENT_SOURCED_WITH_DOCUMENT` keeps event replay authoritative and also maintains a synchronous direct search
-document. `@EntityId` identifies the Model.
+Combining `EVENT_SOURCED` and `DOCUMENT` keeps event replay authoritative and also maintains a synchronous direct
+search document. `@EntityId` identifies the Model.
 
 ## Create a project
 
@@ -130,7 +130,7 @@ model and link it to a project:
   <TabItem label="Java">
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Task(@EntityId TaskId taskId,
                    @Parent(pathInParent = "tasks") ProjectId projectId,
                    TaskDetails details,
@@ -142,7 +142,7 @@ public record Task(@EntityId TaskId taskId,
   <TabItem label="Kotlin">
 
 ```kotlin
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT])
 data class Task(
     @EntityId val taskId: TaskId,
     @Parent(pathInParent = "tasks") val projectId: ProjectId,
@@ -394,7 +394,7 @@ For repeatedly queried large trees, enable a graph projection on the root:
 
 ```java
 @Model(
-    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
     materializeGraph = true,
     graphProjection = @GraphProjection(
         collection = "project-overviews"))

--- a/java-downstream-project/src/test/java/io/fluxzero/downstream/DownstreamProjectTest.java
+++ b/java-downstream-project/src/test/java/io/fluxzero/downstream/DownstreamProjectTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,7 +66,7 @@ class DownstreamProjectTest {
                 DownstreamModel.Child.class.getDeclaredMethod("externalParentId").getAnnotation(Parent.class);
 
         assertNotNull(model);
-        assertEquals(ModelPersistence.DOCUMENT, model.persistence());
+        assertArrayEquals(new ModelPersistence[]{ModelPersistence.DOCUMENT}, model.persistence());
         assertEquals("downstream-models", model.document().collection());
         assertNotNull(typedParent);
         assertNotNull(untypedParent);

--- a/kotlin-downstream-project/src/test/kotlin/io/fluxzero/sdk/modeling/ModelKotlinTest.kt
+++ b/kotlin-downstream-project/src/test/kotlin/io/fluxzero/sdk/modeling/ModelKotlinTest.kt
@@ -3,6 +3,7 @@ package io.fluxzero.sdk.modeling
 import io.fluxzero.sdk.Fluxzero
 import io.fluxzero.sdk.persisting.eventsourcing.Apply
 import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -12,7 +13,7 @@ class ModelKotlinTest {
         val annotation = KotlinModel::class.java.getAnnotation(Model::class.java)
 
         assertNotNull(annotation)
-        assertEquals(ModelPersistence.DOCUMENT, annotation.persistence)
+        assertContentEquals(arrayOf(ModelPersistence.DOCUMENT), annotation.persistence)
         assertEquals("kotlin-models", annotation.document.collection)
         assertEquals(1, KotlinModel("model", emptyList()).rename(RenameKotlinModel("new")).parts.size)
     }
@@ -24,7 +25,7 @@ class ModelKotlinTest {
 }
 
 @Model(
-    persistence = ModelPersistence.DOCUMENT,
+    persistence = [ModelPersistence.DOCUMENT],
     document = DocumentProjection(collection = "kotlin-models"),
 )
 data class KotlinModel(

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -416,10 +416,16 @@ List<Task> tasks = Fluxzero.search(Task.class)
         .fetchAll();
 ```
 
-Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Use
-class-based relationship constraints for selective parent or Graph search through either a searchable child or a
-type-isolated private Graph component; Fluxzero searches matching child IDs before traversing relationships and
-composing targets. Prefer `searchGraph(Root.class).whereDescendant(Child.class, constraint)` over a broad forced-live
+Use `.whereParent(projectId)` or `.whereAncestor(organisationId)` when the related typed ID is known. This traverses
+durable relationships directly and needs no parent or ancestor document. Use the ID-plus-Model-class overload for
+untyped functional IDs and a loaded `Graph` for parent-scoped identities. The returned target must still have either a
+public document or a private current document maintained for Graph participation; standalone event-sourced targets
+without one should be loaded by ID.
+
+Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
+IDs must first be selected by current Model content. They use that Model's own public or type-isolated private current
+document; `materializeGraph = true` supplies a private root document but does not make the whole Graph projection the
+related predicate source. Prefer `searchGraph(Root.class).whereDescendant(Child.class, constraint)` over a broad forced-live
 nested-path filter when the child type is known. Use
 `searchGraph(Root.class).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness. It
 reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -21,7 +21,7 @@ compatibility boundary for already persisted aggregate state.
 ## Define a model
 
 ```java
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
 public record Project(
         @EntityId ProjectId projectId,
         ProjectDetails details,
@@ -34,13 +34,14 @@ definitions unless the user asks for them.
 
 Important settings:
 
-- `persistence`: selects exactly one durable/load contract:
-  - `EVENT_SOURCED` (default): reconstruct from Model events, without a direct public document.
-  - `EVENT_SOURCED_WITH_DOCUMENT`: reconstruct from events and maintain a direct searchable current document.
-  - `DOCUMENT`: load authoritative current state from the direct document.
+- `persistence`: selects a non-empty set of durable representations:
+  - `{EVENT_SOURCED}` (default): reconstruct from Model events, without a direct document.
+  - `{EVENT_SOURCED, DOCUMENT}`: reconstruct from events and also maintain a current document.
+  - `{DOCUMENT}`: load authoritative current state from the current document.
 - `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
-- `document`: optional `@DocumentProjection` configuration for the direct collection and timestamp paths. It is valid
-  only when `persistence` stores a direct document.
+- `document`: optional `@DocumentProjection` configuration for the direct collection, timestamp paths, and public
+  searchability. It is valid only when `persistence` contains `DOCUMENT`; use `searchable = false` for a document that
+  should remain available by Model ID, alias, parent relation and Graph composition without entering typed search.
 - `eventPublication`: controls whether unchanged transitions create an event.
 - `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
@@ -395,8 +396,8 @@ payload turns the method back into ordinary payload handling with direct/ancesto
 
 ## Search and graph composition
 
-Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are synchronous with successful commit
-completion:
+Public Model documents selected by including `DOCUMENT` and keeping `DocumentProjection.searchable = true` are
+synchronous with successful commit completion:
 
 ```java
 List<Task> open = Fluxzero.search(Task.class)
@@ -424,8 +425,9 @@ nested-path filter when the child type is known. Use
 reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 `searchGraph(Root.class, true)`
 forces live composition. Use `fetch(..., ObjectNode.class)` for explicit raw JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` separately only for direct public
-Model search. A blank projection collection appends `-graphs` to the direct Model collection when one exists, or to the
+`@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
+set `DocumentProjection.searchable = false` when that document is reference-only. A blank projection collection
+appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy

--- a/project-files/java/agents/rules/guidelines.md
+++ b/project-files/java/agents/rules/guidelines.md
@@ -202,7 +202,7 @@ Use this tree to find the correct manual for your current task, ordered by the r
     `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`
+21. **The Consistency Window**: Direct Model documents selected by including `DOCUMENT` in the persistence set
     complete with the Model commit. Materialized Graph
     projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
     side effects remain eventually consistent.

--- a/project-files/java/agents/rules/runtime-interaction.md
+++ b/project-files/java/agents/rules/runtime-interaction.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 ### Command Followed by Query
 
-For Models using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+For Models whose persistence set contains `DOCUMENT`, the direct document is part of Model-commit completion.
 A command followed by a direct Model query therefore reads committed state. Whole-Graph projections and documents
 written by event handlers remain asynchronous unless their own completion boundary is awaited.
 

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -143,11 +143,31 @@ List<Task> results = Fluxzero.search(Task.class)
     .fetchAll();
 ```
 
-Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Depth-bounded overloads support grandparents
-and further traversal. Class-based constraints use the related Model's actual current-document collection, including
-the type-isolated private collection of a Graph-only Model component. They select matching related IDs before
-relationship traversal, so prefer `searchGraph(Root.class).whereDescendant(Child.class, constraint)` for selective
-live Graph search based on children. `searchGraph(Root.class).stream()` returns typed lazy `Graph<Root>` values through
+When a parent or ancestor ID is already known, avoid a document predicate:
+
+```java
+List<Task> projectTasks = Fluxzero.search(Task.class)
+    .whereParent(projectId)
+    .fetch(100);
+
+List<Task> organisationTasks = Fluxzero.search(Task.class)
+    .whereAncestor(organisationId)
+    .fetch(100);
+```
+
+The ID overload starts from durable relationships and does not require a document for the parent or ancestor. A typed
+`Id<T>` supplies its Model type; otherwise pass the functional ID and Model class. Use a loaded `Graph` for a
+parent-scoped identity. Depth-bounded overloads support exact grandparents and further traversal.
+
+Use the class-and-constraint overload when IDs must be selected by related Model content. It requires that related
+Model's own public or private current document; an explicit composition path or `materializeGraph = true` supplies a
+private one, while the whole materialized Graph projection is not searched as the Model itself. The returned target
+also needs a public document or relation-scoped private Graph-component document. A standalone event-sourced target
+without either is loaded by ID rather than searched.
+
+Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` for content-based traversal. Prefer
+`searchGraph(Root.class).whereDescendant(Child.class, constraint)` for selective live Graph search based on children.
+`searchGraph(Root.class).stream()` returns typed lazy `Graph<Root>` values through
 explicit `@Parent(pathInParent = "...")` paths. It prefers a configured materialized graph projection and otherwise stitches
 live; pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode.class)` only for an
 explicit raw JSON boundary. Full-graph constraints mean the same on both routes, but broad free-form child filtering,

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -31,8 +31,7 @@ data through a unified document store, leveraging automatic indexing and a rich 
 ## Core Rules
 
 1. **No SQL**: Data retrieval is performed exclusively via the `Fluxzero.search()` API or by loading entities.
-2. **Automatic Indexing**: Models with `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` persistence maintain a direct
-   current-state document.
+2. **Automatic Indexing**: Models whose persistence set contains `DOCUMENT` maintain a direct current-state document.
 3. **Stateful Handlers**: `@Stateful` handlers are automatically searchable as they are backed by the document store.
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
@@ -52,20 +51,29 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 ### Model documents and @Searchable values
 
-Choose a Model persistence option that stores a direct document. Use `@Searchable` for an ordinary document value;
-do not annotate a Model with it.
+Include `DOCUMENT` in a Model's persistence set to store a direct document. Use `@Searchable` for an ordinary document
+value; do not annotate a Model with it.
 
 [//]: # (@formatter:off)
 ```java
 @Model(
-        persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+        persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
         document = @DocumentProjection(collection = "active_projects"))
 public record Project(...) {}
+
+@Model(
+        persistence = ModelPersistence.DOCUMENT,
+        document = @DocumentProjection(searchable = false))
+public record UserPreferences(@EntityId UserId userId, ...) {}
 
 @Searchable(collection = "custom_docs")
 public record ExternalDocument(...) {}
 ```
 [//]: # (@formatter:on)
+
+`DocumentProjection.searchable = false` keeps a Model document in private type-isolated storage. Direct Model loads,
+aliases, parent relations and Graph composition still work, while `Fluxzero.search(UserPreferences.class)` does not
+expose the document.
 
 <a name="facets-sorting"></a>
 
@@ -235,8 +243,8 @@ CompletableFuture<List<FacetStats>> handle(ProjectFacetQuery query) {
 
 ## Consistency & The Window
 
-Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are **synchronous with Model-commit
-completion**.
+Public Model documents selected by including `DOCUMENT` and keeping `DocumentProjection.searchable = true` are
+**synchronous with Model-commit completion**.
 
 - **Direct model guarantee**: `sendCommandAndWait` followed by a direct model search observes the committed direct
   document.

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -21,7 +21,7 @@ compatibility boundary for already persisted aggregate state.
 ## Define a model
 
 ```kotlin
-@Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+@Model(persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT])
 data class Project(
     @EntityId val projectId: ProjectId,
     val details: ProjectDetails,
@@ -34,13 +34,14 @@ definitions unless the user asks for them.
 
 Important settings:
 
-- `persistence`: selects exactly one durable/load contract:
-  - `EVENT_SOURCED` (default): reconstruct from Model events, without a direct public document.
-  - `EVENT_SOURCED_WITH_DOCUMENT`: reconstruct from events and maintain a direct searchable current document.
-  - `DOCUMENT`: load authoritative current state from the direct document.
+- `persistence`: selects a non-empty set of durable representations:
+  - `[EVENT_SOURCED]` (default): reconstruct from Model events, without a direct document.
+  - `[EVENT_SOURCED, DOCUMENT]`: reconstruct from events and also maintain a current document.
+  - `[DOCUMENT]`: load authoritative current state from the current document.
 - `ignoreUnknownEvents`: deliberately tolerates unhandled stored events during event-sourced reconstruction.
-- `document`: optional `DocumentProjection` configuration for the direct collection and timestamp paths. It is valid
-  only when `persistence` stores a direct document.
+- `document`: optional `DocumentProjection` configuration for the direct collection, timestamp paths, and public
+  searchability. It is valid only when `persistence` contains `DOCUMENT`; use `searchable = false` for a document that
+  should remain available by Model ID, alias, parent relation and Graph composition without entering typed search.
 - `eventPublication`: controls whether unchanged transitions create an event.
 - `publicationStrategy`: `DEFAULT`, `STORE_AND_PUBLISH`, `STORE_ONLY` or `PUBLISH_ONLY`.
 - `snapshotPeriod` and `maxSnapshotCount`: event-sourcing optimizations.
@@ -397,8 +398,9 @@ forced-live nested-path filter when the child type is known. Use
 It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` for explicit raw
 JSON. Enable materialization with
-`@Model(materializeGraph = true)`. Select `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` separately only for direct public
-Model search. A blank projection collection appends `-graphs` to the direct Model collection when one exists, or to the
+`@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
+set `DocumentProjection.searchable = false` when that document is reference-only. A blank projection collection
+appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -389,10 +389,16 @@ val related = Fluxzero.search(Task::class.java)
     .fetchAll()
 ```
 
-Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Use
-class-based relationship constraints for selective parent or Graph search through either a searchable child or a
-type-isolated private Graph component; Fluxzero searches matching child IDs before traversing relationships and
-composing targets. Prefer `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` over a broad
+Use `.whereParent(projectId)` or `.whereAncestor(organisationId)` when the related typed ID is known. This traverses
+durable relationships directly and needs no parent or ancestor document. Use the ID-plus-Model-class overload for
+untyped functional IDs and a loaded `Graph` for parent-scoped identities. The returned target must still have either a
+public document or a private current document maintained for Graph participation; standalone event-sourced targets
+without one should be loaded by ID.
+
+Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
+IDs must first be selected by current Model content. They use that Model's own public or type-isolated private current
+document; `materializeGraph = true` supplies a private root document but does not make the whole Graph projection the
+related predicate source. Prefer `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` over a broad
 forced-live nested-path filter when the child type is known. Use
 `searchGraph(Root::class.java).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness.
 It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;

--- a/project-files/kotlin/agents/rules/guidelines.md
+++ b/project-files/kotlin/agents/rules/guidelines.md
@@ -202,7 +202,7 @@ Use this tree to find the correct manual for your current task, ordered by the r
     `DepositMoney` command solely to see what changed. Reserve `Entity<T>` for legacy Aggregate and persistence code.
 20. **The Uber-Document Pattern**: Use `@HandleDocument` within a `@Stateful` saga to maintain a complex view of the
     system that updates whenever source documents change.
-21. **The Consistency Window**: Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`
+21. **The Consistency Window**: Direct Model documents selected by including `DOCUMENT` in the persistence set
     complete with the Model commit. Materialized Graph
     projections are asynchronous unless the operation selects `GraphProjectionCompletion.AWAIT`; unrelated handler
     side effects remain eventually consistent.

--- a/project-files/kotlin/agents/rules/runtime-interaction.md
+++ b/project-files/kotlin/agents/rules/runtime-interaction.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 ### Command Followed by Query
 
-For Models using `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT`, the direct document is part of Model-commit completion.
+For Models whose persistence set contains `DOCUMENT`, the direct document is part of Model-commit completion.
 A command followed by a direct Model query therefore reads committed state. Whole-Graph projections and documents
 written by event handlers remain asynchronous unless their own completion boundary is awaited.
 

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -138,11 +138,31 @@ val results = Fluxzero.search(Task::class.java)
     .fetchAll()
 ```
 
-Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant`. Depth-bounded overloads support grandparents
-and further traversal. Class-based constraints use the related Model's actual current-document collection, including
-the type-isolated private collection of a Graph-only Model component. They select matching related IDs before
-relationship traversal, so prefer `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` for
-selective live Graph search based on children. `searchGraph(Root::class.java).stream()` returns typed lazy `Graph<Root>` values through
+When a parent or ancestor ID is already known, avoid a document predicate:
+
+```kotlin
+val projectTasks = Fluxzero.search(Task::class.java)
+    .whereParent(projectId)
+    .fetch(100)
+
+val organisationTasks = Fluxzero.search(Task::class.java)
+    .whereAncestor(organisationId)
+    .fetch(100)
+```
+
+The ID overload starts from durable relationships and does not require a document for the parent or ancestor. A typed
+`Id<T>` supplies its Model type; otherwise pass the functional ID and Model class. Use a loaded `Graph` for a
+parent-scoped identity. Depth-bounded overloads support exact grandparents and further traversal.
+
+Use the class-and-constraint overload when IDs must be selected by related Model content. It requires that related
+Model's own public or private current document; an explicit composition path or `materializeGraph = true` supplies a
+private one, while the whole materialized Graph projection is not searched as the Model itself. The returned target
+also needs a public document or relation-scoped private Graph-component document. A standalone event-sourced target
+without either is loaded by ID rather than searched.
+
+Use `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` for content-based traversal. Prefer
+`searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` for selective live Graph search based on
+children. `searchGraph(Root::class.java).stream()` returns typed lazy `Graph<Root>` values through
 explicit `@Parent(pathInParent = "...")` paths. It prefers a configured materialized graph projection and otherwise stitches
 live; pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` only for
 an explicit raw JSON boundary. Full-graph constraints mean the same on both routes, but broad free-form child filtering,

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -31,8 +31,7 @@ data through a unified document store, leveraging automatic indexing and a rich 
 ## Core Rules
 
 1. **No SQL**: Data retrieval is performed exclusively via the `Fluxzero.search()` API or by loading entities.
-2. **Automatic Indexing**: Models with `EVENT_SOURCED_WITH_DOCUMENT` or `DOCUMENT` persistence maintain a direct
-   current-state document.
+2. **Automatic Indexing**: Models whose persistence set contains `DOCUMENT` maintain a direct current-state document.
 3. **Stateful Handlers**: `@Stateful` handlers are automatically searchable as they are backed by the document store.
 4. **Case & Accent Insensitive**: Text searches and matches are case and accent insensitive by default.
 5. **Last Known State**: The document store represents the "last known state" of an object. While the event stream is
@@ -52,19 +51,29 @@ data through a unified document store, leveraging automatic indexing and a rich 
 
 ### Model documents and @Searchable values
 
-Choose a Model persistence option that stores a direct document. Use `@Searchable` for an ordinary document value;
-do not annotate a Model with it.
+Include `DOCUMENT` in a Model's persistence set to store a direct document. Use `@Searchable` for an ordinary document
+value; do not annotate a Model with it.
 
 ```kotlin
 @Model(
-    persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    persistence = [ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT],
     document = DocumentProjection(collection = "active_projects"),
 )
 data class Project(...)
 
+@Model(
+    persistence = [ModelPersistence.DOCUMENT],
+    document = DocumentProjection(searchable = false),
+)
+data class UserPreferences(@EntityId val userId: UserId, ...)
+
 @Searchable(collection = "custom_docs")
 data class ExternalDocument(...)
 ```
+
+`DocumentProjection.searchable = false` keeps a Model document in private type-isolated storage. Direct Model loads,
+aliases, parent relations and Graph composition still work, while `Fluxzero.search(UserPreferences::class.java)` does
+not expose the document.
 
 <a name="facets-sorting"></a>
 
@@ -221,8 +230,8 @@ fun handle(query: ProjectFacetQuery): CompletableFuture<List<FacetStats>> =
 
 ## Consistency & The Window
 
-Direct Model documents selected by `DOCUMENT` or `EVENT_SOURCED_WITH_DOCUMENT` are **synchronous with Model-commit
-completion**.
+Public Model documents selected by including `DOCUMENT` and keeping `DocumentProjection.searchable = true` are
+**synchronous with Model-commit completion**.
 
 - **Direct model guarantee**: `sendCommandAndWait` followed by a direct model search observes the committed direct
   document.

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
@@ -34,8 +34,8 @@ public @interface DocumentProjection {
      * Whether this current document is exposed through the Model's public search collection.
      * <p>
      * When {@code false}, Fluxzero stores it in type-isolated private Model storage. It remains available to direct
-     * Model loads, aliases, parent relationships and Graph composition, but is not returned by ordinary typed Model
-     * searches.
+     * Model loads, aliases, parent relationships and Graph composition, but is not returned by an unrestricted typed
+     * Model search. An explicitly parent- or ancestor-bounded relationship search may return it within that scope.
      */
     boolean searchable() default true;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
@@ -30,6 +30,15 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DocumentProjection {
 
+    /**
+     * Whether this current document is exposed through the Model's public search collection.
+     * <p>
+     * When {@code false}, Fluxzero stores it in type-isolated private Model storage. It remains available to direct
+     * Model loads, aliases, parent relationships and Graph composition, but is not returned by ordinary typed Model
+     * searches.
+     */
+    boolean searchable() default true;
+
     /** Collection receiving current Model documents. Blank defaults to the Model's simple class name. */
     String collection() default "";
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
@@ -218,11 +218,10 @@ public final class EntityMetadata {
             throw invalid("%s cannot be annotated with both @Model and @Aggregate".formatted(type.getName()));
         }
         if (model != null) {
-            validateModelPersistence(type, model);
+            Set<ModelPersistence> persistence = validateModelPersistence(type, model);
+            return RootConfiguration.model(model, persistence);
         }
-        return model == null
-                ? aggregate == null ? null : RootConfiguration.aggregate(aggregate)
-                : RootConfiguration.model(model);
+        return aggregate == null ? null : RootConfiguration.aggregate(aggregate);
     }
 
     public Class<?> type() {
@@ -525,10 +524,13 @@ public final class EntityMetadata {
             return Optional.empty();
         }
         if (rootConfiguration.directDocument()) {
-            return Optional.of(configuredModelDocumentCollection());
+            return Optional.of(rootConfiguration.publicDocument()
+                                       ? configuredModelDocumentCollection()
+                                       : ModelDocumentMutation.privateModelDocumentCollection(
+                                               type.getName()));
         }
         return participatesInGraphComposition() || rootConfiguration.materializeGraph()
-                ? Optional.of(ModelDocumentMutation.graphComponentCollection(
+                ? Optional.of(ModelDocumentMutation.privateModelDocumentCollection(
                         type.getName()))
                 : Optional.empty();
     }
@@ -563,7 +565,7 @@ public final class EntityMetadata {
                 () -> new IllegalStateException(
                         "Graph projection root %s has no current-document collection"
                                 .formatted(type.getName())));
-        String publicCollectionBase = rootConfiguration.directDocument()
+        String publicCollectionBase = rootConfiguration.publicDocument()
                 ? rootCollection : type.getSimpleName();
         String collection = projection.collection().isEmpty()
                 ? publicCollectionBase + "-graphs"
@@ -844,9 +846,20 @@ public final class EntityMetadata {
         }
     }
 
-    private static void validateModelPersistence(Class<?> type, Model annotation) {
-        ModelPersistence persistence = annotation.persistence();
-        if (!persistence.isEventSourced()) {
+    private static Set<ModelPersistence> validateModelPersistence(Class<?> type, Model annotation) {
+        ModelPersistence[] configured = annotation.persistence();
+        if (configured.length == 0) {
+            throw invalid("@Model.persistence on %s must contain at least one representation"
+                                  .formatted(type.getName()));
+        }
+        Set<ModelPersistence> persistence = new LinkedHashSet<>(Arrays.asList(configured));
+        if (persistence.size() != configured.length) {
+            throw invalid("@Model.persistence on %s must not contain duplicate representations"
+                                  .formatted(type.getName()));
+        }
+        boolean eventSourced = persistence.contains(ModelPersistence.EVENT_SOURCED);
+        boolean storesDocument = persistence.contains(ModelPersistence.DOCUMENT);
+        if (!eventSourced) {
             if (annotation.ignoreUnknownEvents()) {
                 throw invalid("@Model.ignoreUnknownEvents on %s requires event-sourced persistence"
                                       .formatted(type.getName()));
@@ -865,13 +878,20 @@ public final class EntityMetadata {
             }
         }
         DocumentProjection document = annotation.document();
-        if (!persistence.storesDocument()
-            && (!document.collection().isEmpty()
+        if (!storesDocument
+            && (!document.searchable()
+                || !document.collection().isEmpty()
                 || !document.timestampPath().isEmpty()
                 || !document.endPath().isEmpty())) {
             throw invalid("@Model.document on %s requires persistence that stores a direct document"
                                   .formatted(type.getName()));
         }
+        if (storesDocument && !document.searchable()
+            && !document.collection().isEmpty()) {
+            throw invalid("@Model.document.collection on %s requires a searchable document projection"
+                                  .formatted(type.getName()));
+        }
+        return Set.copyOf(persistence);
     }
 
     private void validateProjectionPath(
@@ -1458,6 +1478,7 @@ public final class EntityMetadata {
             EventPublication eventPublication,
             EventPublicationStrategy publicationStrategy,
             boolean directDocument,
+            boolean publicDocument,
             boolean materializeGraph,
             GraphProjection graphProjection,
             String collection,
@@ -1471,14 +1492,21 @@ public final class EntityMetadata {
                     .orElse(type.getSimpleName());
         }
 
-        static RootConfiguration model(Model annotation) {
+        static RootConfiguration model(
+                Model annotation,
+                Set<ModelPersistence> persistence) {
+            boolean eventSourced = persistence.contains(
+                    ModelPersistence.EVENT_SOURCED);
+            boolean storesDocument = persistence.contains(
+                    ModelPersistence.DOCUMENT);
             return new RootConfiguration(
                     RootKind.MODEL, annotation.conflictPolicy(), annotation.automaticHandling(),
-                    annotation.persistence().isEventSourced(), annotation.ignoreUnknownEvents(),
+                    eventSourced, annotation.ignoreUnknownEvents(),
                     annotation.snapshotPeriod(), annotation.maxSnapshotCount(), annotation.cached(),
                     annotation.cachingDepth(), annotation.checkpointPeriod(), annotation.commitPolicy(),
                     annotation.eventPublication(), annotation.publicationStrategy(),
-                    annotation.persistence().storesDocument(), annotation.materializeGraph(), annotation.graphProjection(),
+                    storesDocument, storesDocument && annotation.document().searchable(),
+                    annotation.materializeGraph(), annotation.graphProjection(),
                     annotation.document().collection(), annotation.document().timestampPath(),
                     annotation.document().endPath());
         }
@@ -1490,7 +1518,8 @@ public final class EntityMetadata {
                     annotation.snapshotPeriod(), annotation.maxSnapshotCount(), annotation.cached(),
                     annotation.cachingDepth(), annotation.checkpointPeriod(), annotation.commitPolicy(),
                     annotation.eventPublication(), annotation.publicationStrategy(),
-                    annotation.searchable(), false, null, annotation.collection(), annotation.timestampPath(),
+                    annotation.searchable(), annotation.searchable(), false, null,
+                    annotation.collection(), annotation.timestampPath(),
                     annotation.endPath());
         }
 
@@ -1529,7 +1558,7 @@ public final class EntityMetadata {
             return new RootConfiguration(
                     kind, conflictPolicy, automaticHandling, eventSourced, ignoreUnknownEvents,
                     snapshotPeriod, maxSnapshotCount, cached, cachingDepth, checkpointPeriod, commitPolicy,
-                    eventPublication, publicationStrategy, directDocument, materializeGraph,
+                    eventPublication, publicationStrategy, directDocument, publicDocument, materializeGraph,
                     graphProjection, collection, timestampPath, endPath);
         }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
@@ -50,16 +50,19 @@ import java.lang.annotation.Target;
  * supported.
  *
  * <h2>Persistence</h2>
- * {@link #persistence()} makes the durable representation and authoritative load path explicit. Event-sourced models
- * are reconstructed from their model stream, optionally from a snapshot. They may additionally maintain a direct
- * current document for search. Document-authoritative models load directly from that current document. Event storage
+ * {@link #persistence()} makes the durable representations and authoritative load path explicit. Event-sourced models
+ * are reconstructed from their model stream, optionally from a snapshot. Adding {@link ModelPersistence#DOCUMENT}
+ * maintains a current document as well; when event sourcing is absent, that document is authoritative. Event storage
  * and publication remain independent and are controlled by {@link #eventPublication()},
  * {@link #publicationStrategy()}, and per-apply overrides. Internal component documents used for Graph composition are
  * likewise orthogonal and never change the selected load path.
  *
  * <h2>Example</h2>
  * <pre>{@code
- * @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+ * @Model(persistence = {
+ *         ModelPersistence.EVENT_SOURCED,
+ *         ModelPersistence.DOCUMENT
+ * })
  * public record Product(@EntityId ProductId productId, String name) {
  *     @Apply
  *     Product rename(RenameProduct command) {
@@ -98,7 +101,11 @@ public @interface Model {
     AutomaticModelHandling automaticHandling() default AutomaticModelHandling.DEFAULT;
 
     /**
-     * Durable representation and authoritative load path for this Model.
+     * Durable representations and authoritative load path for this Model.
+     * <p>
+     * The set must contain at least one unique value. When {@link ModelPersistence#EVENT_SOURCED EVENT_SOURCED} is
+     * present, the event stream is authoritative. Otherwise {@link ModelPersistence#DOCUMENT DOCUMENT} is
+     * authoritative.
      * <p>
      * This setting does not suppress storing or publishing events produced by {@link Apply} methods. A state-changing
      * event-sourced Model apply must store its reconstructing event; a {@code PUBLISH_ONLY} or
@@ -106,7 +113,7 @@ public @interface Model {
      * no-op remains a valid domain notification when publication is explicitly set to
      * {@link EventPublication#ALWAYS ALWAYS}.
      */
-    ModelPersistence persistence() default ModelPersistence.EVENT_SOURCED;
+    ModelPersistence[] persistence() default {ModelPersistence.EVENT_SOURCED};
 
     /**
      * Whether unknown events should be ignored while reconstructing an event-sourced model.
@@ -179,20 +186,21 @@ public @interface Model {
     /**
      * Advanced configuration for the Model's direct current document.
      * <p>
-     * Select a {@link ModelPersistence} that stores a document to enable this projection. The document store makes the
-     * resulting current state searchable. The collection defaults to the Model's simple class name; timestamps default
-     * to the applied event timestamp when no paths are configured.
+     * Include {@link ModelPersistence#DOCUMENT} in {@link #persistence()} to enable this projection. Searchable
+     * documents use a public collection that defaults to the Model's simple class name. Reference-only documents use
+     * type-isolated private storage while remaining available to Model loads, aliases, relationships and Graph
+     * composition. Timestamps default to the applied event timestamp when no paths are configured.
      */
     DocumentProjection document() default @DocumentProjection;
 
     /**
      * Whether Fluxzero should asynchronously materialize the complete model graph as a separate search document.
      * <p>
-     * Fluxzero retains the root's current document in its direct collection when {@link #persistence()} stores a
-     * document and otherwise in the same type-isolated private component storage used by other Graph-only Models. Only
-     * the separately named graph collection is allowed to lag; its high-watermark is exposed through the model
-     * repository. The collection defaults to the resolved direct-model collection plus {@code -graphs} when present,
-     * or to {@code <simple model name>-graphs} otherwise.
+     * Fluxzero retains the root's current document in its public direct collection when it has a searchable document
+     * projection and otherwise in the same type-isolated private storage used by other Graph-only Models. Only the
+     * separately named graph collection is allowed to lag; its high-watermark is exposed through the model repository.
+     * The collection defaults to the resolved public direct-model collection plus {@code -graphs} when present, or to
+     * {@code <simple model name>-graphs} otherwise.
      */
     boolean materializeGraph() default false;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPersistence.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelPersistence.java
@@ -17,38 +17,17 @@
 package io.fluxzero.sdk.modeling;
 
 /**
- * Defines the durable representation and authoritative load path of a {@link Model}.
+ * Defines one durable representation of a {@link Model}.
  * <p>
- * This choice is independent from event publication and from internal documents used to compose model graphs.
+ * A model may select both representations. When {@link #EVENT_SOURCED} is present, the event stream is authoritative;
+ * otherwise {@link #DOCUMENT} is authoritative. This set is independent from event publication and from internal
+ * documents used to compose model graphs.
  */
 public enum ModelPersistence {
 
-    /** Reconstruct state from the model event stream and do not maintain a directly searchable current document. */
-    EVENT_SOURCED(true, false),
+    /** Persist reconstructing events in the model event stream. */
+    EVENT_SOURCED,
 
-    /** Reconstruct state from the event stream and also maintain a directly searchable current document. */
-    EVENT_SOURCED_WITH_DOCUMENT(true, true),
-
-    /**
-     * Treat the current document as authoritative and load state directly through the configured document serializer.
-     */
-    DOCUMENT(false, true);
-
-    private final boolean eventSourced;
-    private final boolean storesDocument;
-
-    ModelPersistence(boolean eventSourced, boolean storesDocument) {
-        this.eventSourced = eventSourced;
-        this.storesDocument = storesDocument;
-    }
-
-    /** Whether normal loads reconstruct state from stored model events. */
-    public boolean isEventSourced() {
-        return eventSourced;
-    }
-
-    /** Whether commits maintain a directly searchable current document. */
-    public boolean storesDocument() {
-        return storesDocument;
-    }
+    /** Persist the current model state as a document. */
+    DOCUMENT
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
@@ -91,7 +91,7 @@ public class SearchParameters implements Substitutable<SearchParameters> {
                 .orElse(null);
         if (model != null) {
             return new SearchParameters(
-                    model.directDocument(), model.resolvedCollection(type),
+                    model.publicDocument(), model.resolvedCollection(type),
                     model.timestampPath(), model.endPath());
         }
         return io.fluxzero.common.reflection.ReflectionUtils

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
@@ -53,7 +53,6 @@ import io.fluxzero.sdk.tracking.handling.HasLocalHandlers;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.With;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
@@ -220,6 +219,17 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
     @Override
     public <T> Search<T> search(SearchQuery.Builder searchBuilder) {
         return new DefaultSearch<>(searchBuilder);
+    }
+
+    @Override
+    public <T> Search<T> search(@NonNull Class<T> collection) {
+        Class<?> targetModelType = EntityMetadata.of(collection).rootConfiguration()
+                .filter(configuration -> configuration.kind() == EntityMetadata.RootKind.MODEL)
+                .map(ignored -> collection)
+                .orElse(null);
+        return new DefaultSearch<>(
+                SearchQuery.builder().collection(determineCollection(collection)),
+                targetModelType);
     }
 
     @Override
@@ -398,10 +408,10 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                         modelTypesSupplier);
     }
 
-    @RequiredArgsConstructor
     protected class DefaultSearch<R> implements Search<R> {
 
         private final SearchQuery.Builder queryBuilder;
+        private final Class<?> targetModelType;
         private final List<String> sorting = new ArrayList<>();
         private final List<String> pathFilters = new ArrayList<>();
         private final List<ModelRelationConstraint> relationConstraints =
@@ -412,7 +422,18 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
         private volatile int skip;
 
         protected DefaultSearch() {
-            this(SearchQuery.builder());
+            this(SearchQuery.builder(), null);
+        }
+
+        protected DefaultSearch(SearchQuery.Builder queryBuilder) {
+            this(queryBuilder, null);
+        }
+
+        protected DefaultSearch(
+                SearchQuery.Builder queryBuilder,
+                Class<?> targetModelType) {
+            this.queryBuilder = queryBuilder;
+            this.targetModelType = targetModelType;
         }
 
         @Override
@@ -453,12 +474,26 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                 ModelRelationConstraint... constraints) {
             for (ModelRelationConstraint constraint :
                     constraints) {
+                useModelCurrentDocumentCollection();
                 relationConstraints.add(
                         Objects.requireNonNull(
                                 constraint,
                                 "Model relation constraint"));
             }
             return this;
+        }
+
+        private void useModelCurrentDocumentCollection() {
+            if (targetModelType == null) {
+                return;
+            }
+            String collection = EntityMetadata.validate(targetModelType)
+                    .modelDocumentCollection()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            ("Relationship search target %s has no current-state document; "
+                             + "load it as a Model or Graph instead")
+                                    .formatted(targetModelType.getName())));
+            queryBuilder.collections(List.of(collection));
         }
 
         @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Search.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Search.java
@@ -38,6 +38,9 @@ import io.fluxzero.common.api.search.constraints.QueryConstraint;
 import io.fluxzero.common.serialization.JsonUtils;
 import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.ClientUtils;
+import io.fluxzero.sdk.modeling.EntityMetadata;
+import io.fluxzero.sdk.modeling.Graph;
+import io.fluxzero.sdk.modeling.Id;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,6 +51,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -306,6 +310,38 @@ public interface Search<R> {
     Search<R> constraint(Constraint... constraints);
 
     /**
+     * Requires a direct parent with the supplied typed identity.
+     * <p>
+     * Unlike the related-document overload, this selector starts directly from the parent's durable Model identity and
+     * therefore does not require the parent to maintain a current-state document.
+     */
+    default Search<R> whereParent(Id<?> parentId) {
+        Objects.requireNonNull(parentId, "Parent ID");
+        return whereAncestor(parentId, parentId.getType(), 1, 1);
+    }
+
+    /**
+     * Requires a direct parent with the supplied functional identity and Model type.
+     * <p>
+     * Use this overload for identifiers that do not extend {@link Id}. The Model type supplies any configured
+     * {@code @EntityId} affixes needed to resolve its exact persisted identity.
+     */
+    default Search<R> whereParent(
+            Object parentId, Class<?> parentType) {
+        return whereAncestor(parentId, parentType, 1, 1);
+    }
+
+    /**
+     * Requires the supplied existing Model graph to be the direct parent.
+     * <p>
+     * This overload is useful when the parent's persisted identity is scoped by one of its own parents.
+     */
+    default Search<R> whereParent(Graph<?> parent) {
+        Objects.requireNonNull(parent, "Parent graph");
+        return whereAncestorModelId(parent.id(), 1, 1);
+    }
+
+    /**
      * Requires a directly related parent document to match the supplied document constraints.
      */
     default Search<R> whereParent(
@@ -321,6 +357,101 @@ public interface Search<R> {
             Object collection, Constraint... constraints) {
         return whereAncestor(
                 collection, 1, 64, constraints);
+    }
+
+    /**
+     * Requires an ancestor with the supplied typed identity at any supported depth.
+     * <p>
+     * This selector uses only the durable Model relationship index; the ancestor does not need a current-state
+     * document or public search projection.
+     */
+    default Search<R> whereAncestor(Id<?> ancestorId) {
+        Objects.requireNonNull(ancestorId, "Ancestor ID");
+        return whereAncestor(
+                ancestorId, ancestorId.getType(), 1, 64);
+    }
+
+    /**
+     * Requires an ancestor with the supplied typed identity within the given depth range.
+     */
+    default Search<R> whereAncestor(
+            Id<?> ancestorId,
+            int minDepth,
+            int maxDepth) {
+        Objects.requireNonNull(ancestorId, "Ancestor ID");
+        return whereAncestor(
+                ancestorId, ancestorId.getType(),
+                minDepth, maxDepth);
+    }
+
+    /**
+     * Requires an ancestor with the supplied functional identity and Model type at any supported depth.
+     * <p>
+     * Use this overload for identifiers that do not extend {@link Id}.
+     */
+    default Search<R> whereAncestor(
+            Object ancestorId, Class<?> ancestorType) {
+        return whereAncestor(
+                ancestorId, ancestorType, 1, 64);
+    }
+
+    /**
+     * Requires the supplied existing Model graph to be an ancestor at any supported depth.
+     */
+    default Search<R> whereAncestor(Graph<?> ancestor) {
+        Objects.requireNonNull(ancestor, "Ancestor graph");
+        return whereAncestorModelId(ancestor.id(), 1, 64);
+    }
+
+    /**
+     * Requires the supplied existing Model graph to be an ancestor within the given depth range.
+     */
+    default Search<R> whereAncestor(
+            Graph<?> ancestor,
+            int minDepth,
+            int maxDepth) {
+        Objects.requireNonNull(ancestor, "Ancestor graph");
+        return whereAncestorModelId(
+                ancestor.id(), minDepth, maxDepth);
+    }
+
+    /**
+     * Requires an ancestor with the supplied functional identity and Model type within the given depth range.
+     * <p>
+     * The related Model itself is never loaded or searched. Models with parent-scoped primary identities cannot be
+     * resolved from a functional ID alone; use an exact persisted identity obtained from their {@code Graph} instead.
+     */
+    default Search<R> whereAncestor(
+            Object ancestorId,
+            Class<?> ancestorType,
+            int minDepth,
+            int maxDepth) {
+        Objects.requireNonNull(ancestorId, "Ancestor ID");
+        Objects.requireNonNull(ancestorType, "Ancestor type");
+        EntityMetadata metadata =
+                EntityMetadata.validate(ancestorType);
+        if (!metadata.isModel()) {
+            throw new IllegalArgumentException(
+                    ancestorType.getName()
+                    + " is not an independent Model");
+        }
+        return whereAncestorModelId(
+                metadata.repositoryId(ancestorId),
+                minDepth, maxDepth);
+    }
+
+    private Search<R> whereAncestorModelId(
+            Object ancestorModelId,
+            int minDepth,
+            int maxDepth) {
+        return relation(ModelRelationConstraint.builder()
+                                .direction(ModelRelationConstraint.RelationDirection.ANCESTOR)
+                                .relatedModelId(Objects.requireNonNull(
+                                        ancestorModelId,
+                                        "Persisted ancestor identity").toString())
+                                .minDepth(minDepth)
+                                .maxDepth(maxDepth)
+                                .build());
     }
 
     /**
@@ -386,6 +517,8 @@ public interface Search<R> {
      * type-isolated collection of a model that participates in graph composition without maintaining a direct public
      * document. Related documents are selected before relationship traversal and target search, so a selective child
      * constraint does not require live composition of unrelated roots.
+     * Constraints with exact related model IDs skip related-document selection and can therefore start from an
+     * event-sourced Model that has no current document.
      * <p>
      * Implementations that do not support independent-model graph search fail when this method is called.
      */

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Searchable.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/Searchable.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <p>
  * This annotation can also be used as a meta-annotation to define custom searchable types with preconfigured values.
  * Independent Models use their dedicated {@link io.fluxzero.sdk.modeling.DocumentProjection} configuration instead;
- * their {@link io.fluxzero.sdk.modeling.ModelPersistence} determines whether a direct document exists.
+ * their {@link io.fluxzero.sdk.modeling.ModelPersistence} set determines whether a direct document exists.
  *
  * <h2>Usage</h2>
  * <pre>{@code

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
@@ -241,23 +241,10 @@ public class InMemorySearchStore implements SearchClient {
         LinkedHashSet<String> candidates = null;
         for (ModelRelationConstraint relation :
                 request.getRelations()) {
-            List<String> related = search(
-                    SearchDocuments.builder()
-                            .query(relation.getQuery())
-                            .maxSize(
-                                    relation.getMaxRelatedModels()
-                                    + 1)
-                            .build(),
-                    relation.getMaxRelatedModels() + 1)
-                    .map(SearchHit::getId)
-                    .toList();
-            if (related.size()
-                > relation.getMaxRelatedModels()) {
-                throw new IllegalArgumentException(
-                        "Related model query exceeds maxRelatedModels "
-                        + relation.getMaxRelatedModels()
-                        + "; narrow the query or use a materialized graph projection");
-            }
+            List<String> related =
+                    relation.getRelatedModelIds().isEmpty()
+                            ? searchRelatedModelIds(relation)
+                            : relation.getRelatedModelIds();
             Set<String> resolved =
                     modelRelationResolver.resolve(
                             new LinkedHashSet<>(related),
@@ -284,6 +271,28 @@ public class InMemorySearchStore implements SearchClient {
                         .documentIds(List.copyOf(candidates))
                         .build(),
                 fetchSize);
+    }
+
+    private List<String> searchRelatedModelIds(
+            ModelRelationConstraint relation) {
+        List<String> result = search(
+                SearchDocuments.builder()
+                        .query(relation.getQuery())
+                        .maxSize(
+                                relation.getMaxRelatedModels()
+                                + 1)
+                        .build(),
+                relation.getMaxRelatedModels() + 1)
+                .map(SearchHit::getId)
+                .toList();
+        if (result.size()
+            > relation.getMaxRelatedModels()) {
+            throw new IllegalArgumentException(
+                    "Related model query exceeds maxRelatedModels "
+                    + relation.getMaxRelatedModels()
+                    + "; narrow the query or use a materialized graph projection");
+        }
+        return result;
     }
 
     @Override

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -542,7 +542,7 @@ class DefaultModelRepositoryCommitTest {
                         .getDocument();
         assertNotNull(document);
         assertEquals(
-                ModelDocumentMutation.graphComponentCollection(
+                ModelDocumentMutation.privateModelDocumentCollection(
                         GraphOnlyChild.class.getName()),
                 document.getCollection());
         assertEquals(

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toSet;
 
-import static io.fluxzero.common.api.modeling.ModelDocumentMutation.graphComponentCollection;
+import static io.fluxzero.common.api.modeling.ModelDocumentMutation.privateModelDocumentCollection;
 import static io.fluxzero.sdk.modeling.EntityMetadata.HandlerKind.APPLY;
 import static io.fluxzero.sdk.modeling.EntityMetadata.HandlerKind.ASSERT_LEGAL;
 import static io.fluxzero.sdk.modeling.EntityMetadata.HandlerKind.INTERCEPT_APPLY;
@@ -139,7 +139,7 @@ class EntityMetadataTest {
     void ownsDirectModelDocumentCollectionResolution() {
         assertEquals("models", EntityMetadata.validate(ConfiguredModel.class)
                 .modelDocumentCollection().orElseThrow());
-        assertEquals(graphComponentCollection(ChildModel.class.getName()), EntityMetadata.validate(ChildModel.class)
+        assertEquals(privateModelDocumentCollection(ChildModel.class.getName()), EntityMetadata.validate(ChildModel.class)
                 .modelDocumentCollection().orElseThrow());
         assertTrue(EntityMetadata.validate(ParentModel.class)
                            .modelDocumentCollection().isEmpty());
@@ -176,7 +176,7 @@ class EntityMetadataTest {
                         .graphProjectionConfiguration()
                         .orElseThrow();
         assertEquals(
-                graphComponentCollection(UnsearchableProjectedModel.class.getName()),
+                privateModelDocumentCollection(UnsearchableProjectedModel.class.getName()),
                 privateConfiguration.getRootCollection());
         assertEquals(
                 "UnsearchableProjectedModel-graphs",
@@ -303,7 +303,7 @@ class EntityMetadataTest {
         Set<String> expectedConfiguration = new java.util.HashSet<>(modelSettings);
         expectedConfiguration.removeAll(Set.of("document", "persistence"));
         expectedConfiguration.addAll(Set.of(
-                "eventSourced", "directDocument", "collection", "timestampPath", "endPath"));
+                "eventSourced", "directDocument", "publicDocument", "collection", "timestampPath", "endPath"));
         assertEquals(expectedConfiguration, configurationSettings);
     }
 
@@ -591,7 +591,7 @@ class EntityMetadataTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             document = @DocumentProjection(collection = "projected-models"),
             materializeGraph = true,
             graphProjection = @GraphProjection(
@@ -631,7 +631,7 @@ class EntityMetadataTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             document = @DocumentProjection(collection = "default-projected-models"),
             materializeGraph = true)
     private record DefaultProjectedModel(
@@ -639,14 +639,14 @@ class EntityMetadataTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             graphProjection = @GraphProjection(collection = "ignored-graphs"))
     private record ConfiguredUnmaterializedModel(
             @EntityId String id) {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             document = @DocumentProjection(collection = "same-collection"),
             materializeGraph = true,
             graphProjection = @GraphProjection(
@@ -656,7 +656,7 @@ class EntityMetadataTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             document = @DocumentProjection(collection = "${graphRootCollection}"),
             materializeGraph = true,
             graphProjection = @GraphProjection(

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
@@ -2497,7 +2497,7 @@ class ModelCommitHandlerIntegrationTest {
         throw lastError;
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record Account(@EntityId AccountId accountId, int balance) {
         @Apply
         Account apply(SetExplicitValue command) {
@@ -3191,7 +3191,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record FamilyRoot(
             @EntityId FamilyRootId familyRootId,
             String name) {
@@ -3362,7 +3362,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record AffixedRoot(
             @EntityId(prefix = "move-", postfix = "-state") AffixedRootId affixedRootId) {
     }
@@ -3476,7 +3476,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record FamilyChild(
             @EntityId FamilyChildId familyChildId,
             @Parent(pathInParent = "children")
@@ -3502,7 +3502,9 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.DOCUMENT)
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(searchable = false))
     private record DocumentFamilyChild(
             @EntityId DocumentFamilyChildId documentFamilyChildId,
             @Parent(pathInParent = "documentChildren")
@@ -3528,7 +3530,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, cached = false)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, cached = false)
     private record FamilyGrandchild(
             @EntityId FamilyGrandchildId familyGrandchildId,
             @Parent(pathInParent = "primaryGrandchildren")
@@ -3664,7 +3666,7 @@ class ModelCommitHandlerIntegrationTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "projectionRoots",
                     pathOverrides = @GraphPathOverride(

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistryTest.java
@@ -2075,7 +2075,7 @@ class ModelCommitHandlerRegistryTest {
                 null, false);
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "retryRoots"))
     private record RetryRoot(
@@ -2463,7 +2463,7 @@ class ModelCommitHandlerRegistryTest {
             String batchId) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "awaited-graphs",
                     completion = GraphProjectionCompletion.AWAIT))
@@ -2485,14 +2485,14 @@ class ModelCommitHandlerRegistryTest {
             ProjectionRootId rootId) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "default-graphs"))
     private record DefaultProjectionRoot(
             @EntityId String id) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "async-graphs",
                     completion = GraphProjectionCompletion.ASYNC))

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
@@ -142,8 +142,8 @@ class ModelGraphComponentSearchTest {
                 .modelDocumentCollection().orElseThrow();
 
         assertNotEquals(first, second);
-        assertTrue(first.startsWith(ModelDocumentMutation.GRAPH_COMPONENT_COLLECTION_PREFIX), first);
-        assertTrue(second.startsWith(ModelDocumentMutation.GRAPH_COMPONENT_COLLECTION_PREFIX), second);
+        assertTrue(first.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), first);
+        assertTrue(second.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), second);
     }
 
     private static List<SearchRootId> graphIds(List<Graph<SearchRoot>> graphs) {
@@ -169,7 +169,7 @@ class ModelGraphComponentSearchTest {
                                  .fetchAll()));
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true)
     private record SearchRoot(@EntityId SearchRootId searchRootId) {
     }
 
@@ -273,7 +273,7 @@ class ModelGraphComponentSearchTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record SearchLeaf(
             @EntityId SearchLeafId searchLeafId,
             @Parent(pathInParent = "searchLeaves") PrivateChildId privateChildId) {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
@@ -45,9 +45,16 @@ class ModelGraphComponentSearchTest {
                         privateProjectionChildIds(Fluxzero.searchGraph(PrivateProjectionRoot.class)
                                                           .fetchAll()),
                         privateProjectionChildIds(Fluxzero.searchGraph(PrivateProjectionRoot.class, true)
-                                                          .fetchAll())))
+                                                          .fetchAll()),
+                        Fluxzero.search(PrivateProjectionChild.class)
+                                .whereParent(
+                                        PrivateProjectionRoot.class,
+                                        match(rootId, true, "id"))
+                                .fetchAll().stream()
+                                .map(PrivateProjectionChild::id).toList()))
                 .expectResult(List.of(
-                        true, List.of(childId), List.of(childId)));
+                        true, List.of(childId), List.of(childId),
+                        List.of(childId)));
     }
 
     @Test
@@ -144,6 +151,51 @@ class ModelGraphComponentSearchTest {
         assertNotEquals(first, second);
         assertTrue(first.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), first);
         assertTrue(second.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), second);
+    }
+
+    @Test
+    void selectsPrivateTargetsByExactParentAndAncestorIdsWithoutAncestorDocuments() {
+        NoDocumentRootId selectedRoot = new NoDocumentRootId("selected");
+        NoDocumentRootId otherRoot = new NoDocumentRootId("other");
+        NoDocumentMiddleId selectedMiddle = new NoDocumentMiddleId("selected");
+        NoDocumentMiddleId otherMiddle = new NoDocumentMiddleId("other");
+        NoDocumentLeafId selectedLeaf = new NoDocumentLeafId("selected");
+
+        assertTrue(EntityMetadata.validate(NoDocumentRoot.class)
+                           .modelDocumentCollection().isEmpty());
+
+        TestFixture.create()
+                .givenCommands(
+                        new CreateNoDocumentRoot(selectedRoot),
+                        new CreateNoDocumentRoot(otherRoot),
+                        new CreateNoDocumentMiddle(selectedMiddle, selectedRoot),
+                        new CreateNoDocumentMiddle(otherMiddle, otherRoot),
+                        new CreateNoDocumentLeaf(selectedLeaf, selectedMiddle),
+                        new CreateNoDocumentLeaf(new NoDocumentLeafId("other"), otherMiddle))
+                .whenApplying(ignored -> List.of(
+                        Fluxzero.search(NoDocumentMiddle.class)
+                                .whereParent(selectedRoot)
+                                .fetchAll().stream()
+                                .map(NoDocumentMiddle::id).toList(),
+                        Fluxzero.search(NoDocumentLeaf.class)
+                                .whereAncestor(selectedRoot)
+                                .fetchAll().stream()
+                                .map(NoDocumentLeaf::id).toList(),
+                        Fluxzero.search(NoDocumentLeaf.class)
+                                .whereAncestor(selectedRoot, 2, 2)
+                                .fetchAll().stream()
+                                .map(NoDocumentLeaf::id).toList(),
+                        Fluxzero.search(NoDocumentLeaf.class)
+                                .whereAncestor("selected", NoDocumentRoot.class)
+                                .fetchAll().stream()
+                                .map(NoDocumentLeaf::id).toList(),
+                        Fluxzero.search(NoDocumentLeaf.class).fetchAll()))
+                .expectResult(List.of(
+                        List.of(selectedMiddle),
+                        List.of(selectedLeaf),
+                        List.of(selectedLeaf),
+                        List.of(selectedLeaf),
+                        List.of()));
     }
 
     private static List<SearchRootId> graphIds(List<Graph<SearchRoot>> graphs) {
@@ -291,6 +343,66 @@ class ModelGraphComponentSearchTest {
         @Apply
         SearchLeaf apply() {
             return new SearchLeaf(searchLeafId, privateChildId);
+        }
+    }
+
+    @Model
+    private record NoDocumentRoot(
+            @EntityId NoDocumentRootId id) {
+    }
+
+    private static final class NoDocumentRootId extends Id<NoDocumentRoot> {
+        private NoDocumentRootId(String id) {
+            super(id, "no-document-root-");
+        }
+    }
+
+    private record CreateNoDocumentRoot(NoDocumentRootId id) {
+        @Apply
+        NoDocumentRoot apply() {
+            return new NoDocumentRoot(id);
+        }
+    }
+
+    @Model
+    private record NoDocumentMiddle(
+            @EntityId NoDocumentMiddleId id,
+            @Parent(pathInParent = "middles") NoDocumentRootId rootId) {
+    }
+
+    private static final class NoDocumentMiddleId extends Id<NoDocumentMiddle> {
+        private NoDocumentMiddleId(String id) {
+            super(id, "no-document-middle-");
+        }
+    }
+
+    private record CreateNoDocumentMiddle(
+            NoDocumentMiddleId id,
+            NoDocumentRootId rootId) {
+        @Apply
+        NoDocumentMiddle apply() {
+            return new NoDocumentMiddle(id, rootId);
+        }
+    }
+
+    @Model
+    private record NoDocumentLeaf(
+            @EntityId NoDocumentLeafId id,
+            @Parent(pathInParent = "leaves") NoDocumentMiddleId middleId) {
+    }
+
+    private static final class NoDocumentLeafId extends Id<NoDocumentLeaf> {
+        private NoDocumentLeafId(String id) {
+            super(id, "no-document-leaf-");
+        }
+    }
+
+    private record CreateNoDocumentLeaf(
+            NoDocumentLeafId id,
+            NoDocumentMiddleId middleId) {
+        @Apply
+        NoDocumentLeaf apply() {
+            return new NoDocumentLeaf(id, middleId);
         }
     }
 }

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import static io.fluxzero.sdk.modeling.ModelCommitPolicy.ASYNC_AFTER_BATCH;
 import static io.fluxzero.sdk.modeling.EventPublication.IF_MODIFIED;
 import static io.fluxzero.sdk.modeling.EventPublicationStrategy.STORE_ONLY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,7 +43,9 @@ class ModelTest {
     void exposesIndependentStorageDefaults() {
         Model model = DefaultModel.class.getAnnotation(Model.class);
 
-        assertEquals(ModelPersistence.EVENT_SOURCED, model.persistence());
+        assertArrayEquals(
+                new ModelPersistence[]{ModelPersistence.EVENT_SOURCED},
+                model.persistence());
         assertFalse(model.ignoreUnknownEvents());
         assertEquals(0, model.snapshotPeriod());
         assertEquals(1, model.maxSnapshotCount());
@@ -55,6 +58,7 @@ class ModelTest {
         assertEquals(ModelConflictPolicy.DEFAULT, model.conflictPolicy());
         assertEquals(AutomaticModelHandling.DEFAULT, model.automaticHandling());
         assertFalse(model.materializeGraph());
+        assertTrue(model.document().searchable());
         assertEquals("", model.document().collection());
         assertEquals("", model.document().timestampPath());
         assertEquals("", model.document().endPath());
@@ -76,7 +80,11 @@ class ModelTest {
     void exposesAggregateEquivalentConfiguration() {
         Model model = ConfiguredModel.class.getAnnotation(Model.class);
 
-        assertEquals(ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, model.persistence());
+        assertArrayEquals(
+                new ModelPersistence[]{
+                        ModelPersistence.EVENT_SOURCED,
+                        ModelPersistence.DOCUMENT},
+                model.persistence());
         assertTrue(model.ignoreUnknownEvents());
         assertEquals(20, model.snapshotPeriod());
         assertEquals(3, model.maxSnapshotCount());
@@ -126,7 +134,11 @@ class ModelTest {
         Model annotation = ReflectionUtils.getTypeMetadata(InheritedModel.class).typeAnnotation(Model.class);
 
         assertNotNull(annotation);
-        assertEquals(ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, annotation.persistence());
+        assertArrayEquals(
+                new ModelPersistence[]{
+                        ModelPersistence.EVENT_SOURCED,
+                        ModelPersistence.DOCUMENT},
+                annotation.persistence());
         assertEquals("base-models", annotation.document().collection());
     }
 
@@ -138,6 +150,39 @@ class ModelTest {
         assertEquals("configured-models", searchable.getCollection());
         assertEquals("createdAt", searchable.getTimestampPath());
         assertEquals("expiresAt", searchable.getEndPath());
+    }
+
+    @Test
+    void keepsReferenceOnlyDocumentsOutOfThePublicModelCollection() {
+        EntityMetadata metadata = EntityMetadata.validate(
+                ReferenceOnlyDocumentModel.class);
+        SearchParameters search = ClientUtils.getSearchParameters(
+                ReferenceOnlyDocumentModel.class);
+
+        assertTrue(metadata.rootConfiguration().orElseThrow().directDocument());
+        assertFalse(metadata.rootConfiguration().orElseThrow().publicDocument());
+        assertEquals(
+                io.fluxzero.common.api.modeling.ModelDocumentMutation
+                        .privateModelDocumentCollection(
+                                ReferenceOnlyDocumentModel.class.getName()),
+                metadata.modelDocumentCollection().orElseThrow());
+        assertFalse(search.isSearchable());
+    }
+
+    @Test
+    void rejectsEmptyAndDuplicatePersistenceRepresentations() {
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(EmptyPersistenceModel.class));
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(DuplicatePersistenceModel.class));
+    }
+
+    @Test
+    void rejectsDocumentProjectionSettingsWithoutMatchingPersistence() {
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(InvalidReferenceOnlyProjection.class));
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(PrivateDocumentWithPublicCollection.class));
     }
 
     @Test
@@ -199,7 +244,7 @@ class ModelTest {
     private static class DefaultModel {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             ignoreUnknownEvents = true,
             snapshotPeriod = 20,
             maxSnapshotCount = 3,
@@ -219,13 +264,41 @@ class ModelTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             document = @DocumentProjection(collection = "base-models"))
     private static class BaseModel {
     }
 
     @Model(document = @DocumentProjection(collection = "inactive-models"))
     private static class InvalidDocumentConfiguration {
+    }
+
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(searchable = false))
+    private record ReferenceOnlyDocumentModel(@EntityId String id) {
+    }
+
+    @Model(persistence = {})
+    private static class EmptyPersistenceModel {
+    }
+
+    @Model(persistence = {
+            ModelPersistence.EVENT_SOURCED,
+            ModelPersistence.EVENT_SOURCED})
+    private static class DuplicatePersistenceModel {
+    }
+
+    @Model(document = @DocumentProjection(searchable = false))
+    private static class InvalidReferenceOnlyProjection {
+    }
+
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(
+                    searchable = false,
+                    collection = "public-models"))
+    private static class PrivateDocumentWithPublicCollection {
     }
 
     @Model(persistence = ModelPersistence.DOCUMENT, ignoreUnknownEvents = true)

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/PersistenceRootParityTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/PersistenceRootParityTest.java
@@ -873,7 +873,7 @@ class PersistenceRootParityTest {
     }
 
     @Model(
-            persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT,
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
             cachingDepth = 1,
             snapshotPeriod = 2)
     private record ParityModel(
@@ -1048,7 +1048,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, publicationStrategy =
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, publicationStrategy =
                     EventPublicationStrategy.STORE_ONLY)
     private record StoreOnlyModel(
             @EntityId StoreOnlyModelId id,
@@ -1103,7 +1103,7 @@ class PersistenceRootParityTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     private record EmbeddedModel(
             @EntityId EmbeddedModelId id,
             @Member List<EmbeddedValue> members) {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/RecursiveModelRelationshipTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/RecursiveModelRelationshipTest.java
@@ -135,7 +135,7 @@ class RecursiveModelRelationshipTest {
         return folders.stream().map(RecursiveFolder::folderId).toList();
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(collection = "recursiveFolderGraphs"))
     private record RecursiveFolder(
             @EntityId RecursiveFolderId folderId,

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1086,6 +1086,8 @@ class DefaultModelRepositoryTest {
             fluxzero.executeModelCommit(
                     new Message(new CreateAliasAccount(
                             id, "first-code", 5))).join();
+            ((DefaultModelRepository) fluxzero.modelRepository())
+                    .invalidateModels(List.of(id.toString()));
 
             Entity<AliasAccount> typed = fluxzero.apply(ignored ->
                     Fluxzero.loadModel(
@@ -1102,6 +1104,8 @@ class DefaultModelRepositoryTest {
             fluxzero.executeModelCommit(
                     new Message(new RenameAliasAccount(
                             id, "second-code"))).join();
+            ((DefaultModelRepository) fluxzero.modelRepository())
+                    .invalidateModels(List.of(id.toString()));
 
             assertTrue(fluxzero.apply(ignored ->
                     Fluxzero.loadModel(
@@ -2473,7 +2477,9 @@ class DefaultModelRepositoryTest {
             AliasedAccountId accountId, int balance) {
     }
 
-    @Model
+    @Model(
+            persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(searchable = false))
     private record AliasAccount(
             @EntityId AliasAccountId accountId,
             @Alias String code,
@@ -2967,7 +2973,7 @@ class DefaultModelRepositoryTest {
             @EntityId GraphRootId graphRootId, String name) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "repository-graphs"))
     private record ProjectedRoot(
@@ -2982,7 +2988,7 @@ class DefaultModelRepositoryTest {
             String rootId) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, materializeGraph = true,
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, materializeGraph = true,
             graphProjection = @GraphProjection(
                     collection = "repository-graphs"))
     private record AlternateProjectedRoot(

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreModelMaterializationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreModelMaterializationTest.java
@@ -122,7 +122,7 @@ class InMemorySearchStoreModelMaterializationTest {
         String rootId = "root-1";
         String childId = "child-1";
         String childCollection =
-                ModelDocumentMutation.graphComponentCollection(
+                ModelDocumentMutation.privateModelDocumentCollection(
                         "Child");
         Map<String, String> collections =
                 Map.of(
@@ -233,7 +233,7 @@ class InMemorySearchStoreModelMaterializationTest {
         String rootId = "legacy-root";
         String childId = "model-child";
         String childCollection =
-                ModelDocumentMutation.graphComponentCollection(
+                ModelDocumentMutation.privateModelDocumentCollection(
                         "Child");
         Map<String, String> collections = Map.of(
                 rootId, "roots", childId,

--- a/sdk/src/test/java/io/fluxzero/sdk/test/DocumentTrackingSearchClient.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/DocumentTrackingSearchClient.java
@@ -33,6 +33,8 @@ import io.fluxzero.common.api.search.HasDocument;
 import io.fluxzero.common.api.search.SearchCollection;
 import io.fluxzero.common.api.search.SearchDocuments;
 import io.fluxzero.common.api.search.SearchHistogram;
+import io.fluxzero.common.api.search.SearchModelDocuments;
+import io.fluxzero.common.api.search.SearchModelGraphDocuments;
 import io.fluxzero.common.api.search.SearchQuery;
 import io.fluxzero.common.api.search.SerializedDocument;
 import io.fluxzero.sdk.persisting.search.SearchHit;
@@ -149,6 +151,30 @@ class DocumentTrackingSearchClient implements SearchClient {
     @Override
     public Stream<SearchHit<SerializedDocument>> search(SearchDocuments searchDocuments, int fetchSize) {
         return delegate.search(searchDocuments, fetchSize);
+    }
+
+    @Override
+    public Stream<SearchHit<SerializedDocument>> searchModels(
+            SearchModelDocuments searchDocuments, int fetchSize) {
+        return delegate.searchModels(searchDocuments, fetchSize);
+    }
+
+    @Override
+    public CompletableFuture<List<SearchHit<SerializedDocument>>> searchModelsAsync(
+            SearchModelDocuments searchDocuments, int fetchSize) {
+        return delegate.searchModelsAsync(searchDocuments, fetchSize);
+    }
+
+    @Override
+    public Stream<SearchHit<SerializedDocument>> searchModelGraph(
+            SearchModelGraphDocuments searchDocuments, int fetchSize) {
+        return delegate.searchModelGraph(searchDocuments, fetchSize);
+    }
+
+    @Override
+    public CompletableFuture<List<SearchHit<SerializedDocument>>> searchModelGraphAsync(
+            SearchModelGraphDocuments searchDocuments, int fetchSize) {
+        return delegate.searchModelGraphAsync(searchDocuments, fetchSize);
     }
 
     @Override

--- a/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/test/TestFixtureModelApiTest.java
@@ -23,6 +23,7 @@ import io.fluxzero.sdk.modeling.EntityId;
 import io.fluxzero.sdk.modeling.EventPublication;
 import io.fluxzero.sdk.modeling.Id;
 import io.fluxzero.sdk.modeling.AssertLegal;
+import io.fluxzero.sdk.modeling.DocumentProjection;
 import io.fluxzero.sdk.modeling.Model;
 import io.fluxzero.sdk.modeling.ModelPersistence;
 import io.fluxzero.sdk.modeling.Parent;
@@ -199,7 +200,10 @@ class TestFixtureModelApiTest {
                 .expectNoEvents()
                 .andThen()
                 .whenApplying(ignored -> Fluxzero.loadModel(id, UncachedDocument.class).get())
-                .expectResult(new UncachedDocument(id, 4));
+                .expectResult(new UncachedDocument(id, 4))
+                .andThen()
+                .whenApplying(ignored -> Fluxzero.search(UncachedDocument.class).fetchAll())
+                .expectResult(List.of());
     }
 
     @Test
@@ -351,6 +355,7 @@ class TestFixtureModelApiTest {
 
     @Model(
             persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(searchable = false),
             eventPublication = EventPublication.NEVER,
             cached = false)
     private record UncachedDocument(@EntityId String id, int value) {

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
@@ -428,13 +428,13 @@ public class HandleDocumentTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT, document = @DocumentProjection(collection = "graph-roots"),
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT}, document = @DocumentProjection(collection = "graph-roots"),
             materializeGraph = true)
     @Revision(1)
     record GraphRoot(@EntityId String id) {
     }
 
-    @Model(persistence = ModelPersistence.EVENT_SOURCED_WITH_DOCUMENT)
+    @Model(persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT})
     record DirectOnlyModel(@EntityId String id) {
     }
 

--- a/test-server/src/test/java/io/fluxzero/testserver/TestServerWebsocketContractTest.java
+++ b/test-server/src/test/java/io/fluxzero/testserver/TestServerWebsocketContractTest.java
@@ -474,11 +474,11 @@ class TestServerWebsocketContractTest {
                             childId,
                             "ContractChild",
                             new ModelDocumentMutation(
-                                    ModelDocumentMutation.graphComponentCollection(
+                                    ModelDocumentMutation.privateModelDocumentCollection(
                                             "ContractChild"),
                                     structuredDocument(
                                             childId,
-                                            ModelDocumentMutation.graphComponentCollection(
+                                            ModelDocumentMutation.privateModelDocumentCollection(
                                                     "ContractChild"),
                                             "name",
                                             "child")),


### PR DESCRIPTION
## Summary
- add typed parent- and ancestor-ID search overloads
- traverse exact identities without requiring related Model documents
- keep private target documents scoped to explicit relationship searches
- document when ID, content-based, Graph, and direct-load routes apply

## Compatibility
- existing content-based relationship searches retain their wire shape and behavior
- exact-ID requests require the matching 2.0 Runtime capability
- unrestricted typed searches do not expose private Model documents

## Verification
- full Maven reactor, including Java and Kotlin downstream projects
- Javadoc/site generation
- in-memory relationship, transport codec, and private-component coverage