### PR TITLE
fix(modeling): align cascade and cache invalidation

### DIFF
--- a/common/src/main/java/io/fluxzero/common/modeling/ModelRelationshipQueries.java
+++ b/common/src/main/java/io/fluxzero/common/modeling/ModelRelationshipQueries.java
@@ -24,6 +24,7 @@ import io.fluxzero.common.api.modeling.ModelCommitValidator;
 import io.fluxzero.common.api.modeling.ModelDeletionCascade;
 import io.fluxzero.common.api.modeling.ModelEventStreamRequest;
 import io.fluxzero.common.api.modeling.ModelGraphEdge;
+import io.fluxzero.common.api.modeling.ModelRelationship;
 import io.fluxzero.common.api.modeling.ModelReadBoundary;
 import io.fluxzero.common.api.search.ModelGraphComposition;
 import io.fluxzero.common.api.search.ModelRelationConstraint;
@@ -338,6 +339,101 @@ public final class ModelRelationshipQueries {
                         Function.identity(),
                         null)
                 .modelIds().stream().filter(modelId -> !rootIds.contains(modelId)).toList();
+    }
+
+    /** Creates the transient owned-relationship view used to validate recursive cascade plans. */
+    public static OwnedRelationshipGraph ownedRelationshipGraph() {
+        return new OwnedRelationshipGraph();
+    }
+
+    /**
+     * Mutable commit-scoped view of relationships that own the child lifecycle.
+     * Deleted children deliberately remain until the caller has verified that every current descendant is a delete
+     * target; {@link #removeModel(String)} advances the view after an accepted plan in a commit batch.
+     */
+    public static final class OwnedRelationshipGraph {
+        private final Map<String, LinkedHashSet<String>> childrenByParent =
+                new LinkedHashMap<>();
+        private final Map<String, LinkedHashSet<String>> parentsByChild =
+                new LinkedHashMap<>();
+
+        /** Adds one current owned child edge. */
+        public void add(String parentId, String childId) {
+            childrenByParent.computeIfAbsent(
+                    parentId, ignored -> new LinkedHashSet<>()).add(childId);
+            parentsByChild.computeIfAbsent(
+                    childId, ignored -> new LinkedHashSet<>()).add(parentId);
+        }
+
+        /** Adds a relationship only when deletion of its parent owns the child lifecycle. */
+        public void add(Relationship relationship) {
+            if (relationship.deleteOnParentDeletion()) {
+                add(relationship.parentId(), relationship.childId());
+            }
+        }
+
+        /** Applies the final non-deletion relationship values from ordered commit steps. */
+        public void overlayChanges(
+                Collection<ModelCommitAssignment.RelationshipStep> steps) {
+            steps.stream().flatMap(step -> step.changes().stream())
+                    .filter(change -> !change.deleted())
+                    .forEach(change -> {
+                        removeChild(change.childId());
+                        change.desired().stream()
+                                .filter(ModelRelationship::isDeleteOnParentDeletion)
+                                .forEach(relationship -> add(
+                                        relationship.getParentId(), change.childId()));
+                    });
+        }
+
+        /** Removes every incoming and outgoing owned edge for an accepted deleted Model. */
+        public void removeModel(String modelId) {
+            removeChild(modelId);
+            removeParent(modelId);
+        }
+
+        /** Returns all transitive owned descendants in deterministic traversal order. */
+        public List<String> descendants(Collection<String> roots) {
+            return ModelRelationshipQueries.descendants(
+                    roots,
+                    frontier -> frontier.stream()
+                            .map(childrenByParent::get)
+                            .filter(java.util.Objects::nonNull)
+                            .flatMap(Set::stream)
+                            .toList());
+        }
+
+        private void removeChild(String childId) {
+            Set<String> parents = parentsByChild.remove(childId);
+            if (parents == null) {
+                return;
+            }
+            parents.forEach(parentId -> {
+                LinkedHashSet<String> children = childrenByParent.get(parentId);
+                if (children != null) {
+                    children.remove(childId);
+                    if (children.isEmpty()) {
+                        childrenByParent.remove(parentId);
+                    }
+                }
+            });
+        }
+
+        private void removeParent(String parentId) {
+            Set<String> children = childrenByParent.remove(parentId);
+            if (children == null) {
+                return;
+            }
+            children.forEach(childId -> {
+                LinkedHashSet<String> parents = parentsByChild.get(childId);
+                if (parents != null) {
+                    parents.remove(parentId);
+                    if (parents.isEmpty()) {
+                        parentsByChild.remove(childId);
+                    }
+                }
+            });
+        }
     }
 
     /** Storage-independent view of one temporal child-to-parent relationship interval. */

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStore.java
@@ -31,6 +31,7 @@ import io.fluxzero.common.api.modeling.GetModelGraphResult;
 import io.fluxzero.common.api.modeling.GetRelationships;
 import io.fluxzero.common.api.modeling.ModelCommitValidator;
 import io.fluxzero.common.api.modeling.ModelChangeTarget;
+import io.fluxzero.common.api.modeling.ModelCommitConflict;
 import io.fluxzero.common.api.modeling.ModelCommitStep;
 import io.fluxzero.common.api.modeling.ModelCommitTarget;
 import io.fluxzero.common.api.modeling.ModelCommitTargetResult;
@@ -284,6 +285,10 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
             if (conflict != null) {
                 return new ModelCommitOutcome(conflict, List.of());
             }
+            conflict = cascadeConflict(commit, description);
+            if (conflict != null) {
+                return new ModelCommitOutcome(conflict, List.of());
+            }
             validateCommitRelationships(description);
             description.aliases().validate(modelAliases);
             List<ModelStreamHead> assignedHeads = new ArrayList<>(
@@ -383,6 +388,45 @@ public class InMemoryEventStore extends InMemoryMessageStore implements EventSto
             }
             return new ModelCommitOutcome(
                     modelCommits.get(commit.getCommitId()), publishedEvents);
+    }
+
+    private CommitModelsResult cascadeConflict(
+            CommitModels commit,
+            ModelCommitAssignment.Description description) {
+        List<String> cascadeRoots = description.cascadeRootIds();
+        if (cascadeRoots.isEmpty()) {
+            return null;
+        }
+        ModelRelationshipQueries.OwnedRelationshipGraph graph =
+                ModelRelationshipQueries.ownedRelationshipGraph();
+        currentModelRelationships.forEach((childId, current) ->
+                current.values().forEach(graph::add));
+        graph.overlayChanges(description.relationshipSteps());
+        LinkedHashSet<String> missing = new LinkedHashSet<>(
+                graph.descendants(cascadeRoots));
+        missing.removeAll(description.finalDeletedModelIds());
+        if (missing.isEmpty()) {
+            return null;
+        }
+        long missingRelationStateIndex = missing.stream()
+                .mapToLong(modelId -> modelRelationStateIndices.getOrDefault(
+                        modelId, -1L))
+                .max().orElse(-1L);
+        List<ModelCommitConflict> conflicts =
+                cascadeRoots.stream()
+                        .map(rootId -> {
+                            ModelStreamHead head = modelHeads.get(rootId);
+                            return new ModelCommitConflict(
+                                    rootId,
+                                    head == null ? -1L : head.stateIndex(),
+                                    Math.max(
+                                            modelRelationStateIndices.getOrDefault(
+                                                    rootId, -1L),
+                                            missingRelationStateIndex));
+                        })
+                        .toList();
+        return ModelCommitConflicts.result(
+                commit, conflicts, modelStateIndex);
     }
 
     private Map<Long, SerializedMessage> existingEvents(

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelCacheTracker.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelCacheTracker.java
@@ -139,16 +139,7 @@ final class ModelCacheTracker implements AutoCloseable {
             return;
         }
         staleModelIds.remove(modelId);
-        CompletableFuture<Void> refresh =
-                entry.refresh;
-        if (refresh != null) {
-            /*
-             * A current lookup may already be waiting for this stale entry to refresh. A missing cached value makes
-             * that refresh ineligible, so release the waiter; it will observe the detached stale entry and use the
-             * repository path.
-             */
-            refresh.complete(null);
-        }
+        releaseRefreshWaiter(entry);
     }
 
     /**
@@ -725,9 +716,13 @@ final class ModelCacheTracker implements AutoCloseable {
             }
             if (update.getKind()
                 == ModelUpdateKind.HARD_DELETE) {
+                List<Entry> discardedEntries =
+                        List.copyOf(entries.values());
                 cache.clear();
                 entries.clear();
                 staleModelIds.clear();
+                discardedEntries.forEach(
+                        ModelCacheTracker::releaseRefreshWaiter);
             } else {
                 for (ModelCommitTargetResult target :
                         update.getTargets()) {
@@ -998,6 +993,18 @@ final class ModelCacheTracker implements AutoCloseable {
             result = result.getCause();
         }
         return result;
+    }
+
+    private static void releaseRefreshWaiter(Entry entry) {
+        CompletableFuture<Void> refresh = entry.refresh;
+        if (refresh != null) {
+            /*
+             * A current lookup may already be waiting for this stale entry. Once the entry is detached, its refresh
+             * is ineligible and the reader must fall back to the repository path. Cache eviction notifications may be
+             * asynchronous, so the owner performing a bulk invalidation cannot rely on the listener to release it.
+             */
+            refresh.complete(null);
+        }
     }
 
     private static void validatePosition(

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/eventsourcing/client/InMemoryEventStoreModelCommitTest.java
@@ -1236,6 +1236,48 @@ class InMemoryEventStoreModelCommitTest {
     }
 
     @Test
+    void staleCascadeDeleteRebasesWhenADeepDescendantIsMissingFromThePlan() {
+        InMemoryEventStore store = denseStore();
+        store.commitModels(commit(
+                "create-parent", -1L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("parent"))
+                        .targets(List.of(storedTarget("parent-1")))
+                        .build())).join();
+        store.commitModels(commit(
+                "create-child", 0L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("child"))
+                        .targets(List.of(ownedTarget("child-1", "parent-1")))
+                        .build())).join();
+        store.commitModels(commit(
+                "create-grandchild", 1L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("grandchild"))
+                        .targets(List.of(ownedTarget("grandchild-1", "child-1")))
+                        .build())).join();
+
+        CommitModelsResult result = store.commitModels(commit(
+                "delete-incomplete-tree", 1L,
+                ModelConflictPolicy.ACCEPT,
+                ModelCommitStep.builder()
+                        .event(event("delete"))
+                        .targets(List.of(
+                                cascadeDeleteTarget("parent-1"),
+                                deleteTarget("child-1")))
+                        .build())).join();
+
+        assertTrue(result.isRebaseRequired());
+        assertEquals("parent-1", result.getConflicts().getFirst().getModelId());
+        assertEquals(2L, result.getConflicts().getFirst().getCurrentRelationStateIndex());
+        assertFalse(modelStream(store, "parent-1").getHead().isDeleted());
+        assertFalse(modelStream(store, "child-1").getHead().isDeleted());
+    }
+
+    @Test
     void deletionPlanIncludesDetachedAndExternallySharedDescendantsWithoutMutating() {
         InMemoryEventStore store =
                 denseStore();
@@ -1674,6 +1716,34 @@ class InMemoryEventStoreModelCommitTest {
                 .modelType("example.Model")
                 .storeEvent(true)
                 .updateState(true)
+                .relationships(List.of())
+                .build();
+    }
+
+    private static ModelCommitTarget ownedTarget(
+            String modelId,
+            String parentId) {
+        return storedTarget(modelId).toBuilder()
+                .updateRelationships(true)
+                .relationships(List.of(ModelRelationship.builder()
+                                               .parentId(parentId)
+                                               .parentType("example.Model")
+                                               .path("children")
+                                               .deleteOnParentDeletion(true)
+                                               .build()))
+                .build();
+    }
+
+    private static ModelCommitTarget cascadeDeleteTarget(String modelId) {
+        return deleteTarget(modelId).toBuilder()
+                .cascadeDelete(true)
+                .build();
+    }
+
+    private static ModelCommitTarget deleteTarget(String modelId) {
+        return storedTarget(modelId).toBuilder()
+                .delete(true)
+                .updateRelationships(true)
                 .relationships(List.of())
                 .build();
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelCacheTrackerTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelCacheTrackerTest.java
@@ -27,6 +27,7 @@ import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.ImmutableModelRoot;
 import io.fluxzero.sdk.persisting.caching.DefaultCache;
+import io.fluxzero.sdk.persisting.caching.SoftReferenceCache;
 import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
@@ -1094,6 +1096,89 @@ class ModelCacheTrackerTest {
                     12L,
                     tracker.safeDocumentBoundary());
         } finally {
+            cache.close();
+        }
+    }
+
+    @Test
+    void hardDeleteReleasesLookupBeforeDeferredEvictionNotification()
+            throws Exception {
+        EventStoreClient eventStore = mock(EventStoreClient.class);
+        ConcurrentLinkedQueue<CompletableFuture<TrackModelUpdatesResult>>
+                polls = polls(eventStore);
+        ConcurrentLinkedQueue<Runnable> evictionNotifications =
+                new ConcurrentLinkedQueue<>();
+        Cache cache = new SoftReferenceCache(
+                100, evictionNotifications::add, null);
+        cache.put("sample-1", entity(SampleModel.class));
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch continueRefresh = new CountDownLatch(1);
+        try (ModelCacheTracker tracker =
+                     new ModelCacheTracker(
+                             eventStore, cache,
+                             (ignored, safeStateIndex) -> {
+                                 refreshStarted.countDown();
+                                 try {
+                                     assertTrue(continueRefresh.await(
+                                             5L, TimeUnit.SECONDS));
+                                 } catch (InterruptedException failure) {
+                                     Thread.currentThread().interrupt();
+                                     throw new RuntimeException(failure);
+                                 }
+                                 return new ModelCacheTracker.RefreshedBatch(
+                                         safeStateIndex);
+                             })) {
+            tracker.loaded("sample-1", SampleModel.class, 10L);
+            completeNext(
+                    polls,
+                    new TrackModelUpdatesResult(
+                            2L, 11L, 11L, 11L,
+                            List.of(
+                                    new ModelUpdate(
+                                            ModelUpdateKind.COMMIT,
+                                            "remote-commit", 0,
+                                            11L, null,
+                                            List.of(
+                                                    new ModelCommitTargetResult(
+                                                            "sample-1",
+                                                            1L,
+                                                            true))))));
+            assertTrue(refreshStarted.await(5L, TimeUnit.SECONDS));
+
+            CompletableFuture<Entity<?>> lookup = new CompletableFuture<>();
+            CountDownLatch lookupStarted = new CountDownLatch(1);
+            Thread lookupThread = Thread.ofVirtual().start(() -> {
+                lookupStarted.countDown();
+                lookup.complete(tracker.current(
+                        "sample-1", SampleModel.class));
+            });
+            assertTrue(lookupStarted.await(5L, TimeUnit.SECONDS));
+            long waitingDeadline = System.nanoTime()
+                                   + TimeUnit.SECONDS.toNanos(5L);
+            while (lookupThread.getState() != Thread.State.WAITING
+                   && !lookup.isDone()
+                   && System.nanoTime() < waitingDeadline) {
+                Thread.onSpinWait();
+            }
+            assertFalse(lookup.isDone());
+
+            completeNext(
+                    polls,
+                    new TrackModelUpdatesResult(
+                            3L, 12L, 12L, 12L,
+                            List.of(
+                                    new ModelUpdate(
+                                            ModelUpdateKind.HARD_DELETE,
+                                            "deletion-1", 0,
+                                            12L, null,
+                                            List.of()))));
+
+            assertTimeoutPreemptively(
+                    Duration.ofSeconds(1L),
+                    () -> assertNull(lookup.join()));
+            assertFalse(evictionNotifications.isEmpty());
+        } finally {
+            continueRefresh.countDown();
             cache.close();
         }
     }


### PR DESCRIPTION
## Summary

- reject incomplete recursive cascade plans in the in-memory Model store before mutation
- share the owned-relationship closure implementation with the Runtime
- release Model cache refresh readers directly on global hard deletion

This closes two correctness races found by the RC5 release gate without changing the ordinary non-cascade commit path.