### PR TITLE
feat(modeling): persist logical Model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3252,6 +3252,26 @@ public record UserAccount(
 }
 ```
 
+Every Model also has one durable logical type name. It defaults to the concrete class's simple name and is persisted in
+Model heads, relationships, migrations and Graph manifests independently from the serializer payload type. Declare it
+explicitly before data exists when the Java class name may change, and retain that value through later class/package
+renames:
+
+```java
+@Model(name = "UserAccount")
+public record RenamedUserAccount(
+        @EntityId UserId userId,
+        UserProfile profile,
+        boolean accountClosed) {
+}
+```
+
+Logical names must be unique within an application namespace. Applications sharing one Runtime namespace may set
+`fluxzero.model.namePrefix`; Fluxzero concatenates it literally, so prefix `billing` plus `UserAccount` becomes
+`billingUserAccount`. There are deliberately no name aliases or FQN fallback. Changing `name` or the prefix after data
+exists is therefore an application-managed data transition. Serializer upcasters and `Data<T>` envelopes remain the
+separate mechanism for evolving serialized event/document payload types.
+
 ### Model persistence
 
 Every model ID is an independent persistence and lifecycle boundary. Depending on its `@Model` settings, it has its own
@@ -3297,8 +3317,9 @@ public record UserPreferences(
 }
 ```
 
-Reference-only documents remain in the normal resolved document collection: `UserPreferences` in this example, or the
-explicit `DocumentProjection.collection` when configured. This preserves existing collection names during migration.
+Reference-only documents remain in the normal resolved document collection: the resolved logical Model name
+(`UserPreferences` in this example), or the explicit `DocumentProjection.collection` when configured. This preserves
+existing collection names during migration.
 Without a separate Graph role they contain no text summary/reversary, facets or sortables, and
 `Fluxzero.search(UserPreferences.class)` does not expose them. They can still be reached through their Model ID, an
 alias or an exact parent/ancestor ID; these routes use the durable Model identity and relationship indexes. When the
@@ -3530,8 +3551,9 @@ public record User(@EntityId UserId userId, String name) {
 direct Model collection. Add `DOCUMENT` to an event-sourced Model only when callers should also be able to search its
 current state directly. Select document-only persistence when that document should be authoritative; set
 `document.searchable = false` when it should remain reference-only. Use `document = @DocumentProjection(...)` or
-`graphProjection = @GraphProjection(...)` only for advanced configuration. The graph collection is `User-graphs` by
-default; for a root with a direct document Fluxzero appends `-graphs` to the resolved direct collection. Set
+`graphProjection = @GraphProjection(...)` only for advanced configuration. The graph collection uses the resolved
+logical Model name (`User-graphs` by default); for a root with a direct document Fluxzero appends `-graphs` to the
+resolved direct collection. Set
 `GraphProjection.collection` only when a custom durable name is needed. Projection is asynchronous unless completion
 is explicitly configured otherwise. Both live and materialized composition follow the complete finite graph by
 default; lower-level `ModelGraphComposition` maxima are optional advanced guardrails and use `UNBOUNDED` (`-1`) when
@@ -4837,7 +4859,7 @@ annotations that own automatic indexing:
 
 Adding `DOCUMENT` enables automatic document maintenance after updates without needing to call
 `Fluxzero.index(...)` manually. Every direct document uses its resolved collection, which defaults to the Model's
-simple class name and may be overridden through `DocumentProjection.collection`. Its `searchable` setting determines
+resolved logical Model name and may be overridden through `DocumentProjection.collection`. Its `searchable` setting determines
 whether unrestricted typed Model search exposes that collection. When it is `false`, a document without a separate
 Graph role is stored without summary/reversary, facets or sortables; a Graph-component role retains only its
 independently required indexes.
@@ -4851,7 +4873,7 @@ public record UserAccount(@EntityId UserId userId,
 }
 ```
 
-By default, the collection name is derived from the class’s **simple name** (UserAccount → `"UserAccount"`),
+By default, the collection name is derived from the Model's **resolved logical name** (UserAccount → `"UserAccount"`),
 unless explicitly overridden through `Model.document`, `@Stateful`, `@Searchable` or in the search/index call:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -3297,8 +3297,12 @@ public record UserPreferences(
 }
 ```
 
-Reference-only documents use the same type-isolated private Model storage as Graph components. They remain durable and
-directly loadable, but `Fluxzero.search(UserPreferences.class)` does not expose them.
+Reference-only documents remain durable and directly loadable, but contain no text summary/reversary, facets or
+sortables. `Fluxzero.search(UserPreferences.class)` therefore does not expose them. They can still be reached through
+their Model ID, an alias or an exact parent/ancestor ID; these routes use the separate durable Model identity and
+relationship indexes. When the same Model independently participates in Graph composition, its private current
+document keeps the internal indexes required by content-based Graph and relationship queries without becoming publicly
+searchable. Use `@SearchExclude`, `@Facet` and `@Sortable` to shape those internal indexes explicitly.
 
 Event-sourcing-only settings such as `ignoreUnknownEvents`, `snapshotPeriod`, `maxSnapshotCount` and
 `checkpointPeriod` are rejected on `DOCUMENT` Models instead of being silently ignored.
@@ -3423,7 +3427,8 @@ List<Task> activeProjectTasks = Fluxzero.search(Task.class)
 
 This form first searches the related Model's own current-document collection and then traverses the matching IDs. A
 public direct document is not required: an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true`
-maintains a type-isolated private current document that can supply the predicate. The materialized whole-Graph
+maintains a type-isolated internal component document that can supply the predicate. A reference-only `DOCUMENT`
+projection without such a Graph role contributes no summary, facet or sortable indexes. The materialized whole-Graph
 projection is not used as a substitute for the related Model's own fields.
 
 The returned target also needs a current document because `Search` returns current documents. That may be a public
@@ -4829,7 +4834,9 @@ annotations that own automatic indexing:
 
 Adding `DOCUMENT` enables automatic document maintenance after updates without needing to call
 `Fluxzero.index(...)` manually. Its `DocumentProjection.searchable` setting determines whether that document is placed
-in the public Model collection or retained in type-isolated private storage.
+in the public Model collection with its derived search indexes, or kept out of unrestricted Model search. In the latter
+case a document without a separate Graph role is stored reference-only, without summary/reversary, facets or sortables;
+an internal Graph-component role retains only the independently required private indexes.
 
 ```java
 

--- a/README.md
+++ b/README.md
@@ -3297,12 +3297,14 @@ public record UserPreferences(
 }
 ```
 
-Reference-only documents remain durable and directly loadable, but contain no text summary/reversary, facets or
-sortables. `Fluxzero.search(UserPreferences.class)` therefore does not expose them. They can still be reached through
-their Model ID, an alias or an exact parent/ancestor ID; these routes use the separate durable Model identity and
-relationship indexes. When the same Model independently participates in Graph composition, its private current
-document keeps the internal indexes required by content-based Graph and relationship queries without becoming publicly
-searchable. Use `@SearchExclude`, `@Facet` and `@Sortable` to shape those internal indexes explicitly.
+Reference-only documents remain in the normal resolved document collection: `UserPreferences` in this example, or the
+explicit `DocumentProjection.collection` when configured. This preserves existing collection names during migration.
+Without a separate Graph role they contain no text summary/reversary, facets or sortables, and
+`Fluxzero.search(UserPreferences.class)` does not expose them. They can still be reached through their Model ID, an
+alias or an exact parent/ancestor ID; these routes use the durable Model identity and relationship indexes. When the
+same Model independently participates in Graph composition, its current component document keeps the indexes required
+by content-based Graph and relationship queries without becoming publicly searchable. Use `@SearchExclude`, `@Facet`
+and `@Sortable` to shape those internal indexes explicitly.
 
 Event-sourcing-only settings such as `ignoreUnknownEvents`, `snapshotPeriod`, `maxSnapshotCount` and
 `checkpointPeriod` are rejected on `DOCUMENT` Models instead of being silently ignored.
@@ -3427,9 +3429,10 @@ List<Task> activeProjectTasks = Fluxzero.search(Task.class)
 
 This form first searches the related Model's own current-document collection and then traverses the matching IDs. A
 public direct document is not required: an explicit `@Parent(pathInParent = "...")` or `materializeGraph = true`
-maintains a type-isolated internal component document that can supply the predicate. A reference-only `DOCUMENT`
-projection without such a Graph role contributes no summary, facet or sortable indexes. The materialized whole-Graph
-projection is not used as a substitute for the related Model's own fields.
+maintains a component document that can supply the predicate. It uses the direct document's resolved collection when
+`DOCUMENT` is configured, and otherwise a type-isolated internal collection. A reference-only `DOCUMENT` projection
+without such a Graph role contributes no summary, facet or sortable indexes. The materialized whole-Graph projection
+is not used as a substitute for the related Model's own fields.
 
 The returned target also needs a current document because `Search` returns current documents. That may be a public
 `DOCUMENT` projection or a private document maintained for Graph participation; adding a relationship selector makes
@@ -4833,10 +4836,11 @@ annotations that own automatic indexing:
 - Directly annotate any POJO with `@Searchable`
 
 Adding `DOCUMENT` enables automatic document maintenance after updates without needing to call
-`Fluxzero.index(...)` manually. Its `DocumentProjection.searchable` setting determines whether that document is placed
-in the public Model collection with its derived search indexes, or kept out of unrestricted Model search. In the latter
-case a document without a separate Graph role is stored reference-only, without summary/reversary, facets or sortables;
-an internal Graph-component role retains only the independently required private indexes.
+`Fluxzero.index(...)` manually. Every direct document uses its resolved collection, which defaults to the Model's
+simple class name and may be overridden through `DocumentProjection.collection`. Its `searchable` setting determines
+whether unrestricted typed Model search exposes that collection. When it is `false`, a document without a separate
+Graph role is stored without summary/reversary, facets or sortables; a Graph-component role retains only its
+independently required indexes.
 
 ```java
 

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelChangeTarget.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelChangeTarget.java
@@ -21,6 +21,9 @@ import lombok.Value;
 /** One model identity changed by a durable model-commit substep. */
 @Value
 public class ModelChangeTarget {
+    /** Exact persisted Model identity. */
     String modelId;
+
+    /** Stable application-scoped logical Model name, or {@code null} for an untyped effect. */
     String modelType;
 }

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelCommitTarget.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelCommitTarget.java
@@ -39,10 +39,11 @@ public class ModelCommitTarget {
     String modelId;
 
     /**
-     * Stable serialized model type descriptor. A model's first commit that creates its durable head must provide this
+     * Stable application-scoped logical Model name. A model's first commit that creates its durable head must provide this
      * value; later commits may omit it and inherit the durable type.
      * <p>
-     * This is coordination metadata for untyped and graph loads; it is not part of model identity.
+     * This is coordination metadata for untyped and graph loads; it is independent from the serializer payload type
+     * and is not part of model identity.
      */
     String modelType;
 

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
@@ -34,10 +34,6 @@ public class ModelDocumentMutation {
     public static final String PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX =
             "$modelGraphComponents/";
 
-    /** Prefix for type-isolated reference-only current-Model collections. */
-    public static final String REFERENCE_MODEL_DOCUMENT_COLLECTION_PREFIX =
-            "$modelDocuments/";
-
     /**
      * Returns the private search collection for current documents of one Model type.
      * <p>
@@ -48,17 +44,6 @@ public class ModelDocumentMutation {
     public static String privateModelDocumentCollection(String modelType) {
         return collectionForModelType(
                 PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX, modelType);
-    }
-
-    /**
-     * Returns the private retrieval collection for a reference-only document of one Model type.
-     * <p>
-     * This collection is distinct from internal Graph-component collections so a Model that has no Graph search role
-     * does not accidentally acquire or expose derived search indexes.
-     */
-    public static String referenceModelDocumentCollection(String modelType) {
-        return collectionForModelType(
-                REFERENCE_MODEL_DOCUMENT_COLLECTION_PREFIX, modelType);
     }
 
     private static String collectionForModelType(
@@ -79,8 +64,8 @@ public class ModelDocumentMutation {
             "$modelMigrationDocuments";
 
     /**
-     * Current-document collection. This is either the independently searchable Model collection or an internal,
-     * type-isolated current-Model collection.
+     * Current-document collection. A direct Model document uses its configured collection; a Model that only supplies
+     * a Graph component uses an internal, type-isolated collection.
      */
     String collection;
 

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
@@ -30,9 +30,13 @@ import java.util.Objects;
 @Value
 public class ModelDocumentMutation {
 
-    /** Prefix for type-isolated internal current-Model collections. */
+    /** Prefix for type-isolated internal Graph-component collections. */
     public static final String PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX =
             "$modelGraphComponents/";
+
+    /** Prefix for type-isolated reference-only current-Model collections. */
+    public static final String REFERENCE_MODEL_DOCUMENT_COLLECTION_PREFIX =
+            "$modelDocuments/";
 
     /**
      * Returns the private search collection for current documents of one Model type.
@@ -42,12 +46,29 @@ public class ModelDocumentMutation {
      * contract and keeps the collection deterministic across SDK instances.
      */
     public static String privateModelDocumentCollection(String modelType) {
+        return collectionForModelType(
+                PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX, modelType);
+    }
+
+    /**
+     * Returns the private retrieval collection for a reference-only document of one Model type.
+     * <p>
+     * This collection is distinct from internal Graph-component collections so a Model that has no Graph search role
+     * does not accidentally acquire or expose derived search indexes.
+     */
+    public static String referenceModelDocumentCollection(String modelType) {
+        return collectionForModelType(
+                REFERENCE_MODEL_DOCUMENT_COLLECTION_PREFIX, modelType);
+    }
+
+    private static String collectionForModelType(
+            String prefix, String modelType) {
         Objects.requireNonNull(modelType, "Model type");
         if (modelType.isBlank() || !modelType.equals(modelType.trim())) {
             throw new IllegalArgumentException(
                     "Model type must not be blank or have surrounding whitespace");
         }
-        return PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX + modelType;
+        return prefix + modelType;
     }
 
     /**

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelDocumentMutation.java
@@ -38,8 +38,8 @@ public class ModelDocumentMutation {
      * Returns the private search collection for current documents of one Model type.
      * <p>
      * Type isolation lets direct lookup, relationship search and Graph composition use ordinary document indexes
-     * without scanning or mixing unrelated Model types. The complete Model type name is already part of the persisted
-     * contract and keeps the collection deterministic across SDK instances.
+     * without scanning or mixing unrelated Model types. The logical Model name is already part of the persisted
+     * contract and keeps the collection deterministic across SDK instances and Java class/package renames.
      */
     public static String privateModelDocumentCollection(String modelType) {
         return collectionForModelType(

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelGraphEdge.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelGraphEdge.java
@@ -26,6 +26,8 @@ import lombok.Value;
 public class ModelGraphEdge {
     String childId;
     String parentId;
+
+    /** Stable application-scoped logical parent Model name, or {@code null} when unknown. */
     String parentType;
     String path;
     long validFrom;

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelGraphProjectionConfiguration.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelGraphProjectionConfiguration.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 public class ModelGraphProjectionConfiguration {
 
     /**
-     * Stable serialized type descriptor of projection roots.
+     * Stable application-scoped logical Model name of projection roots.
      */
     String rootModelType;
 
@@ -56,7 +56,7 @@ public class ModelGraphProjectionConfiguration {
     ModelGraphComposition composition;
 
     /**
-     * Types that can occur in this projection and the revision of their direct document schema.
+     * Logical Model names that can occur in this projection and the revision of their direct document schema.
      * <p>
      * The ordered list is part of the durable projection definition. Changing any participating model revision
      * therefore advances the Runtime's existing configuration fence and triggers a complete rebuild.

--- a/common/src/main/java/io/fluxzero/common/api/modeling/ModelRelationship.java
+++ b/common/src/main/java/io/fluxzero/common/api/modeling/ModelRelationship.java
@@ -37,7 +37,7 @@ public class ModelRelationship {
     String parentId;
 
     /**
-     * Parent model class/type name when statically known, otherwise {@code null}.
+     * Stable application-scoped logical parent Model name when statically known, otherwise {@code null}.
      */
     String parentType;
 

--- a/common/src/main/java/io/fluxzero/common/api/search/SerializedDocument.java
+++ b/common/src/main/java/io/fluxzero/common/api/search/SerializedDocument.java
@@ -207,6 +207,26 @@ public class SerializedDocument {
     }
 
     /**
+     * Returns a retrieval-only view that preserves the complete serialized payload and document identity while
+     * discarding all derived search data.
+     * <p>
+     * The returned document has no text summary, facets or sortable indexes. Its entries and metadata remain available
+     * for deserialization, including through a custom document serializer.
+     */
+    public SerializedDocument withoutSearchIndexes() {
+        Supplier<Document> retrievalDocument = memoize(() -> deserializeDocument()
+                .toBuilder()
+                .summary(() -> null)
+                .facets(Collections.emptySet())
+                .sortables(Collections.emptySet())
+                .build());
+        return new SerializedDocument(
+                id, timestamp, end, collection, data,
+                retrievalDocument, null,
+                Collections.emptySet(), Collections.emptySet());
+    }
+
+    /**
      * Returns the deserialized document view.
      */
     public Document deserializeDocument() {

--- a/common/src/main/java/io/fluxzero/common/search/ModelGraphDocumentManifest.java
+++ b/common/src/main/java/io/fluxzero/common/search/ModelGraphDocumentManifest.java
@@ -30,18 +30,21 @@ import java.util.Optional;
  * Hidden structural description carried by a composed independent-model graph document.
  * <p>
  * The visible document remains ordinary nested JSON. This compact, dictionary-encoded manifest preserves exact node
- * identities, concrete types, revisions and placements so SDK clients can reconstruct and independently upcast a
- * typed lazy graph without guessing schema information from JSON paths. Parent nodes always precede their children.
+ * identities, logical Model names, serializer payload types, revisions and placements so SDK clients can reconstruct
+ * and independently upcast a typed lazy graph without guessing schema information from JSON paths. Parent nodes
+ * always precede their children. Logical names deliberately remain separate from serializer types so a Java
+ * class/package rename does not change durable Model identity.
  */
 public record ModelGraphDocumentManifest(
         @JsonProperty("v") int version,
         @JsonProperty("s") long stateIndex,
+        @JsonProperty("m") List<String> modelTypes,
         @JsonProperty("t") List<String> types,
         @JsonProperty("r") List<String> relationshipPaths,
         @JsonProperty("n") List<Node> nodes) {
 
     /** Current manifest format version. */
-    public static final int CURRENT_VERSION = 2;
+    public static final int CURRENT_VERSION = 3;
 
     /** Reserved document-metadata key containing the manifest. */
     public static final String METADATA_KEY = "$fluxzeroModelGraph";
@@ -57,10 +60,11 @@ public record ModelGraphDocumentManifest(
 
     public ModelGraphDocumentManifest(
             long stateIndex,
+            List<String> modelTypes,
             List<String> types,
             List<String> relationshipPaths,
             List<Node> nodes) {
-        this(CURRENT_VERSION, stateIndex, types,
+        this(CURRENT_VERSION, stateIndex, modelTypes, types,
              relationshipPaths, nodes);
     }
 
@@ -69,9 +73,15 @@ public record ModelGraphDocumentManifest(
             throw new IllegalArgumentException(
                     "Unsupported model graph manifest version " + version);
         }
+        modelTypes = List.copyOf(modelTypes);
         types = List.copyOf(types);
         relationshipPaths = List.copyOf(relationshipPaths);
         nodes = List.copyOf(nodes);
+        if (modelTypes.stream().anyMatch(type -> type == null || type.isBlank())
+            || modelTypes.stream().distinct().count() != modelTypes.size()) {
+            throw new IllegalArgumentException(
+                    "Model graph manifest Model types must be unique and non-blank");
+        }
         if (types.stream().anyMatch(type -> type == null || type.isBlank())
             || types.stream().distinct().count() != types.size()) {
             throw new IllegalArgumentException(
@@ -92,6 +102,10 @@ public record ModelGraphDocumentManifest(
         }
         for (int index = 0; index < nodes.size(); index++) {
             Node node = nodes.get(index);
+            if (node.modelType() < 0 || node.modelType() >= modelTypes.size()) {
+                throw new IllegalArgumentException(
+                        "Invalid model graph manifest Model type index " + node.modelType());
+            }
             if (node.type() < 0 || node.type() >= types.size()) {
                 throw new IllegalArgumentException(
                         "Invalid model graph manifest type index " + node.type());
@@ -114,9 +128,14 @@ public record ModelGraphDocumentManifest(
         }
     }
 
-    /** Returns the concrete class name referenced by a node. */
+    /** Returns the serializer payload type referenced by a node. */
     public String type(Node node) {
         return types.get(node.type());
+    }
+
+    /** Returns the stable logical Model name referenced by a node. */
+    public String modelType(Node node) {
+        return modelTypes.get(node.modelType());
     }
 
     /** Returns the relationship path referenced by a non-root node. */
@@ -167,6 +186,7 @@ public record ModelGraphDocumentManifest(
      */
     public record Node(
             @JsonProperty("i") String id,
+            @JsonProperty("m") int modelType,
             @JsonProperty("t") int type,
             @JsonProperty("v") int revision,
             @JsonProperty("p") int parent,

--- a/common/src/main/java/io/fluxzero/common/search/ModelGraphDocumentStitcher.java
+++ b/common/src/main/java/io/fluxzero/common/search/ModelGraphDocumentStitcher.java
@@ -62,8 +62,9 @@ public final class ModelGraphDocumentStitcher {
             List<SerializedDocument> roots,
             Collection<ModelGraphEdge> edges,
             Map<String, SerializedDocument> documents,
+            Map<String, String> modelTypes,
             ModelGraphComposition composition) {
-        return stitch(roots, edges, documents, composition, -1L);
+        return stitch(roots, edges, documents, modelTypes, composition, -1L);
     }
 
     /**
@@ -73,11 +74,13 @@ public final class ModelGraphDocumentStitcher {
             List<SerializedDocument> roots,
             Collection<ModelGraphEdge> edges,
             Map<String, SerializedDocument> documents,
+            Map<String, String> modelTypes,
             ModelGraphComposition composition,
             long stateIndex) {
         Objects.requireNonNull(roots, "Root documents");
         Objects.requireNonNull(edges, "Model graph edges");
         Objects.requireNonNull(documents, "Model documents");
+        Objects.requireNonNull(modelTypes, "Model types");
         Objects.requireNonNull(
                 composition, "Model graph composition");
 
@@ -113,7 +116,7 @@ public final class ModelGraphDocumentStitcher {
                     root.getId(),
                     rootDocument,
                     -1, null, 0,
-                    children, documents, bounds, manifest, 0,
+                    children, documents, modelTypes, bounds, manifest, 0,
                     new LinkedHashSet<>());
             composed = withManifest(
                     composed, manifest.build());
@@ -226,6 +229,7 @@ public final class ModelGraphDocumentStitcher {
             int ordinal,
             Map<String, List<ModelGraphEdge>> children,
             Map<String, SerializedDocument> documents,
+            Map<String, String> modelTypes,
             Bounds bounds,
             ManifestBuilder manifest,
             int depth,
@@ -241,7 +245,9 @@ public final class ModelGraphDocumentStitcher {
             Document direct =
                     serialized.deserializeDocument();
             int nodeIndex = manifest.add(
-                    modelId, direct.getType(), direct.getRevision(), parent,
+                    modelId, Objects.requireNonNull(modelTypes.get(modelId),
+                            () -> "No logical Model type is available for " + modelId),
+                    direct.getType(), direct.getRevision(), parent,
                     relationshipPath, ordinal);
             Map<String, List<ModelGraphEdge>> byPath =
                     new LinkedHashMap<>();
@@ -308,7 +314,7 @@ public final class ModelGraphDocumentStitcher {
                     Document childDocument = compose(
                             edge.getChildId(), child,
                             nodeIndex, path, childOrdinal,
-                            children, documents, bounds, manifest,
+                            children, documents, modelTypes, bounds, manifest,
                             depth + 1, ancestry);
                     String prefix =
                             path + "/" + childOrdinal++;
@@ -477,6 +483,9 @@ public final class ModelGraphDocumentStitcher {
 
     private static final class ManifestBuilder {
         private final long stateIndex;
+        private final List<String> modelTypes = new ArrayList<>();
+        private final Map<String, Integer> modelTypeIndexes =
+                new LinkedHashMap<>();
         private final List<String> types = new ArrayList<>();
         private final Map<String, Integer> typeIndexes =
                 new LinkedHashMap<>();
@@ -491,20 +500,21 @@ public final class ModelGraphDocumentStitcher {
         }
 
         private int add(
-                String modelId, String type, int revision, int parent,
+                String modelId, String modelType, String type, int revision, int parent,
                 String relationshipPath, int ordinal) {
             int nodeIndex = nodes.size();
+            int modelTypeIndex = index(modelType, modelTypes, modelTypeIndexes);
             int typeIndex = index(type, types, typeIndexes);
             int pathIndex = relationshipPath == null ? -1
                     : index(relationshipPath, paths, pathIndexes);
             nodes.add(new ModelGraphDocumentManifest.Node(
-                    modelId, typeIndex, revision, parent, pathIndex, ordinal));
+                    modelId, modelTypeIndex, typeIndex, revision, parent, pathIndex, ordinal));
             return nodeIndex;
         }
 
         private ModelGraphDocumentManifest build() {
             return new ModelGraphDocumentManifest(
-                    stateIndex, types, paths, nodes);
+                    stateIndex, modelTypes, types, paths, nodes);
         }
 
         private static int index(

--- a/common/src/test/java/io/fluxzero/common/search/ModelGraphDocumentStitcherTest.java
+++ b/common/src/test/java/io/fluxzero/common/search/ModelGraphDocumentStitcherTest.java
@@ -88,6 +88,7 @@ class ModelGraphDocumentStitcherTest {
                                                 "child-a",
                                                 "details")),
                                 documents,
+                                modelTypes("root", "child-a", "child-b", "grandchild"),
                                 ModelGraphComposition
                                         .builder()
                                         .build())
@@ -136,6 +137,7 @@ class ModelGraphDocumentStitcherTest {
         Document result = ModelGraphDocumentStitcher.stitch(
                         List.of(root), List.of(edge("child", "root", "children")),
                         Map.of("root", root, "child", child),
+                        modelTypes("root", "child"),
                         ModelGraphComposition.builder().build())
                 .getFirst().deserializeDocument();
 
@@ -167,6 +169,7 @@ class ModelGraphDocumentStitcherTest {
                                         edge("shared", "child", "details")),
                                 Map.of("root", root, "child", child,
                                        "shared", shared),
+                                Map.of("root", "Root", "child", "Child", "shared", "Detail"),
                                 ModelGraphComposition.builder().build(),
                                 42L)
                         .getFirst();
@@ -180,17 +183,19 @@ class ModelGraphDocumentStitcherTest {
         assertEquals(List.of("example.Root", "example.Child",
                              "example.Detail"),
                      manifest.types());
+        assertEquals(List.of("Root", "Child", "Detail"),
+                     manifest.modelTypes());
         assertEquals(List.of("children", "details"),
                      manifest.relationshipPaths());
         assertEquals(List.of(
                 new ModelGraphDocumentManifest.Node(
-                        "root", 0, 1, -1, -1, 0),
+                        "root", 0, 0, 1, -1, -1, 0),
                 new ModelGraphDocumentManifest.Node(
-                        "child", 1, 2, 0, 0, 0),
+                        "child", 1, 1, 2, 0, 0, 0),
                 new ModelGraphDocumentManifest.Node(
-                        "shared", 2, 3, 1, 1, 0),
+                        "shared", 2, 2, 3, 1, 1, 0),
                 new ModelGraphDocumentManifest.Node(
-                        "shared", 2, 3, 0, 1, 0)),
+                        "shared", 2, 2, 3, 0, 1, 0)),
                      manifest.nodes());
         assertTrue(stitched.deserializeDocument()
                            .getMatchingEntries(path ->
@@ -213,6 +218,7 @@ class ModelGraphDocumentStitcherTest {
                         List.of(root),
                         List.of(edge("child", "root", "children")),
                         Map.of("child", child),
+                        Map.of("root", "Root", "child", "Child"),
                         ModelGraphComposition.builder().build(),
                         12L)
                 .getFirst();
@@ -262,6 +268,7 @@ class ModelGraphDocumentStitcherTest {
                                         "child-b", document(
                                                 "child-b", "secondType",
                                                 "name", "B")),
+                                modelTypes("root", "child-a", "child-b"),
                                 ModelGraphComposition.builder()
                                         .build())
                         .getFirst()
@@ -292,6 +299,7 @@ class ModelGraphDocumentStitcherTest {
                         List.of(edge("child", "root", "children"),
                                 edge("grandchild", "child", "grandchildren")),
                         Map.of("root", root, "child", child, "grandchild", grandchild),
+                        modelTypes("root", "child", "grandchild"),
                         ModelGraphComposition.builder().maxDepth(1).build()));
 
         assertTrue(failure.getMessage().contains("maxDepth 1"));
@@ -311,6 +319,7 @@ class ModelGraphDocumentStitcherTest {
                         List.of(edge("child", "root", "children"),
                                 edge("root", "child", "parent")),
                         Map.of("root", root, "child", child),
+                        modelTypes("root", "child"),
                         ModelGraphComposition.builder().build()));
 
         assertTrue(failure.getMessage().contains("cycle at root"));
@@ -370,6 +379,7 @@ class ModelGraphDocumentStitcherTest {
                                 Map.of(
                                         "root", root,
                                         "child", child),
+                                modelTypes("root", "child"),
                                 ModelGraphComposition
                                         .builder()
                                         .build())
@@ -407,6 +417,7 @@ class ModelGraphDocumentStitcherTest {
                                         "root",
                                         directCollision,
                                         "child", child),
+                                modelTypes("root", "child"),
                                 ModelGraphComposition
                                         .builder()
                                         .build()));
@@ -437,6 +448,7 @@ class ModelGraphDocumentStitcherTest {
                                                 "children",
                                                 "name",
                                                 "other")),
+                                modelTypes("root", "child", "other"),
                                 ModelGraphComposition
                                         .builder()
                                         .build()));
@@ -476,6 +488,7 @@ class ModelGraphDocumentStitcherTest {
                                         "root-b",
                                         secondRoot,
                                         "shared", shared),
+                                modelTypes("root-a", "root-b", "shared"),
                                 ModelGraphComposition
                                         .builder()
                                         .maxPlacements(1)
@@ -504,6 +517,7 @@ class ModelGraphDocumentStitcherTest {
                                         Map.of(
                                                 "root",
                                                 oversized),
+                                        modelTypes("root"),
                                         ModelGraphComposition
                                                 .builder()
                                                 .maxBytes(100L)
@@ -524,6 +538,7 @@ class ModelGraphDocumentStitcherTest {
                                 List.of(root),
                                 List.of(),
                                 Map.of("root", root),
+                                modelTypes("root"),
                                 ModelGraphComposition.builder()
                                         .build())
                         .getFirst().bytes();
@@ -539,6 +554,7 @@ class ModelGraphDocumentStitcherTest {
                                         List.of(),
                                         Map.of(
                                                 "root", root),
+                                        modelTypes("root"),
                                         ModelGraphComposition
                                                 .builder()
                                                 .maxBytes(
@@ -577,6 +593,12 @@ class ModelGraphDocumentStitcherTest {
                                 "rank", "sortable")))
                 .build();
         return new SerializedDocument(document);
+    }
+
+    private static Map<String, String> modelTypes(String... modelIds) {
+        return java.util.Arrays.stream(modelIds).collect(
+                java.util.stream.Collectors.toUnmodifiableMap(
+                        id -> id, id -> "Model-" + id));
     }
 
     private static SerializedDocument typedDocument(

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -87,9 +87,11 @@ record UserPreferences(
 }
 ```
 
-Fluxzero keeps this value in a type-isolated private Model collection. Identity and alias loads, parent relationships
-and Graph composition still use it; `Fluxzero.search(UserPreferences.class)` does not expose it. A custom public
-collection is consequently invalid for a reference-only projection.
+Fluxzero keeps this value in its normal resolved collection, which defaults to `UserPreferences`; an explicitly
+configured `DocumentProjection.collection` is also valid. Keeping that collection stable makes an existing document
+collection directly usable during migration. Identity and alias loads, parent relationships and Graph composition still
+use it, while `Fluxzero.search(UserPreferences.class)` does not expose it. Without a separate Graph role Fluxzero omits
+the summary/reversary, facets and sortables from the stored document.
 
 ## Event storage and publication
 

--- a/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
+++ b/docs/developer/guides/Modeling & persistence/220-document-index-and-search.mdx
@@ -119,8 +119,9 @@ settings themselves:
   </TabItem>
 </Tabs>
 
-The document is placed in the public Model collection by default. A document-authoritative Model that only needs
-identity-, alias-, relationship- and Graph-based lookup can keep it reference-only:
+The document uses the resolved Model collection and is exposed to unrestricted typed Model search by default. A
+document-authoritative Model that only needs identity-, alias-, relationship- and Graph-based lookup can keep it
+reference-only:
 
 <Tabs>
   <TabItem label="Java">
@@ -147,8 +148,11 @@ identity-, alias-, relationship- and Graph-based lookup can keep it reference-on
   </TabItem>
 </Tabs>
 
-Fluxzero stores this document in a type-isolated private Model collection. `loadModel(...)`, aliases, parent
-relationships and Graph composition still use it, while `Fluxzero.search(UserPreferences.class)` does not expose it.
+Fluxzero stores this document in its normal resolved collection, which defaults to `UserPreferences` and can be
+overridden with `DocumentProjection.collection`. This keeps existing collection names usable during migration.
+`loadModel(...)`, aliases, parent relationships and Graph composition still use it, while
+`Fluxzero.search(UserPreferences.class)` does not expose it. Without a separate Graph role the stored document has no
+summary/reversary, facets or sortables.
 
 ---
 
@@ -255,10 +259,10 @@ List<Task> activeProjectTasks = Fluxzero.search(Task.class)
         .fetch(100);
 ```
 
-This form requires a current document for the related Model. It may be a public direct document or the type-isolated
-private document maintained because the Model has an explicit `@Parent(pathInParent = "...")` or
-`materializeGraph = true`. The predicate applies to that Model's own fields, not to fields nested only in a materialized
-whole-Graph projection.
+This form requires a current document for the related Model. A direct `DOCUMENT` uses its resolved collection,
+irrespective of public search visibility. Without a direct document, an explicit
+`@Parent(pathInParent = "...")` or `materializeGraph = true` maintains a type-isolated private component document. The
+predicate applies to that Model's own fields, not to fields nested only in a materialized whole-Graph projection.
 
 The returned target also needs a current document. A public `DOCUMENT` projection works, and a private Graph-component
 document becomes available only because the query is explicitly relation-bounded; ordinary typed search still does not

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -34,6 +34,10 @@ definitions unless the user asks for them.
 
 Important settings:
 
+- `name`: durable logical Model type name; defaults to the concrete class's simple name. Keep an explicit value stable
+  across Java class/package renames. It is separate from serializer payload types and has no aliases or FQN fallback.
+  `fluxzero.model.namePrefix` is prepended literally for applications sharing a namespace (`billing` + `Invoice` =
+  `billingInvoice`). Changing either value after data exists requires an application-managed data transition.
 - `persistence`: selects a non-empty set of durable representations:
   - `{EVENT_SOURCED}` (default): reconstruct from Model events, without a direct document.
   - `{EVENT_SOURCED, DOCUMENT}`: reconstruct from events and also maintain a current document.
@@ -52,7 +56,7 @@ Important settings:
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `@GraphProjection` configuration; its collection defaults to the resolved direct
-  Model collection plus `-graphs` when a direct document exists, or `<simple model name>-graphs` otherwise, and
+  Model collection plus `-graphs` when a direct document exists, or `<logical Model name>-graphs` otherwise, and
   materializes the complete finite graph without implicit size limits.
 
 Persistence does not control event storage or publication. Those remain owned by `eventPublication`,
@@ -439,7 +443,7 @@ Graph role its payload remains reference-loadable but its summary/reversary, fac
 Graph-component role retains its independently required indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
 `@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
-simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
+logical root-Model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy
 

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -419,24 +419,24 @@ List<Task> tasks = Fluxzero.search(Task.class)
 Use `.whereParent(projectId)` or `.whereAncestor(organisationId)` when the related typed ID is known. This traverses
 durable relationships directly and needs no parent or ancestor document. Use the ID-plus-Model-class overload for
 untyped functional IDs and a loaded `Graph` for parent-scoped identities. The returned target must still have either a
-public document or a private current document maintained for Graph participation; standalone event-sourced targets
+public document or a relation-scoped current component document maintained for Graph participation; standalone event-sourced targets
 without one should be loaded by ID.
 
 Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
 IDs must first be selected by current Model content. They use that Model's own public document or independently
-maintained internal Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
+maintained Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
 not add content, facet or sortable indexes. `materializeGraph = true` supplies an internal root document but does not
 make the whole Graph projection the related predicate source. Prefer
 `searchGraph(Root.class).whereDescendant(Child.class, constraint)` over a broad forced-live
 nested-path filter when the child type is known. Use
 `searchGraph(Root.class).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness. It
-reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
+reads a configured `@GraphProjection` by default and otherwise stitches the applicable current documents live;
 `searchGraph(Root.class, true)`
 forces live composition. Use `fetch(..., ObjectNode.class)` for explicit raw JSON. Enable materialization with
 `@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
 set `DocumentProjection.searchable = false` when that document must not be publicly searchable. Without a separate
 Graph role its payload remains reference-loadable but its summary/reversary, facets and sortables are not indexed. A
-Graph-component role retains its private indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
+Graph-component role retains its independently required indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
 `@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.

--- a/project-files/java/agents/rules/entities.md
+++ b/project-files/java/agents/rules/entities.md
@@ -423,16 +423,21 @@ public document or a private current document maintained for Graph participation
 without one should be loaded by ID.
 
 Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
-IDs must first be selected by current Model content. They use that Model's own public or type-isolated private current
-document; `materializeGraph = true` supplies a private root document but does not make the whole Graph projection the
-related predicate source. Prefer `searchGraph(Root.class).whereDescendant(Child.class, constraint)` over a broad forced-live
+IDs must first be selected by current Model content. They use that Model's own public document or independently
+maintained internal Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
+not add content, facet or sortable indexes. `materializeGraph = true` supplies an internal root document but does not
+make the whole Graph projection the related predicate source. Prefer
+`searchGraph(Root.class).whereDescendant(Child.class, constraint)` over a broad forced-live
 nested-path filter when the child type is known. Use
 `searchGraph(Root.class).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness. It
 reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 `searchGraph(Root.class, true)`
 forces live composition. Use `fetch(..., ObjectNode.class)` for explicit raw JSON. Enable materialization with
 `@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
-set `DocumentProjection.searchable = false` when that document is reference-only. A blank projection collection
+set `DocumentProjection.searchable = false` when that document must not be publicly searchable. Without a separate
+Graph role its payload remains reference-loadable but its summary/reversary, facets and sortables are not indexed. A
+Graph-component role retains its private indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
+`@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -71,9 +71,12 @@ public record ExternalDocument(...) {}
 ```
 [//]: # (@formatter:on)
 
-`DocumentProjection.searchable = false` keeps a Model document in private type-isolated storage. Direct Model loads,
-aliases, parent relations and Graph composition still work, while `Fluxzero.search(UserPreferences.class)` does not
-expose the document.
+`DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
+separate Graph role it uses private type-isolated reference-only storage: the payload remains available to the
+configured `DocumentSerializer`, but its summary/reversary, facets and sortables are empty. Direct Model loads, aliases
+and exact parent/ancestor-ID relations still work. If the same Model participates in Graph composition, its private
+current document retains the independently required internal indexes without becoming publicly searchable; shape those
+with `@SearchExclude`, `@Facet` and `@Sortable`.
 
 <a name="facets-sorting"></a>
 
@@ -160,8 +163,10 @@ The ID overload starts from durable relationships and does not require a documen
 parent-scoped identity. Depth-bounded overloads support exact grandparents and further traversal.
 
 Use the class-and-constraint overload when IDs must be selected by related Model content. It requires that related
-Model's own public or private current document; an explicit composition path or `materializeGraph = true` supplies a
-private one, while the whole materialized Graph projection is not searched as the Model itself. The returned target
+Model's own public document or independently maintained internal Graph-component document; an explicit composition
+path or `materializeGraph = true` supplies the latter. A reference-only `DOCUMENT` projection without such a Graph role
+supplies no content, facet or sortable indexes. The whole materialized Graph projection is not searched as the Model
+itself. The returned target
 also needs a public document or relation-scoped private Graph-component document. A standalone event-sourced target
 without either is loaded by ID rather than searched.
 

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -72,7 +72,7 @@ public record ExternalDocument(...) {}
 [//]: # (@formatter:on)
 
 `DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
-separate Graph role it stays in the normal resolved collection—by default the simple Model name or the explicitly
+separate Graph role it stays in the normal resolved collection—by default the resolved logical Model name or the explicitly
 configured collection—but its summary/reversary, facets and sortables are empty. Keeping the collection stable supports
 adoption of existing documents. Direct Model loads, aliases and exact parent/ancestor-ID relations still work. If the
 same Model participates in Graph composition, its current component document retains the independently required

--- a/project-files/java/agents/rules/search.md
+++ b/project-files/java/agents/rules/search.md
@@ -72,11 +72,11 @@ public record ExternalDocument(...) {}
 [//]: # (@formatter:on)
 
 `DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
-separate Graph role it uses private type-isolated reference-only storage: the payload remains available to the
-configured `DocumentSerializer`, but its summary/reversary, facets and sortables are empty. Direct Model loads, aliases
-and exact parent/ancestor-ID relations still work. If the same Model participates in Graph composition, its private
-current document retains the independently required internal indexes without becoming publicly searchable; shape those
-with `@SearchExclude`, `@Facet` and `@Sortable`.
+separate Graph role it stays in the normal resolved collection—by default the simple Model name or the explicitly
+configured collection—but its summary/reversary, facets and sortables are empty. Keeping the collection stable supports
+adoption of existing documents. Direct Model loads, aliases and exact parent/ancestor-ID relations still work. If the
+same Model participates in Graph composition, its current component document retains the independently required
+indexes without becoming publicly searchable; shape those with `@SearchExclude`, `@Facet` and `@Sortable`.
 
 <a name="facets-sorting"></a>
 

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -392,24 +392,24 @@ val related = Fluxzero.search(Task::class.java)
 Use `.whereParent(projectId)` or `.whereAncestor(organisationId)` when the related typed ID is known. This traverses
 durable relationships directly and needs no parent or ancestor document. Use the ID-plus-Model-class overload for
 untyped functional IDs and a loaded `Graph` for parent-scoped identities. The returned target must still have either a
-public document or a private current document maintained for Graph participation; standalone event-sourced targets
+public document or a relation-scoped current component document maintained for Graph participation; standalone event-sourced targets
 without one should be loaded by ID.
 
 Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
 IDs must first be selected by current Model content. They use that Model's own public document or independently
-maintained internal Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
+maintained Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
 not add content, facet or sortable indexes. `materializeGraph = true` supplies an internal root document but does not
 make the whole Graph projection the related predicate source. Prefer
 `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` over a broad
 forced-live nested-path filter when the child type is known. Use
 `searchGraph(Root::class.java).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness.
-It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
+It reads a configured `@GraphProjection` by default and otherwise stitches the applicable current documents live;
 pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` for explicit raw
 JSON. Enable materialization with
 `@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
 set `DocumentProjection.searchable = false` when that document must not be publicly searchable. Without a separate
 Graph role its payload remains reference-loadable but its summary/reversary, facets and sortables are not indexed. A
-Graph-component role retains its private indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
+Graph-component role retains its independently required indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
 `@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -396,16 +396,21 @@ public document or a private current document maintained for Graph participation
 without one should be loaded by ID.
 
 Use the class-and-constraint `whereParent`, `whereAncestor`, `whereChild` and `whereDescendant` overloads when related
-IDs must first be selected by current Model content. They use that Model's own public or type-isolated private current
-document; `materializeGraph = true` supplies a private root document but does not make the whole Graph projection the
-related predicate source. Prefer `searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` over a broad
+IDs must first be selected by current Model content. They use that Model's own public document or independently
+maintained internal Graph-component document. A reference-only `DOCUMENT` projection without such a Graph role does
+not add content, facet or sortable indexes. `materializeGraph = true` supplies an internal root document but does not
+make the whole Graph projection the related predicate source. Prefer
+`searchGraph(Root::class.java).whereDescendant(Child::class.java, constraint)` over a broad
 forced-live nested-path filter when the child type is known. Use
 `searchGraph(Root::class.java).stream()` for complete typed lazy `Graph<Root>` results without a cast or type witness.
 It reads a configured `@GraphProjection` by default and otherwise stitches public or private current documents live;
 pass `true` as the second argument to force live composition. Use `fetch(..., ObjectNode::class.java)` for explicit raw
 JSON. Enable materialization with
 `@Model(materializeGraph = true)`. Include `DOCUMENT` separately only when the Model itself needs a current document;
-set `DocumentProjection.searchable = false` when that document is reference-only. A blank projection collection
+set `DocumentProjection.searchable = false` when that document must not be publicly searchable. Without a separate
+Graph role its payload remains reference-loadable but its summary/reversary, facets and sortables are not indexed. A
+Graph-component role retains its private indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
+`@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
 simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 

--- a/project-files/kotlin/agents/rules/entities.md
+++ b/project-files/kotlin/agents/rules/entities.md
@@ -34,6 +34,11 @@ definitions unless the user asks for them.
 
 Important settings:
 
+- `name`: durable logical Model type name; defaults to the concrete class's simple name. Keep an explicit value stable
+  across Java/Kotlin class or package renames. It is separate from serializer payload types and has no aliases or FQN
+  fallback. `fluxzero.model.namePrefix` is prepended literally for applications sharing a namespace (`billing` +
+  `Invoice` = `billingInvoice`). Changing either value after data exists requires an application-managed data
+  transition.
 - `persistence`: selects a non-empty set of durable representations:
   - `[EVENT_SOURCED]` (default): reconstruct from Model events, without a direct document.
   - `[EVENT_SOURCED, DOCUMENT]`: reconstruct from events and also maintain a current document.
@@ -52,7 +57,7 @@ Important settings:
 - `automaticHandling`: opt out when an explicit command handler must call `Fluxzero.assertAndApply`.
 - `materializeGraph`: enables the optional durable whole-tree read model.
 - `graphProjection`: optional advanced `GraphProjection` configuration; its collection defaults to the resolved direct
-  Model collection plus `-graphs` when a direct document exists, or `<simple model name>-graphs` otherwise, and
+  Model collection plus `-graphs` when a direct document exists, or `<logical Model name>-graphs` otherwise, and
   materializes the complete finite graph without implicit size limits.
 
 Persistence does not control event storage or publication. Those remain owned by `eventPublication`,
@@ -412,7 +417,7 @@ Graph role its payload remains reference-loadable but its summary/reversary, fac
 Graph-component role retains its independently required indexes; shape those explicitly with `@SearchExclude`, `@Facet` and
 `@Sortable`. A blank projection collection
 appends `-graphs` to the direct Model collection when one exists, or to the
-simple root-model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
+logical root-Model name otherwise; explicit lower-level composition limits fail rather than returning a partial graph.
 
 ## Conflict policy
 

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -72,7 +72,7 @@ data class ExternalDocument(...)
 ```
 
 `DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
-separate Graph role it stays in the normal resolved collection—by default the simple Model name or the explicitly
+separate Graph role it stays in the normal resolved collection—by default the resolved logical Model name or the explicitly
 configured collection—but its summary/reversary, facets and sortables are empty. Keeping the collection stable supports
 adoption of existing documents. Direct Model loads, aliases and exact parent/ancestor-ID relations still work. If the
 same Model participates in Graph composition, its current component document retains the independently required

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -72,11 +72,11 @@ data class ExternalDocument(...)
 ```
 
 `DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
-separate Graph role it uses private type-isolated reference-only storage: the payload remains available to the
-configured `DocumentSerializer`, but its summary/reversary, facets and sortables are empty. Direct Model loads, aliases
-and exact parent/ancestor-ID relations still work. If the same Model participates in Graph composition, its private
-current document retains the independently required internal indexes without becoming publicly searchable; shape those
-with `@SearchExclude`, `@Facet` and `@Sortable`.
+separate Graph role it stays in the normal resolved collection—by default the simple Model name or the explicitly
+configured collection—but its summary/reversary, facets and sortables are empty. Keeping the collection stable supports
+adoption of existing documents. Direct Model loads, aliases and exact parent/ancestor-ID relations still work. If the
+same Model participates in Graph composition, its current component document retains the independently required
+indexes without becoming publicly searchable; shape those with `@SearchExclude`, `@Facet` and `@Sortable`.
 
 <a name="facets-sorting"></a>
 

--- a/project-files/kotlin/agents/rules/search.md
+++ b/project-files/kotlin/agents/rules/search.md
@@ -71,9 +71,12 @@ data class UserPreferences(@EntityId val userId: UserId, ...)
 data class ExternalDocument(...)
 ```
 
-`DocumentProjection.searchable = false` keeps a Model document in private type-isolated storage. Direct Model loads,
-aliases, parent relations and Graph composition still work, while `Fluxzero.search(UserPreferences::class.java)` does
-not expose the document.
+`DocumentProjection.searchable = false` keeps a Model document out of unrestricted typed Model search. Without a
+separate Graph role it uses private type-isolated reference-only storage: the payload remains available to the
+configured `DocumentSerializer`, but its summary/reversary, facets and sortables are empty. Direct Model loads, aliases
+and exact parent/ancestor-ID relations still work. If the same Model participates in Graph composition, its private
+current document retains the independently required internal indexes without becoming publicly searchable; shape those
+with `@SearchExclude`, `@Facet` and `@Sortable`.
 
 <a name="facets-sorting"></a>
 
@@ -155,8 +158,10 @@ The ID overload starts from durable relationships and does not require a documen
 parent-scoped identity. Depth-bounded overloads support exact grandparents and further traversal.
 
 Use the class-and-constraint overload when IDs must be selected by related Model content. It requires that related
-Model's own public or private current document; an explicit composition path or `materializeGraph = true` supplies a
-private one, while the whole materialized Graph projection is not searched as the Model itself. The returned target
+Model's own public document or independently maintained internal Graph-component document; an explicit composition
+path or `materializeGraph = true` supplies the latter. A reference-only `DOCUMENT` projection without such a Graph role
+supplies no content, facet or sortable indexes. The whole materialized Graph projection is not searched as the Model
+itself. The returned target
 also needs a public document or relation-scoped private Graph-component document. A standalone event-sourced target
 without either is loaded by ID rather than searched.
 

--- a/sdk/src/main/java/io/fluxzero/sdk/common/ClientUtils.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/common/ClientUtils.java
@@ -485,8 +485,8 @@ public class ClientUtils {
     }
 
     /**
-     * Returns the effective {@link SearchParameters} for the given type, using the {@link Searchable} annotation.
-     * Defaults to a collection name matching the class’s simple name if not explicitly set.
+     * Returns the effective {@link SearchParameters} for the given type. Ordinary searchable documents default to the
+     * class's simple name; Models default to their resolved logical name.
      */
     public static SearchParameters getSearchParameters(Class<?> type) {
         return SearchParameters.forType(type);

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/ApplicationProperties.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/ApplicationProperties.java
@@ -76,6 +76,16 @@ public class ApplicationProperties {
      */
     public static final String APPLICATION_VERSION_PROPERTY = "fluxzero.application.version";
 
+    /**
+     * Optional literal prefix for every persisted logical {@code @Model} name in one application.
+     * <p>
+     * Fluxzero does not insert a separator. For example, prefix {@code billing} and Model name {@code Invoice}
+     * resolve to {@code billingInvoice}. Applications that share a Runtime namespace can use this to avoid Model-name
+     * collisions. Changing the prefix changes durable Model identity and requires an application-managed data
+     * transition.
+     */
+    public static final String MODEL_NAME_PREFIX_PROPERTY = "fluxzero.model.namePrefix";
+
     private static final DateTimeFormatter DEFAULTS_VERSION_FORMAT = DateTimeFormatter.ofPattern("uuuu.MM.dd");
 
     /**

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
@@ -1110,7 +1110,8 @@ public class DefaultFluxzero implements Fluxzero {
                             DOCUMENT, handlerChains, runtimeParameterResolvers, dispatchChains,
                             handlerRepositorySupplier,
                             repositorySupplier), dispatchChains.get(DOCUMENT), serializer)
-                            : HandlerRegistry.noOp()));
+                            : HandlerRegistry.noOp(),
+                    propertySource.get(ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY)));
             runtimeDocumentStore = documentStore.get();
 
             //event sourcing
@@ -1139,7 +1140,8 @@ public class DefaultFluxzero implements Fluxzero {
                             new DefaultEntityHelper(
                                     runtimeParameterResolvers, disablePayloadValidation),
                             snapshotSerializer, modelCache,
-                            runtimeParameterResolvers);
+                            runtimeParameterResolvers,
+                            propertySource.get(ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY));
             graphRepository.set(commandModelRepository);
             modelCommitHandlerRegistry = new ModelCommitHandlerRegistry(
                     commandModelRepository, client.getEventStoreClient(),

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
@@ -33,9 +33,12 @@ public @interface DocumentProjection {
     /**
      * Whether this current document is exposed through the Model's public search collection.
      * <p>
-     * When {@code false}, Fluxzero stores it in type-isolated private Model storage. It remains available to direct
-     * Model loads, aliases, parent relationships and Graph composition, but is not returned by an unrestricted typed
-     * Model search. An explicitly parent- or ancestor-bounded relationship search may return it within that scope.
+     * When {@code false}, Fluxzero does not expose the document through an unrestricted typed Model search. A Model
+     * without a separate Graph role is stored reference-only, without a text summary, facets or sortable indexes, and
+     * remains available through direct Model loads, aliases and exact parent or ancestor relationships. A Model that
+     * participates in Graph composition still maintains its independently required internal component indexes; use
+     * {@link io.fluxzero.common.search.SearchExclude @SearchExclude}, {@code @Facet} and {@code @Sortable} to shape
+     * those indexes explicitly.
      */
     boolean searchable() default true;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/DocumentProjection.java
@@ -33,10 +33,11 @@ public @interface DocumentProjection {
     /**
      * Whether this current document is exposed through the Model's public search collection.
      * <p>
-     * When {@code false}, Fluxzero does not expose the document through an unrestricted typed Model search. A Model
-     * without a separate Graph role is stored reference-only, without a text summary, facets or sortable indexes, and
-     * remains available through direct Model loads, aliases and exact parent or ancestor relationships. A Model that
-     * participates in Graph composition still maintains its independently required internal component indexes; use
+     * When {@code false}, Fluxzero does not expose the document through an unrestricted typed Model search. The direct
+     * document remains in {@link #collection() its normal resolved collection}. A Model without a separate Graph role
+     * is stored without a text summary, facets or sortable indexes and remains available through direct Model loads,
+     * aliases and exact parent or ancestor relationships. A Model that participates in Graph composition still
+     * maintains its independently required internal component indexes; use
      * {@link io.fluxzero.common.search.SearchExclude @SearchExclude}, {@code @Facet} and {@code @Sortable} to shape
      * those indexes explicitly.
      */

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
@@ -74,6 +74,7 @@ import static io.fluxzero.common.reflection.ReflectionUtils.getPropertyType;
 public final class EntityMetadata {
     private final Class<?> type;
     private final Model model;
+    private final String localModelName;
     private final Aggregate aggregate;
     private final RootConfiguration rootConfiguration;
     private final Property entityId;
@@ -158,6 +159,9 @@ public final class EntityMetadata {
         this.type = type;
         ReflectionUtils.TypeMetadata typeMetadata = ReflectionUtils.getTypeMetadata(type);
         this.model = typeMetadata.typeAnnotation(Model.class);
+        Model declaredModel = type.getDeclaredAnnotation(Model.class);
+        this.localModelName = model == null ? null : validateModelName(
+                type, declaredModel == null ? "" : declaredModel.name());
         this.aggregate = typeMetadata.typeAnnotation(Aggregate.class);
         this.revision = ClientUtils.getRevisionNumberForType(type);
         this.rootConfiguration = rootConfiguration(type, model, aggregate);
@@ -230,6 +234,14 @@ public final class EntityMetadata {
 
     public boolean isModel() {
         return model != null;
+    }
+
+    /** Returns the prefix-independent durable name of this concrete Model type. */
+    public String localModelName() {
+        if (localModelName == null) {
+            throw new IllegalStateException(type.getName() + " is not annotated with @Model");
+        }
+        return localModelName;
     }
 
     /** Returns this type's serializer revision. */
@@ -393,8 +405,8 @@ public final class EntityMetadata {
                             .formatted(type.getName(), parents.size()));
         }
         ParentValue parent = parents.getFirst();
-        String parentType = Objects.requireNonNull(parent.parentModelType(),
-                                                   "Parent model type must be known for scoped identity").getName();
+        String parentType = ModelNames.name(Objects.requireNonNull(
+                parent.parentModelType(), "Parent model type must be known for scoped identity"));
         String parentId = parent.reference().repositoryId(parent.value());
         String childId = unscopedRepositoryId(functionalId);
         return "@%d:%s:%d:%s:%s".formatted(
@@ -527,15 +539,21 @@ public final class EntityMetadata {
 
     /** Returns the application-resolved collection that owns this Model's current document, if it has one. */
     public Optional<String> modelDocumentCollection() {
+        return modelDocumentCollection(ApplicationProperties.getProperty(
+                ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+    }
+
+    /** Returns the Model current-document collection using an already application-scoped name prefix. */
+    public Optional<String> modelDocumentCollection(String modelNamePrefix) {
         if (model == null) {
             return Optional.empty();
         }
         if (rootConfiguration.directDocument()) {
-            return Optional.of(configuredModelDocumentCollection());
+            return Optional.of(configuredModelDocumentCollection(modelNamePrefix));
         }
         return maintainsGraphComponentDocument()
                 ? Optional.of(ModelDocumentMutation.privateModelDocumentCollection(
-                        type.getName()))
+                        ModelNames.name(type, modelNamePrefix)))
                 : Optional.empty();
     }
 
@@ -544,16 +562,25 @@ public final class EntityMetadata {
      * non-event-sourced Model that does not materialize one itself.
      */
     public String modelDocumentReadCollection() {
-        return modelDocumentCollection().orElseGet(this::configuredModelDocumentCollection);
+        return modelDocumentReadCollection(ApplicationProperties.getProperty(
+                ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
     }
 
-    private String configuredModelDocumentCollection() {
-        return rootConfiguration.resolvedCollection(type);
+    /** Returns the read collection using an already application-scoped name prefix. */
+    public String modelDocumentReadCollection(String modelNamePrefix) {
+        return modelDocumentCollection(modelNamePrefix)
+                .orElseGet(() -> configuredModelDocumentCollection(modelNamePrefix));
+    }
+
+    private String configuredModelDocumentCollection(String modelNamePrefix) {
+        return rootConfiguration.resolvedCollection(type, modelNamePrefix);
     }
 
     /** Returns this root's application-resolved materialized graph definition, if enabled. */
     public Optional<ModelGraphProjectionConfiguration> graphProjectionConfiguration() {
-        return graphProjectionConfiguration(List.of(type));
+        return graphProjectionConfiguration(
+                List.of(type), ApplicationProperties.getProperty(
+                        ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
     }
 
     /**
@@ -561,16 +588,24 @@ public final class EntityMetadata {
      */
     public Optional<ModelGraphProjectionConfiguration> graphProjectionConfiguration(
             Collection<Class<?>> knownModelTypes) {
+        return graphProjectionConfiguration(
+                knownModelTypes, ApplicationProperties.getProperty(
+                        ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+    }
+
+    /** Returns the durable Graph definition using an already application-scoped Model-name prefix. */
+    public Optional<ModelGraphProjectionConfiguration> graphProjectionConfiguration(
+            Collection<Class<?>> knownModelTypes, String modelNamePrefix) {
         if (model == null || !model.materializeGraph()) {
             return Optional.empty();
         }
         GraphProjection projection = model.graphProjection();
-        String rootCollection = modelDocumentCollection().orElseThrow(
+        String rootCollection = modelDocumentCollection(modelNamePrefix).orElseThrow(
                 () -> new IllegalStateException(
                         "Graph projection root %s has no current-document collection"
                                 .formatted(type.getName())));
         String graphCollectionBase = rootConfiguration.directDocument()
-                ? rootCollection : type.getSimpleName();
+                ? rootCollection : ModelNames.name(type, modelNamePrefix);
         String collection = projection.collection().isEmpty()
                 ? graphCollectionBase + "-graphs"
                 : ApplicationProperties.substituteProperties(projection.collection());
@@ -580,9 +615,9 @@ public final class EntityMetadata {
                             .formatted(type.getName(), rootCollection));
         }
         return Optional.of(new ModelGraphProjectionConfiguration(
-                type.getName(), rootCollection, collection,
+                ModelNames.name(type, modelNamePrefix), rootCollection, collection,
                 ModelGraphComposition.builder().build(),
-                graphModelRevisions(knownModelTypes),
+                graphModelRevisions(knownModelTypes, modelNamePrefix),
                 Arrays.stream(projection.pathOverrides())
                         .map(override -> new ModelGraphPathOverride(
                                 override.path(), override.projectionPath()))
@@ -590,7 +625,7 @@ public final class EntityMetadata {
     }
 
     private List<ModelGraphProjectionConfiguration.ModelRevision>
-            graphModelRevisions(Collection<Class<?>> knownModelTypes) {
+            graphModelRevisions(Collection<Class<?>> knownModelTypes, String modelNamePrefix) {
         Objects.requireNonNull(knownModelTypes, "Known model types");
         LinkedHashSet<Class<?>> reachable = new LinkedHashSet<>();
         reachable.add(type);
@@ -625,7 +660,7 @@ public final class EntityMetadata {
                 .map(modelType -> {
                     EntityMetadata metadata = EntityMetadata.of(modelType);
                     return new ModelGraphProjectionConfiguration.ModelRevision(
-                            modelType.getName(), metadata.revision());
+                            ModelNames.name(modelType, modelNamePrefix), metadata.revision());
                 })
                 .toList();
     }
@@ -891,6 +926,22 @@ public final class EntityMetadata {
                                   .formatted(type.getName()));
         }
         return Set.copyOf(persistence);
+    }
+
+    private static String validateModelName(Class<?> type, String configured) {
+        if (configured.isEmpty()) {
+            String inferred = type.getSimpleName();
+            if (!inferred.isEmpty()) {
+                return inferred;
+            }
+            throw invalid("@Model.name must be set on a Model type without a simple class name: %s"
+                                  .formatted(type.getName()));
+        }
+        if (configured.isBlank() || !configured.equals(configured.trim())) {
+            throw invalid("@Model.name on %s must not be blank or have surrounding whitespace"
+                                  .formatted(type.getName()));
+        }
+        return configured;
     }
 
     private void validateProjectionPath(
@@ -1338,9 +1389,15 @@ public final class EntityMetadata {
 
         /** Converts this structural relationship to its commit-wire value. */
         public ModelRelationship asCommitRelationship() {
+            return asCommitRelationship(ApplicationProperties.getProperty(
+                    ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+        }
+
+        /** Converts this relationship using an already application-scoped Model-name prefix. */
+        public ModelRelationship asCommitRelationship(String modelNamePrefix) {
             return ModelRelationship.builder()
                     .parentId(parentId)
-                    .parentType(parentType == null ? null : parentType.getName())
+                    .parentType(parentType == null ? null : ModelNames.name(parentType, modelNamePrefix))
                     .path(pathInParent)
                     .deleteOnParentDeletion(deleteOnParentDeletion)
                     .build();
@@ -1348,9 +1405,15 @@ public final class EntityMetadata {
 
         /** Converts this structural relationship to one transient Graph edge. */
         public ModelGraphEdge asGraphEdge(String childId) {
+            return asGraphEdge(childId, ApplicationProperties.getProperty(
+                    ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+        }
+
+        /** Converts this relationship using an already application-scoped Model-name prefix. */
+        public ModelGraphEdge asGraphEdge(String childId, String modelNamePrefix) {
             return new ModelGraphEdge(
                     childId, parentId,
-                    parentType == null ? null : parentType.getName(),
+                    parentType == null ? null : ModelNames.name(parentType, modelNamePrefix),
                     pathInParent, -1L, null, deleteOnParentDeletion);
         }
     }
@@ -1485,10 +1548,16 @@ public final class EntityMetadata {
             String endPath) {
 
         String resolvedCollection(Class<?> type) {
+            return resolvedCollection(type, ApplicationProperties.getProperty(
+                    ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+        }
+
+        String resolvedCollection(Class<?> type, String modelNamePrefix) {
             return Optional.of(collection)
                     .filter(value -> !value.isEmpty())
                     .map(ApplicationProperties::substituteProperties)
-                    .orElse(type.getSimpleName());
+                    .orElseGet(() -> kind == RootKind.MODEL
+                            ? ModelNames.name(type, modelNamePrefix) : type.getSimpleName());
         }
 
         static RootConfiguration model(

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
@@ -518,6 +518,13 @@ public final class EntityMetadata {
                 .anyMatch(ParentReference::automaticallyComposed);
     }
 
+    /** Whether this Model independently needs an indexed internal current document for Graph operations. */
+    public boolean maintainsGraphComponentDocument() {
+        return model != null
+               && (participatesInGraphComposition()
+                   || rootConfiguration.materializeGraph());
+    }
+
     /** Returns the application-resolved collection that owns this Model's current document, if it has one. */
     public Optional<String> modelDocumentCollection() {
         if (model == null) {
@@ -526,10 +533,13 @@ public final class EntityMetadata {
         if (rootConfiguration.directDocument()) {
             return Optional.of(rootConfiguration.publicDocument()
                                        ? configuredModelDocumentCollection()
-                                       : ModelDocumentMutation.privateModelDocumentCollection(
-                                               type.getName()));
+                                       : maintainsGraphComponentDocument()
+                                               ? ModelDocumentMutation.privateModelDocumentCollection(
+                                                       type.getName())
+                                               : ModelDocumentMutation.referenceModelDocumentCollection(
+                                                       type.getName()));
         }
-        return participatesInGraphComposition() || rootConfiguration.materializeGraph()
+        return maintainsGraphComponentDocument()
                 ? Optional.of(ModelDocumentMutation.privateModelDocumentCollection(
                         type.getName()))
                 : Optional.empty();

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/EntityMetadata.java
@@ -531,13 +531,7 @@ public final class EntityMetadata {
             return Optional.empty();
         }
         if (rootConfiguration.directDocument()) {
-            return Optional.of(rootConfiguration.publicDocument()
-                                       ? configuredModelDocumentCollection()
-                                       : maintainsGraphComponentDocument()
-                                               ? ModelDocumentMutation.privateModelDocumentCollection(
-                                                       type.getName())
-                                               : ModelDocumentMutation.referenceModelDocumentCollection(
-                                                       type.getName()));
+            return Optional.of(configuredModelDocumentCollection());
         }
         return maintainsGraphComponentDocument()
                 ? Optional.of(ModelDocumentMutation.privateModelDocumentCollection(
@@ -575,10 +569,10 @@ public final class EntityMetadata {
                 () -> new IllegalStateException(
                         "Graph projection root %s has no current-document collection"
                                 .formatted(type.getName())));
-        String publicCollectionBase = rootConfiguration.publicDocument()
+        String graphCollectionBase = rootConfiguration.directDocument()
                 ? rootCollection : type.getSimpleName();
         String collection = projection.collection().isEmpty()
-                ? publicCollectionBase + "-graphs"
+                ? graphCollectionBase + "-graphs"
                 : ApplicationProperties.substituteProperties(projection.collection());
         if (rootCollection.equals(collection)) {
             throw new IllegalStateException(
@@ -894,11 +888,6 @@ public final class EntityMetadata {
                 || !document.timestampPath().isEmpty()
                 || !document.endPath().isEmpty())) {
             throw invalid("@Model.document on %s requires persistence that stores a direct document"
-                                  .formatted(type.getName()));
-        }
-        if (storesDocument && !document.searchable()
-            && !document.collection().isEmpty()) {
-            throw invalid("@Model.document.collection on %s requires a searchable document projection"
                                   .formatted(type.getName()));
         }
         return Set.copyOf(persistence);

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphChangeHandlerDecorator.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/GraphChangeHandlerDecorator.java
@@ -30,6 +30,7 @@ import io.fluxzero.sdk.common.ThreadLocalContext;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
 import io.fluxzero.sdk.persisting.repository.ModelAncestorResolver;
 import io.fluxzero.sdk.persisting.repository.ModelRepository;
+import io.fluxzero.sdk.persisting.repository.ModelTypeResolver;
 import io.fluxzero.sdk.tracking.handling.HandleEvent;
 import io.fluxzero.sdk.tracking.handling.HandleMessage;
 import io.fluxzero.sdk.tracking.handling.HandleNotification;
@@ -213,7 +214,9 @@ public final class GraphChangeHandlerDecorator {
         List<ModelChangeTarget> targets = change.getTargets().isEmpty()
                 ? payloadTypes.entrySet().stream()
                         .map(entry -> new ModelChangeTarget(
-                                entry.getKey(), entry.getValue().getName()))
+                                entry.getKey(), repository instanceof ModelTypeResolver resolver
+                                        ? resolver.modelName(entry.getValue())
+                                        : ModelNames.name(entry.getValue())))
                         .toList()
                 : change.getTargets();
         long currentState = change.getStateIndex();
@@ -221,7 +224,7 @@ public final class GraphChangeHandlerDecorator {
         LinkedHashMap<String, Class<? extends T>> roots = new LinkedHashMap<>();
         for (ModelChangeTarget target : targets) {
             Class<?> targetType = targetType(
-                    target, payloadTypes, fluxzero);
+                    target, payloadTypes, repository);
             if (targetType == null) {
                 continue;
             }
@@ -261,13 +264,16 @@ public final class GraphChangeHandlerDecorator {
     private static Class<?> targetType(
             ModelChangeTarget target,
             Map<String, Class<?>> payloadTypes,
-            Fluxzero fluxzero) {
+            ModelRepository repository) {
         if (target.getModelType() == null
             || target.getModelType().isBlank()) {
             return payloadTypes.get(target.getModelId());
         }
-        return ReflectionUtils.classForName(
-                fluxzero.serializer().upcastType(target.getModelType()), null);
+        if (repository instanceof ModelTypeResolver resolver) {
+            return resolver.modelType(target.getModelType(), target.getModelId());
+        }
+        throw new UnsupportedOperationException(
+                "Graph-change handlers require a Model repository with a logical type catalog");
     }
 
     private static <T> void addRoots(

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
@@ -91,6 +91,20 @@ import java.lang.annotation.Target;
 public @interface Model {
 
     /**
+     * Stable logical name of this Model in persisted Model metadata.
+     * <p>
+     * The default is the simple name of the concrete Model class. This name deliberately does not contain the Java
+     * package, so moving or renaming a class remains possible by retaining its previous logical name explicitly.
+     * Applications sharing one Runtime namespace can prepend an application-scoped prefix with
+     * {@code fluxzero.model.namePrefix}; the prefix is concatenated literally and should therefore include any desired
+     * separator; prefix {@code billing} and name {@code Invoice} become {@code billingInvoice}.
+     * <p>
+     * This is a durable identity. Changing it for an existing Model creates a different Model type and requires an
+     * application-managed data transition.
+     */
+    String name() default "";
+
+    /**
      * Conflict handling for this model when an apply does not provide an explicit override.
      */
     ModelConflictPolicy conflictPolicy() default ModelConflictPolicy.DEFAULT;
@@ -187,7 +201,7 @@ public @interface Model {
      * Advanced configuration for the Model's direct current document.
      * <p>
      * Include {@link ModelPersistence#DOCUMENT} in {@link #persistence()} to enable this projection. Every direct
-     * document uses the configured collection, which defaults to the Model's simple class name. A reference-only
+     * document uses the configured collection, which defaults to the resolved logical Model name. A reference-only
      * document is excluded from unrestricted typed Model search while remaining available to Model loads, aliases,
      * relationships and Graph composition. Timestamps default to the applied event timestamp when no paths are
      * configured.
@@ -201,7 +215,7 @@ public @interface Model {
      * irrespective of that document's public search visibility. A root without a direct document uses the same
      * type-isolated private storage as other Graph-only Models. Only the separately named graph collection is allowed
      * to lag; its high-watermark is exposed through the model repository. The collection defaults to the resolved
-     * direct-model collection plus {@code -graphs} when present, or to {@code <simple model name>-graphs} otherwise.
+     * direct-model collection plus {@code -graphs} when present, or to {@code <logical Model name>-graphs} otherwise.
      */
     boolean materializeGraph() default false;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/Model.java
@@ -186,21 +186,22 @@ public @interface Model {
     /**
      * Advanced configuration for the Model's direct current document.
      * <p>
-     * Include {@link ModelPersistence#DOCUMENT} in {@link #persistence()} to enable this projection. Searchable
-     * documents use a public collection that defaults to the Model's simple class name. Reference-only documents use
-     * type-isolated private storage while remaining available to Model loads, aliases, relationships and Graph
-     * composition. Timestamps default to the applied event timestamp when no paths are configured.
+     * Include {@link ModelPersistence#DOCUMENT} in {@link #persistence()} to enable this projection. Every direct
+     * document uses the configured collection, which defaults to the Model's simple class name. A reference-only
+     * document is excluded from unrestricted typed Model search while remaining available to Model loads, aliases,
+     * relationships and Graph composition. Timestamps default to the applied event timestamp when no paths are
+     * configured.
      */
     DocumentProjection document() default @DocumentProjection;
 
     /**
      * Whether Fluxzero should asynchronously materialize the complete model graph as a separate search document.
      * <p>
-     * Fluxzero retains the root's current document in its public direct collection when it has a searchable document
-     * projection and otherwise in the same type-isolated private storage used by other Graph-only Models. Only the
-     * separately named graph collection is allowed to lag; its high-watermark is exposed through the model repository.
-     * The collection defaults to the resolved public direct-model collection plus {@code -graphs} when present, or to
-     * {@code <simple model name>-graphs} otherwise.
+     * Fluxzero retains the root's current document in its resolved direct collection when it has a document projection,
+     * irrespective of that document's public search visibility. A root without a direct document uses the same
+     * type-isolated private storage as other Graph-only Models. Only the separately named graph collection is allowed
+     * to lag; its high-watermark is exposed through the model repository. The collection defaults to the resolved
+     * direct-model collection plus {@code -graphs} when present, or to {@code <simple model name>-graphs} otherwise.
      */
     boolean materializeGraph() default false;
 

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistry.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelCommitHandlerRegistry.java
@@ -117,6 +117,7 @@ public final class ModelCommitHandlerRegistry implements HandlerRegistry, Handle
                 throw new IllegalArgumentException(
                         type.getName() + " is not a Model root");
             }
+            repository.modelName(type);
         });
         validated.forEach(definitions::register);
         return () -> validated.forEach(definitions::unregister);
@@ -194,6 +195,7 @@ public final class ModelCommitHandlerRegistry implements HandlerRegistry, Handle
         if (!EntityMetadata.of(targetType).isModel()) {
             return Registration.noOp();
         }
+        repository.modelName(targetType);
         definitions.register(targetType);
         EntityMetadata.graphProjectionRoots(targetType)
                 .forEach(root -> repository.registerGraphProjection(

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelNames.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/ModelNames.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fluxzero.sdk.modeling;
+
+import io.fluxzero.common.application.PropertySource;
+import io.fluxzero.sdk.configuration.ApplicationProperties;
+
+import java.util.Objects;
+
+import static io.fluxzero.sdk.configuration.ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY;
+
+/** Central resolver for stable logical Model names. */
+public final class ModelNames {
+
+    private ModelNames() {
+    }
+
+    /** Resolves a Model name using the active application's configured literal prefix. */
+    public static String name(Class<?> modelType) {
+        return name(modelType, ApplicationProperties.getProperty(MODEL_NAME_PREFIX_PROPERTY, ""));
+    }
+
+    /** Resolves a Model name using a prefix read from the supplied application property source. */
+    public static String name(Class<?> modelType, PropertySource propertySource) {
+        Objects.requireNonNull(propertySource, "Property source");
+        return name(modelType, propertySource.get(MODEL_NAME_PREFIX_PROPERTY));
+    }
+
+    /** Resolves a Model name using an already application-scoped literal prefix. */
+    public static String name(Class<?> modelType, String prefix) {
+        String resolvedPrefix = validatePrefix(prefix);
+        return resolvedPrefix + EntityMetadata.validate(modelType).localModelName();
+    }
+
+    private static String validatePrefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return "";
+        }
+        if (prefix.isBlank() || !prefix.equals(prefix.trim())) {
+            throw new IllegalArgumentException(
+                    "%s must not be blank or have surrounding whitespace"
+                            .formatted(MODEL_NAME_PREFIX_PROPERTY));
+        }
+        return prefix;
+    }
+}

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
@@ -37,8 +37,8 @@ import lombok.With;
  * <ul>
  *   <li>{@code searchable} – whether the type's ordinary search representation is enabled. For Models this controls
  *       exposure through unrestricted typed search.</li>
- *   <li>{@code collection} – name of the logical collection under which documents are grouped; if not
- *       specified, the simple name of the class is used.</li>
+ *   <li>{@code collection} – name of the logical collection under which documents are grouped; if not specified,
+ *       ordinary documents use the simple class name and Models use their resolved logical name.</li>
  *   <li>{@code timestampPath} – expression to extract the primary timestamp (start time) from the object.</li>
  *   <li>{@code endPath} – expression to extract the end timestamp (for ranged entities) from the object.</li>
  * </ul>
@@ -64,8 +64,8 @@ public class SearchParameters implements Substitutable<SearchParameters> {
     boolean searchable = true;
 
     /**
-     * Optional name of the document collection to use. If not specified, the simple class name will be used as the
-     * default.
+     * Optional name of the document collection to use. If not specified, ordinary documents use the simple class name
+     * and Models use their resolved logical name.
      */
     @With
     String collection;
@@ -86,7 +86,8 @@ public class SearchParameters implements Substitutable<SearchParameters> {
      * Resolves the effective search configuration for a model or searchable document type.
      *
      * <p>Models own their direct-document projection through {@link Model#document()}; other document types continue
-     * to use {@link Searchable}. An unspecified collection resolves to the type's simple name.</p>
+     * to use {@link Searchable}. An unspecified collection resolves to the simple name for an ordinary document and
+     * the resolved logical name for a Model.</p>
      */
     public static SearchParameters forType(Class<?> type) {
         EntityMetadata.RootConfiguration model = EntityMetadata.rootConfiguration(type)

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/SearchParameters.java
@@ -35,7 +35,8 @@ import lombok.With;
  *
  * <h2>Fields:</h2>
  * <ul>
- *   <li>{@code searchable} – whether documents of this type should be indexed and searchable.</li>
+ *   <li>{@code searchable} – whether the type's ordinary search representation is enabled. For Models this controls
+ *       exposure through unrestricted typed search.</li>
  *   <li>{@code collection} – name of the logical collection under which documents are grouped; if not
  *       specified, the simple name of the class is used.</li>
  *   <li>{@code timestampPath} – expression to extract the primary timestamp (start time) from the object.</li>
@@ -55,7 +56,9 @@ public class SearchParameters implements Substitutable<SearchParameters> {
     public static final SearchParameters defaultSearchParameters = SearchParameters.builder().build();
 
     /**
-     * Whether instances of the annotated class are eligible for indexing and search. Defaults to {@code true}.
+     * Whether the type's ordinary search representation is enabled. Defaults to {@code true}. For Models this controls
+     * exposure through unrestricted typed search; a non-searchable Model that participates in Graph composition may
+     * still maintain the internal indexes required by explicitly bounded Graph and relationship queries.
      */
     @Builder.Default
     boolean searchable = true;

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
@@ -2001,11 +2001,16 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     blankToNull(model.timestampPath()), value, false, () -> eventTimestamp);
             Instant end = parseTimeProperty(
                     blankToNull(model.endPath()), value, true, () -> begin);
-            return new ModelDocumentMutation(
-                    collection,
-                    documentSerializer.toDocument(
-                            value, transition.modelId(), collection,
-                            begin, end, metadata));
+            SerializedDocument document = documentSerializer.toDocument(
+                    value, transition.modelId(), collection,
+                    begin, end, metadata);
+            if (model.directDocument()
+                && !model.publicDocument()
+                && !transition.metadata()
+                        .maintainsGraphComponentDocument()) {
+                document = document.withoutSearchIndexes();
+            }
+            return new ModelDocumentMutation(collection, document);
         }
 
         private static String blankToNull(String value) {

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepository.java
@@ -117,7 +117,7 @@ import static io.fluxzero.common.api.tracking.SegmentRange.MAX_SEGMENT;
  * loads use the model-stream protocol and reconstruct every selected stream at one pinned {@code stateIndex}.
  */
 public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
-        implements ModelRepository, ModelAncestorResolver {
+        implements ModelRepository, ModelAncestorResolver, ModelTypeResolver {
     private static final int COMMITTED_CACHE_UPDATE_BATCH_SIZE = 128;
     private static final CompletableFuture<Void> COMPLETED_VOID =
             CompletableFuture.completedFuture(null);
@@ -125,6 +125,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
     private static final long MAX_MIGRATION_POLL_NANOS = Duration.ofMillis(250).toNanos();
 
     private final Client client;
+    private final String modelNamePrefix;
     private final DocumentStore documentStore;
     private final Serializer serializer;
     private final EntityHelper entityHelper;
@@ -140,6 +141,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
     private final AtomicLong migratedThrough = new AtomicLong(-1L);
     private final ConcurrentHashMap<Class<?>, GraphProjectionRegistration>
             graphProjectionRegistrations = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Class<?>> modelTypesByName;
     private volatile Supplier<List<Class<?>>> modelTypes = List::of;
 
     public DefaultModelRepository(
@@ -151,9 +153,23 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             Cache cache,
             List<ParameterResolver<? super DeserializingMessage>> parameterResolvers) {
         this(client, documentStore, serializer, entityHelper, snapshotSerializer, cache,
+             parameterResolvers, ApplicationProperties.getProperty(
+                        ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+    }
+
+    public DefaultModelRepository(
+            Client client,
+            DocumentStore documentStore,
+            Serializer serializer,
+            EntityHelper entityHelper,
+            Serializer snapshotSerializer,
+            Cache cache,
+            List<ParameterResolver<? super DeserializingMessage>> parameterResolvers,
+            String modelNamePrefix) {
+        this(client, documentStore, serializer, entityHelper, snapshotSerializer, cache,
              new MutationPlan.Compiler(Objects.requireNonNull(
                      parameterResolvers, "parameterResolvers")),
-             new AtomicReference<>());
+             new AtomicReference<>(), modelNamePrefix, new ConcurrentHashMap<>());
     }
 
     private DefaultModelRepository(
@@ -165,8 +181,12 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             Cache cache,
             MutationPlan.Compiler modelDefinitionCompiler,
             AtomicReference<MigrationReadBarrierConfiguration>
-                    migrationReadBarrierConfiguration) {
+                    migrationReadBarrierConfiguration,
+            String modelNamePrefix,
+            ConcurrentHashMap<String, Class<?>> modelTypesByName) {
         this.client = Objects.requireNonNull(client, "client");
+        this.modelNamePrefix = modelNamePrefix == null ? "" : modelNamePrefix;
+        this.modelTypesByName = Objects.requireNonNull(modelTypesByName, "Model type catalog");
         this.documentStore = Objects.requireNonNull(documentStore, "documentStore");
         this.serializer = Objects.requireNonNull(serializer, "serializer");
         this.entityHelper = Objects.requireNonNull(entityHelper, "entityHelper");
@@ -186,7 +206,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                 eventStoreClient, serializer, entityHelper,
                 modelDefinitionCompiler, modelCache, snapshotStore,
                 this::loadDocumentProjection, this,
-                this::awaitPublishedEventMigration);
+                this::awaitPublishedEventMigration, this);
         this.modelCacheTracker = cache == NoOpCache.INSTANCE
                 ? null
                 : new ModelCacheTracker(
@@ -206,7 +226,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
         DefaultModelRepository result = new DefaultModelRepository(
                 namespacedClient, namespacedDocumentStore, serializer, entityHelper,
                 snapshotSerializer, cacheSource, modelDefinitionCompiler,
-                migrationReadBarrierConfiguration);
+                migrationReadBarrierConfiguration, modelNamePrefix, modelTypesByName);
         result.configureModelTypes(modelTypes);
         return result;
     }
@@ -418,7 +438,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             String persistedId,
             Class<?> modelType,
             EntityMetadata metadata) {
-        String collection = metadata.modelDocumentCollection()
+        String collection = metadata.modelDocumentCollection(modelNamePrefix)
                 .orElseThrow(() -> new IllegalArgumentException(
                         modelType.getName() + " has no current document to adopt"));
         GetModelMigrationResult migration = client.getSearchClient()
@@ -430,13 +450,13 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     new IllegalStateException(
                             "No staged Model migration exists for " + persistedId));
         }
-        if (!modelType.getName().equals(migratedHead.getModelType())) {
+        if (!modelName(modelType).equals(migratedHead.getModelType())) {
             return CompletableFuture.failedFuture(
                     new IllegalStateException(
                             "Staged Model type %s does not match requested type %s for %s"
                                     .formatted(
                                             migratedHead.getModelType(),
-                                            modelType.getName(), persistedId)));
+                                            modelName(modelType), persistedId)));
         }
         SerializedDocument production = migration.getProductionDocument();
         SerializedDocument staged = migration.getMigratedDocument();
@@ -502,7 +522,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
     private Class<?> migrationType(
             ModelHeadState migration) {
         return modelTypes.get().stream()
-                .filter(type -> type.getName().equals(
+                .filter(type -> modelName(type).equals(
                         migration.getModelType()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException(
@@ -567,14 +587,44 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             Supplier<List<Class<?>>> modelTypes) {
         this.modelTypes = Objects.requireNonNull(
                 modelTypes, "Model types");
+        modelTypes.get().forEach(this::modelName);
+    }
+
+    @Override
+    public String modelName(Class<?> modelType) {
+        String name = io.fluxzero.sdk.modeling.ModelNames.name(modelType, modelNamePrefix);
+        Class<?> existing = modelTypesByName.putIfAbsent(name, modelType);
+        if (existing != null && !existing.equals(modelType)) {
+            throw new IllegalStateException(
+                    "Logical Model name '%s' is used by both %s and %s"
+                            .formatted(name, existing.getName(), modelType.getName()));
+        }
+        return name;
+    }
+
+    @Override
+    public Class<?> modelType(String modelName, String modelId) {
+        if (modelName == null || modelName.isBlank()) {
+            throw new IllegalStateException("Model '%s' has no stored type metadata".formatted(modelId));
+        }
+        modelTypes.get().forEach(this::modelName);
+        Class<?> result = modelTypesByName.get(modelName);
+        if (result == null) {
+            throw new IllegalStateException(
+                    "Stored Model type '%s' for %s is not registered in this application"
+                            .formatted(modelName, modelId));
+        }
+        return result;
     }
 
     /** Returns the application-resolved durable definition owned by this repository. */
     public ModelGraphProjectionConfiguration graphProjectionDefinition(
             @NonNull Class<?> modelType) {
+        modelName(modelType);
+        modelTypes.get().forEach(this::modelName);
         return EntityMetadata.validate(modelType)
                 .graphProjectionConfiguration(
-                        modelTypes.get())
+                        modelTypes.get(), modelNamePrefix)
                 .orElseThrow(() ->
                         new IllegalArgumentException(
                                 modelType.getName()
@@ -668,6 +718,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     modelId, resolvedType,
                     boundary, handlerBoundary));
         }
+        modelName(modelType);
         EntityMetadata metadata = EntityMetadata.validate(modelType);
         metadata.rootConfiguration()
                 .filter(root -> root.kind() == EntityMetadata.RootKind.MODEL)
@@ -691,6 +742,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
         if (modelIds.isEmpty()) {
             return List.of();
         }
+        modelName(modelType);
         EntityMetadata metadata = EntityMetadata.validate(modelType);
         String idProperty = metadata.entityId().orElseThrow().name();
         LinkedHashSet<String> uniqueIds = new LinkedHashSet<>();
@@ -776,6 +828,8 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             Class<A> ancestorType,
             ModelReadBoundary boundary,
             boolean all) {
+        modelName(modelType);
+        modelName(ancestorType);
         EntityMetadata sourceMetadata = EntityMetadata.validate(modelType);
         MutationPlan.ResolvedModel source =
                 new MutationPlan.ResolvedModel(
@@ -855,6 +909,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             ModelReadBoundary boundary,
             PinnedBoundary handlerBoundary,
             boolean includeMessageBatch) {
+        modelName(rootType);
         EntityMetadata.validate(rootType);
         Map<String, Entity<?>> staged =
                 includeMessageBatch
@@ -1278,7 +1333,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
     private ModelReplayCursor.DocumentVersion loadDocumentUnchecked(
             String modelId, Class<?> modelType, EntityMetadata metadata,
             boolean migration) {
-        String collection = metadata.modelDocumentReadCollection();
+        String collection = metadata.modelDocumentReadCollection(modelNamePrefix);
         GetDocumentResult result = client.getSearchClient().fetchModelDocument(
                 new GetDocument(
                         modelId,
@@ -1768,7 +1823,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     ModelCommitTarget left = before.getTargets().get(target);
                     ModelCommitTarget right = after.getTargets().get(target);
                     if (!left.getModelId().equals(right.getModelId())
-                        || !left.getModelType().equals(right.getModelType())
+                        || !Objects.equals(left.getModelType(), right.getModelType())
                         || left.isStoreEvent() != right.isStoreEvent()
                         || left.isUpdateState() != right.isUpdateState()) {
                         throw changedRebaseShape();
@@ -1819,7 +1874,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     : null;
             return new ModelCommitTarget(
                     transition.modelId(),
-                    transition.modelType().getName(),
+                    modelName(transition.modelType()),
                     transition.beforeSequenceNumber(),
                     transition.storeEvent(),
                     transition.updateState(),
@@ -1927,7 +1982,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
                     .anyMatch(index -> index >= sourceIndex);
         }
 
-        private static RelationshipUpdate relationshipUpdate(
+        private RelationshipUpdate relationshipUpdate(
                 Change transition) {
             EntityMetadata metadata = transition.metadata();
             if (metadata.parentReferences().isEmpty()) {
@@ -1937,11 +1992,11 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
             }
             List<ModelRelationship> before = metadata.parentRelationships(
                             transition.modelId(), transition.before()).stream()
-                    .map(EntityMetadata.ParentRelationship::asCommitRelationship)
+                    .map(relationship -> relationship.asCommitRelationship(modelNamePrefix))
                     .toList();
             List<ModelRelationship> after = metadata.parentRelationships(
                             transition.modelId(), transition.after()).stream()
-                    .map(EntityMetadata.ParentRelationship::asCommitRelationship)
+                    .map(relationship -> relationship.asCommitRelationship(modelNamePrefix))
                     .toList();
             boolean update = transition.after() == null
                              || !before.equals(after);
@@ -2020,7 +2075,7 @@ public class DefaultModelRepository extends AbstractNamespaced<ModelRepository>
         private String documentCollection(Change transition) {
             return documentCollections.computeIfAbsent(
                     transition.metadata().type(),
-                    ignored -> transition.metadata().modelDocumentCollection())
+                    ignored -> transition.metadata().modelDocumentCollection(modelNamePrefix))
                     .orElse(null);
         }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
@@ -112,6 +112,7 @@ final class ModelReplayCursor {
     private final DocumentReader documentReader;
     private final ModelRepository repository;
     private final EventBoundaryBarrier eventBoundaryBarrier;
+    private final ModelTypeResolver modelTypeResolver;
 
     ModelReplayCursor(EventStoreClient eventStoreClient) {
         this(eventStoreClient, DEFAULT_SETTINGS);
@@ -119,7 +120,7 @@ final class ModelReplayCursor {
 
     ModelReplayCursor(EventStoreClient eventStoreClient, Settings settings) {
         this(eventStoreClient, settings, null, null, null, null, null, null, null,
-             EventBoundaryBarrier.NONE);
+             EventBoundaryBarrier.NONE, null);
     }
 
     ModelReplayCursor(
@@ -127,7 +128,7 @@ final class ModelReplayCursor {
             Settings settings,
             EventBoundaryBarrier eventBoundaryBarrier) {
         this(eventStoreClient, settings, null, null, null, null, null, null, null,
-             eventBoundaryBarrier);
+             eventBoundaryBarrier, null);
     }
 
     ModelReplayCursor(
@@ -140,7 +141,7 @@ final class ModelReplayCursor {
             DocumentReader documentReader,
             ModelRepository repository) {
         this(eventStoreClient, serializer, entityHelper, modelDefinitionCompiler, modelCache,
-             snapshotStore, documentReader, repository, EventBoundaryBarrier.NONE);
+             snapshotStore, documentReader, repository, EventBoundaryBarrier.NONE, null);
     }
 
     ModelReplayCursor(
@@ -153,8 +154,24 @@ final class ModelReplayCursor {
             DocumentReader documentReader,
             ModelRepository repository,
             EventBoundaryBarrier eventBoundaryBarrier) {
+        this(eventStoreClient, serializer, entityHelper, modelDefinitionCompiler, modelCache,
+             snapshotStore, documentReader, repository, eventBoundaryBarrier, null);
+    }
+
+    ModelReplayCursor(
+            EventStoreClient eventStoreClient,
+            Serializer serializer,
+            EntityHelper entityHelper,
+            MutationPlan.Compiler modelDefinitionCompiler,
+            Cache modelCache,
+            ModelSnapshotStore snapshotStore,
+            DocumentReader documentReader,
+            ModelRepository repository,
+            EventBoundaryBarrier eventBoundaryBarrier,
+            ModelTypeResolver modelTypeResolver) {
         this(eventStoreClient, DEFAULT_SETTINGS, serializer, entityHelper, modelDefinitionCompiler,
-             modelCache, snapshotStore, documentReader, repository, eventBoundaryBarrier);
+             modelCache, snapshotStore, documentReader, repository, eventBoundaryBarrier,
+             modelTypeResolver);
     }
 
     private ModelReplayCursor(
@@ -167,7 +184,8 @@ final class ModelReplayCursor {
             ModelSnapshotStore snapshotStore,
             DocumentReader documentReader,
             ModelRepository repository,
-            EventBoundaryBarrier eventBoundaryBarrier) {
+            EventBoundaryBarrier eventBoundaryBarrier,
+            ModelTypeResolver modelTypeResolver) {
         this.eventStoreClient = Objects.requireNonNull(eventStoreClient, "eventStoreClient");
         this.settings = Objects.requireNonNull(settings, "settings");
         this.eventBoundaryBarrier = Objects.requireNonNull(
@@ -185,6 +203,7 @@ final class ModelReplayCursor {
         this.snapshotStore = snapshotStore;
         this.documentReader = documentReader;
         this.repository = repository;
+        this.modelTypeResolver = modelTypeResolver;
     }
 
     Session session() {
@@ -1263,8 +1282,11 @@ final class ModelReplayCursor {
                     "Model '%s' has no stored type metadata".formatted(modelId));
         }
         try {
-            Class<?> result = io.fluxzero.common.reflection.ReflectionUtils.classForName(
-                    serializer.upcastType(storedType));
+            if (modelTypeResolver == null) {
+                throw new IllegalStateException(
+                        "No application Model type catalog is configured");
+            }
+            Class<?> result = modelTypeResolver.modelType(storedType, modelId);
             EntityMetadata.validate(result);
             return result;
         } catch (Throwable failure) {

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelTypeResolver.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelTypeResolver.java
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-package io.fluxzero.common.api.modeling;
+package io.fluxzero.sdk.persisting.repository;
 
-import lombok.Value;
+/** Resolves application-scoped logical Model names in both directions. */
+public interface ModelTypeResolver {
 
-/**
- * Coordination head observed for one model at the response boundary.
- */
-@Value
-public class ModelHeadState {
-    /** Exact persisted Model identity. */
-    String modelId;
+    /** Returns and registers the stable logical name for one concrete Model type. */
+    String modelName(Class<?> modelType);
 
-    /** Stable application-scoped logical Model name. */
-    String modelType;
-    long sequenceNumber;
-    long stateIndex;
-    boolean historyComplete;
-    boolean deleted;
+    /** Resolves a stored logical name to a registered concrete Model type. */
+    Class<?> modelType(String modelName, String modelId);
 }

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
@@ -81,6 +81,8 @@ import static java.util.stream.Collectors.toMap;
 @Slf4j
 public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> implements DocumentStore, HasLocalHandlers {
 
+    private static final String NON_SEARCHABLE_MODEL_QUERY_PREFIX = "$nonSearchableModels/";
+
     @With
     private final Client client;
     @Getter
@@ -223,12 +225,15 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
 
     @Override
     public <T> Search<T> search(@NonNull Class<T> collection) {
-        Class<?> targetModelType = EntityMetadata.of(collection).rootConfiguration()
+        EntityMetadata.RootConfiguration model = EntityMetadata.of(collection).rootConfiguration()
                 .filter(configuration -> configuration.kind() == EntityMetadata.RootKind.MODEL)
-                .map(ignored -> collection)
                 .orElse(null);
+        Class<?> targetModelType = model == null ? null : collection;
+        String queryCollection = model != null && !model.publicDocument()
+                ? NON_SEARCHABLE_MODEL_QUERY_PREFIX + collection.getName()
+                : determineCollection(collection);
         return new DefaultSearch<>(
-                SearchQuery.builder().collection(determineCollection(collection)),
+                SearchQuery.builder().collection(queryCollection),
                 targetModelType);
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultDocumentStore.java
@@ -43,6 +43,7 @@ import io.fluxzero.common.api.search.bulkupdate.IndexDocumentIfNotExists;
 import io.fluxzero.common.search.ModelGraphDocumentManifest;
 import io.fluxzero.sdk.common.AbstractNamespaced;
 import io.fluxzero.sdk.configuration.client.Client;
+import io.fluxzero.sdk.configuration.ApplicationProperties;
 import io.fluxzero.sdk.modeling.Entity;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.EntityMetadata;
@@ -89,6 +90,7 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
     private final DocumentSerializer serializer;
     @Delegate
     private final HasLocalHandlers handlerRegistry;
+    private final String modelNamePrefix;
     private volatile Supplier<ModelRepository> modelRepositorySupplier = () -> null;
     private volatile Supplier<List<Class<?>>> modelTypesSupplier = List::of;
 
@@ -96,18 +98,30 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
             Client client,
             DocumentSerializer serializer,
             HasLocalHandlers handlerRegistry) {
+        this(client, serializer, handlerRegistry,
+             ApplicationProperties.getProperty(
+                     ApplicationProperties.MODEL_NAME_PREFIX_PROPERTY, ""));
+    }
+
+    public DefaultDocumentStore(
+            Client client,
+            DocumentSerializer serializer,
+            HasLocalHandlers handlerRegistry,
+            String modelNamePrefix) {
         this.client = client;
         this.serializer = serializer;
         this.handlerRegistry = handlerRegistry;
+        this.modelNamePrefix = modelNamePrefix == null ? "" : modelNamePrefix;
     }
 
     private DefaultDocumentStore(
             Client client,
             DocumentSerializer serializer,
             HasLocalHandlers handlerRegistry,
+            String modelNamePrefix,
             Supplier<ModelRepository> modelRepositorySupplier,
             Supplier<List<Class<?>>> modelTypesSupplier) {
-        this(client, serializer, handlerRegistry);
+        this(client, serializer, handlerRegistry, modelNamePrefix);
         this.modelRepositorySupplier = modelRepositorySupplier;
         this.modelTypesSupplier = modelTypesSupplier;
     }
@@ -230,7 +244,8 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                 .orElse(null);
         Class<?> targetModelType = model == null ? null : collection;
         String queryCollection = model != null && !model.publicDocument()
-                ? NON_SEARCHABLE_MODEL_QUERY_PREFIX + collection.getName()
+                ? NON_SEARCHABLE_MODEL_QUERY_PREFIX
+                  + io.fluxzero.sdk.modeling.ModelNames.name(collection, modelNamePrefix)
                 : determineCollection(collection);
         return new DefaultSearch<>(
                 SearchQuery.builder().collection(queryCollection),
@@ -254,13 +269,13 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                     rootModelType.getName()
                     + " is not an independent model");
         }
-        String rootCollection = metadata.modelDocumentCollection()
+        String rootCollection = metadata.modelDocumentCollection(modelNamePrefix)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Graph search root %s has no current document"
                                 .formatted(rootModelType.getName())));
         Optional<io.fluxzero.common.api.modeling.ModelGraphProjectionConfiguration>
                 projection =
-                metadata.graphProjectionConfiguration();
+                metadata.graphProjectionConfiguration(modelTypesSupplier.get(), modelNamePrefix);
         boolean live =
                 forceAdHoc
                 || projection.isEmpty();
@@ -408,6 +423,7 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                 : new DefaultDocumentStore(
                         namespacedClient, serializer,
                         namespacedHandlerRegistry,
+                        modelNamePrefix,
                         () -> modelRepositorySupplier.get()
                                 .forNamespace(namespace),
                         modelTypesSupplier);
@@ -493,7 +509,7 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                 return;
             }
             String collection = EntityMetadata.validate(targetModelType)
-                    .modelDocumentCollection()
+                    .modelDocumentCollection(modelNamePrefix)
                     .orElseThrow(() -> new IllegalArgumentException(
                             ("Relationship search target %s has no current-state document; "
                              + "load it as a Model or Graph instead")
@@ -752,6 +768,18 @@ public class DefaultDocumentStore extends AbstractNamespaced<DocumentStore> impl
                                 .collect(toMap(DocumentStats::getGroup, DocumentStats::getFieldStats)));
             }
         }
+    }
+
+    @Override
+    public String determineCollection(@NonNull Object collection) {
+        Class<?> type = io.fluxzero.common.reflection.ReflectionUtils.ifClass(collection);
+        if (type != null) {
+            EntityMetadata metadata = EntityMetadata.of(type);
+            if (metadata.isModel()) {
+                return metadata.modelDocumentReadCollection(modelNamePrefix);
+            }
+        }
+        return DocumentStore.super.determineCollection(collection);
     }
 
     protected class DefaultGraphSearch<T> extends DefaultSearch<Graph<T>> {

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultIndexOperation.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/DefaultIndexOperation.java
@@ -73,7 +73,7 @@ public class DefaultIndexOperation implements IndexOperation {
     public static DefaultIndexOperation prepare(DocumentStore documentStore, @NonNull Object object) {
         Class<?> objectType = object instanceof Entity<?> e ? e.type() : object.getClass();
         var searchParams = ofNullable(getSearchParameters(objectType)).orElse(defaultSearchParameters);
-        String collection = ofNullable(searchParams.getCollection()).orElseGet(objectType::getSimpleName);
+        String collection = documentStore.determineCollection(objectType);
         String idPath = object instanceof Entity<?> e ? e.idProperty() : getAnnotatedPropertyName(object, EntityId.class).orElse(null);
         return prepare(documentStore, object, collection, idPath,
                        searchParams.getTimestampPath(), searchParams.getEndPath());

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/MaterializedGraphDocumentMigration.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/MaterializedGraphDocumentMigration.java
@@ -78,6 +78,7 @@ public final class MaterializedGraphDocumentMigration {
         Instant end = instant(message.getMetadata().get("$end"));
         String collection = message.getTopic();
         Map<String, SerializedDocument> documents = new LinkedHashMap<>();
+        Map<String, String> modelTypes = new LinkedHashMap<>();
         List<ModelGraphEdge> edges = new ArrayList<>();
         boolean evolved = false;
         for (int index = 0; index < placements.size(); index++) {
@@ -97,6 +98,11 @@ public final class MaterializedGraphDocumentMigration {
             evolved |= !manifest.type(source).equals(direct.getDocument().getType())
                        || source.revision() != direct.getDocument().getRevision();
             SerializedDocument previous = documents.putIfAbsent(source.id(), direct);
+            String modelType = manifest.modelType(source);
+            String previousModelType = modelTypes.putIfAbsent(source.id(), modelType);
+            if (previousModelType != null && !previousModelType.equals(modelType)) {
+                throw incompatible("shared node %s has inconsistent Model types".formatted(source.id()));
+            }
             if (previous != null
                 && (!previous.getDocument().getType().equals(direct.getDocument().getType())
                     || previous.getDocument().getRevision() != direct.getDocument().getRevision()
@@ -105,9 +111,9 @@ public final class MaterializedGraphDocumentMigration {
                 throw incompatible("shared node %s has inconsistent values".formatted(source.id()));
             }
             if (placement.parent() >= 0) {
-                Graph<?> parent = placements.get(placement.parent()).graph();
+                ModelGraphDocumentManifest.Node parent = manifest.nodes().get(placement.parent());
                 edges.add(new ModelGraphEdge(
-                        source.id(), parent.id().toString(), parent.type().getName(),
+                        source.id(), parent.id(), manifest.modelType(parent),
                         placement.path(), 0L, null, false));
             }
         }
@@ -116,7 +122,7 @@ public final class MaterializedGraphDocumentMigration {
         }
         SerializedDocument replacement = ModelGraphDocumentStitcher.stitch(
                 List.of(documents.get(manifest.nodes().getFirst().id())),
-                edges, documents, ModelGraphComposition.builder().build(),
+                edges, documents, modelTypes, ModelGraphComposition.builder().build(),
                 manifest.stateIndex()).getFirst().withCollection(collection);
         return Optional.of(new Migration(expectedManifest, replacement));
     }

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/MaterializedGraphFactory.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/MaterializedGraphFactory.java
@@ -21,13 +21,14 @@ import io.fluxzero.common.SearchUtils;
 import io.fluxzero.common.api.Data;
 import io.fluxzero.common.api.Metadata;
 import io.fluxzero.common.api.search.SerializedDocument;
-import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.common.search.ModelGraphDocumentManifest;
 import io.fluxzero.sdk.common.serialization.Serializer;
 import io.fluxzero.sdk.modeling.Graph;
 import io.fluxzero.sdk.modeling.Graphs;
 import io.fluxzero.sdk.modeling.EntityMetadata;
+import io.fluxzero.sdk.modeling.ModelNames;
 import io.fluxzero.sdk.persisting.repository.ModelRepository;
+import io.fluxzero.sdk.persisting.repository.ModelTypeResolver;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -78,6 +79,10 @@ final class MaterializedGraphFactory {
     }
 
     private static <T> Graph<T> create(Source source, Class<T> rootType) {
+        if (source.repository instanceof ModelTypeResolver resolver) {
+            resolver.modelName(rootType);
+            source.registeredModelTypes.forEach(resolver::modelName);
+        }
         List<Graphs.MaterializedNode> nodes = source.nodes();
         if (nodes.isEmpty() || !rootType.isAssignableFrom(nodes.getFirst().type())) {
             throw new IllegalArgumentException(
@@ -101,6 +106,7 @@ final class MaterializedGraphFactory {
         private final Long previousStateIndex;
         private final Supplier<JsonNode> jsonSupplier;
         private final Map<String, String> pathOverrides;
+        private final List<Class<?>> registeredModelTypes;
         private final Map<Class<?>, List<String>> declaredPaths;
         private volatile JsonNode json;
 
@@ -119,6 +125,7 @@ final class MaterializedGraphFactory {
             this.previousStateIndex = previousStateIndex;
             this.jsonSupplier = Objects.requireNonNull(jsonSupplier, "jsonSupplier");
             this.pathOverrides = Map.copyOf(pathOverrides);
+            this.registeredModelTypes = List.copyOf(registeredModelTypes);
             this.declaredPaths = declaredPaths(registeredModelTypes, pathOverrides);
         }
 
@@ -132,13 +139,15 @@ final class MaterializedGraphFactory {
                             "Invalid parent placement %s for model graph node %s"
                                     .formatted(manifestNode.parent(), manifestNode.id()));
                 }
-                String typeName = manifest.type(manifestNode);
-                String currentTypeName = documentSerializer instanceof Serializer serializer
-                        ? serializer.upcastType(typeName) : typeName;
-                Class<?> type = ReflectionUtils.classForName(currentTypeName, null);
+                String modelTypeName = manifest.modelType(manifestNode);
+                Class<?> type = repository instanceof ModelTypeResolver resolver
+                        ? resolver.modelType(modelTypeName, manifestNode.id())
+                        : registeredModelTypes.stream()
+                                .filter(candidate -> ModelNames.name(candidate).equals(modelTypeName))
+                                .findFirst().orElse(null);
                 if (type == null) {
                     throw new IllegalArgumentException(
-                            "Could not resolve materialized graph model type " + typeName);
+                            "Could not resolve materialized graph Model type " + modelTypeName);
                 }
                 String relationshipPath = manifest.relationshipPath(manifestNode);
                 String documentPath = manifestNode.parent() < 0 ? "" : joinPath(

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStore.java
@@ -391,6 +391,7 @@ public class InMemorySearchStore implements SearchClient {
                         ModelGraphDocumentStitcher.stitch(
                                 roots, edges,
                                 graphDocuments,
+                                graphModelTypes(graphDocuments),
                                 request.getComposition(),
                                 modelStateIndex),
                         graphSearch)
@@ -618,6 +619,21 @@ public class InMemorySearchStore implements SearchClient {
                     }
                 });
         return result;
+    }
+
+    private Map<String, String> graphModelTypes(
+            Map<String, SerializedDocument> graphDocuments) {
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        graphDocuments.forEach((modelId, document) -> {
+            DirectDocumentVersion version = modelDocumentVersions.get(
+                    asIdentifier(document.getCollection(), modelId));
+            if (version == null || version.head() == null) {
+                throw new IllegalStateException(
+                        "No Model head is available for graph component " + modelId);
+            }
+            result.put(modelId, version.head().getModelType());
+        });
+        return Map.copyOf(result);
     }
 
     @Override
@@ -1068,6 +1084,7 @@ public class InMemorySearchStore implements SearchClient {
                                     List.of(root),
                                     edges,
                                     graphDocuments,
+                                    graphModelTypes(graphDocuments),
                                     configuration
                                             .getComposition(),
                                     stateIndex)
@@ -1251,8 +1268,8 @@ public class InMemorySearchStore implements SearchClient {
             String rootId, String rootType, long stateIndex,
             Long previousStateIndex) {
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
-                stateIndex, List.of(rootType), List.of(),
-                List.of(new ModelGraphDocumentManifest.Node(rootId, 0, 0, -1, -1, 0)));
+                stateIndex, List.of(rootType), List.of(rootType), List.of(),
+                List.of(new ModelGraphDocumentManifest.Node(rootId, 0, 0, 0, -1, -1, 0)));
         Metadata metadata = Metadata.of(
                 ModelGraphDocumentManifest.METADATA_KEY, manifest.serialize(),
                 ModelGraphDocumentManifest.TOMBSTONE_METADATA_KEY, true);

--- a/sdk/src/test/java/io/fluxzero/sdk/benchmark/ModelCacheBenchmark.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/benchmark/ModelCacheBenchmark.java
@@ -359,7 +359,7 @@ public class ModelCacheBenchmark {
                 .targets(List.of(
                         ModelCommitTarget.builder()
                                 .modelId(id.toString())
-                                .modelType(Counter.class.getName())
+                                .modelType(Counter.class.getSimpleName())
                                 .storeEvent(true)
                                 .updateState(true)
                                 .relationships(List.of())

--- a/sdk/src/test/java/io/fluxzero/sdk/common/serialization/jackson/GraphJsonSerializerTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/common/serialization/jackson/GraphJsonSerializerTest.java
@@ -256,9 +256,9 @@ class GraphJsonSerializerTest {
                        visible.id(), entity(visible.id(), ViewChild.class, visible),
                        hidden.id(), entity(hidden.id(), ViewChild.class, hidden)),
                 List.of(
-                        new ModelGraphEdge(visible.id(), rootValue.id(), ViewRoot.class.getName(),
+                        new ModelGraphEdge(visible.id(), rootValue.id(), ViewRoot.class.getSimpleName(),
                                            "children", 0L, null, false),
-                        new ModelGraphEdge(hidden.id(), rootValue.id(), ViewRoot.class.getName(),
+                        new ModelGraphEdge(hidden.id(), rootValue.id(), ViewRoot.class.getSimpleName(),
                                            "children", 0L, null, false)),
                 mock(ModelRepository.class), false);
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -1259,10 +1259,7 @@ class DefaultModelRepositoryCommitTest {
         assertEquals(after, serializer.fromDocument(
                 update.getDocument(),
                 PrivateDocument.class));
-        assertEquals(
-                ModelDocumentMutation.referenceModelDocumentCollection(
-                        PrivateDocument.class.getName()),
-                update.getCollection());
+        assertEquals("privateDocuments", update.getCollection());
         assertNull(update.getDocument().getSummary());
         assertTrue(update.getDocument().getFacets().isEmpty());
         assertTrue(update.getDocument().getIndexes().isEmpty());
@@ -1551,7 +1548,9 @@ class DefaultModelRepositoryCommitTest {
     }
 
     @Model(persistence = ModelPersistence.DOCUMENT,
-            document = @DocumentProjection(searchable = false),
+            document = @DocumentProjection(
+                    searchable = false,
+                    collection = "privateDocuments"),
             eventPublication = EventPublication.NEVER)
     private record PrivateDocument(
             @EntityId PrivateDocumentId documentId,

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -29,6 +29,8 @@ import io.fluxzero.common.api.modeling.ModelUpdate;
 import io.fluxzero.common.api.modeling.ModelUpdateKind;
 import io.fluxzero.common.api.search.SerializedDocument;
 import io.fluxzero.common.serialization.Revision;
+import io.fluxzero.common.search.Facet;
+import io.fluxzero.common.search.Sortable;
 import io.fluxzero.sdk.Fluxzero;
 import io.fluxzero.sdk.common.Message;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
@@ -1232,7 +1234,8 @@ class DefaultModelRepositoryCommitTest {
     @Test
     void neverPublicationUpdatesStateAndDirectDocumentWithoutCreatingEvent() throws Exception {
         PrivateDocumentId id = new PrivateDocumentId("1");
-        PrivateDocument after = new PrivateDocument(id, "secret");
+        PrivateDocument after = new PrivateDocument(
+                id, "findable summary", "classified", 42);
         var evaluation = evaluation(
                 List.of(id.toString()),
                 substep(new UpdatePrivateDocument(id), transition(
@@ -1257,8 +1260,15 @@ class DefaultModelRepositoryCommitTest {
                 update.getDocument(),
                 PrivateDocument.class));
         assertEquals(
-                "privateDocuments",
+                ModelDocumentMutation.referenceModelDocumentCollection(
+                        PrivateDocument.class.getName()),
                 update.getCollection());
+        assertNull(update.getDocument().getSummary());
+        assertTrue(update.getDocument().getFacets().isEmpty());
+        assertTrue(update.getDocument().getIndexes().isEmpty());
+        assertNull(update.getDocument().deserializeDocument().getSummary());
+        assertTrue(update.getDocument().deserializeDocument().getFacets().isEmpty());
+        assertTrue(update.getDocument().deserializeDocument().getSortables().isEmpty());
     }
 
     @Test
@@ -1540,9 +1550,14 @@ class DefaultModelRepositoryCommitTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "privateDocuments"),
+    @Model(persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(searchable = false),
             eventPublication = EventPublication.NEVER)
-    private record PrivateDocument(@EntityId PrivateDocumentId documentId, String value) {
+    private record PrivateDocument(
+            @EntityId PrivateDocumentId documentId,
+            String description,
+            @Facet String category,
+            @Sortable int priority) {
     }
 
     private static class PrivateDocumentId extends Id<PrivateDocument> {

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/DefaultModelRepositoryCommitTest.java
@@ -545,7 +545,7 @@ class DefaultModelRepositoryCommitTest {
         assertNotNull(document);
         assertEquals(
                 ModelDocumentMutation.privateModelDocumentCollection(
-                        GraphOnlyChild.class.getName()),
+                        GraphOnlyChild.class.getSimpleName()),
                 document.getCollection());
         assertEquals(
                 after,
@@ -637,7 +637,7 @@ class DefaultModelRepositoryCommitTest {
                 nextCustomer.toString(),
                 target.getRelationships().getFirst().getParentId());
         assertEquals(
-                Customer.class.getName(),
+                Customer.class.getSimpleName(),
                 target.getRelationships().getFirst().getParentType());
         assertEquals(
                 "orders",
@@ -665,7 +665,7 @@ class DefaultModelRepositoryCommitTest {
                 .findFirst().orElseThrow();
         assertEquals(1, target.getRelationships().size());
         assertEquals(parentId.toString(), target.getRelationships().getFirst().getParentId());
-        assertEquals(AlternateCustomer.class.getName(),
+        assertEquals(AlternateCustomer.class.getSimpleName(),
                      target.getRelationships().getFirst().getParentType());
         assertEquals("contacts", target.getRelationships().getFirst().getPath());
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
@@ -186,6 +186,13 @@ class EntityMetadataTest {
                 EntityMetadata.validate(DefaultProjectedModel.class)
                         .graphProjectionConfiguration()
                         .orElseThrow().getCollection());
+        var referenceOnlyConfiguration =
+                EntityMetadata.validate(ReferenceOnlyProjectedModel.class)
+                        .graphProjectionConfiguration().orElseThrow();
+        assertEquals("reference-only-projected-models",
+                     referenceOnlyConfiguration.getRootCollection());
+        assertEquals("reference-only-projected-models-graphs",
+                     referenceOnlyConfiguration.getCollection());
         assertTrue(EntityMetadata.validate(ParentModel.class)
                            .graphProjectionConfiguration().isEmpty());
         assertTrue(EntityMetadata.validate(ConfiguredUnmaterializedModel.class)
@@ -635,6 +642,16 @@ class EntityMetadataTest {
             document = @DocumentProjection(collection = "default-projected-models"),
             materializeGraph = true)
     private record DefaultProjectedModel(
+            @EntityId String id) {
+    }
+
+    @Model(
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
+            document = @DocumentProjection(
+                    searchable = false,
+                    collection = "reference-only-projected-models"),
+            materializeGraph = true)
+    private record ReferenceOnlyProjectedModel(
             @EntityId String id) {
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/EntityMetadataTest.java
@@ -139,7 +139,7 @@ class EntityMetadataTest {
     void ownsDirectModelDocumentCollectionResolution() {
         assertEquals("models", EntityMetadata.validate(ConfiguredModel.class)
                 .modelDocumentCollection().orElseThrow());
-        assertEquals(privateModelDocumentCollection(ChildModel.class.getName()), EntityMetadata.validate(ChildModel.class)
+        assertEquals(privateModelDocumentCollection(ChildModel.class.getSimpleName()), EntityMetadata.validate(ChildModel.class)
                 .modelDocumentCollection().orElseThrow());
         assertTrue(EntityMetadata.validate(ParentModel.class)
                            .modelDocumentCollection().isEmpty());
@@ -176,7 +176,7 @@ class EntityMetadataTest {
                         .graphProjectionConfiguration()
                         .orElseThrow();
         assertEquals(
-                privateModelDocumentCollection(UnsearchableProjectedModel.class.getName()),
+                privateModelDocumentCollection(UnsearchableProjectedModel.class.getSimpleName()),
                 privateConfiguration.getRootCollection());
         assertEquals(
                 "UnsearchableProjectedModel-graphs",
@@ -216,11 +216,11 @@ class EntityMetadataTest {
         assertEquals(
                 List.of(
                         new io.fluxzero.common.api.modeling.ModelGraphProjectionConfiguration.ModelRevision(
-                                ProjectedModel.class.getName(), 0),
+                                ProjectedModel.class.getSimpleName(), 0),
                         new io.fluxzero.common.api.modeling.ModelGraphProjectionConfiguration.ModelRevision(
-                                RevisionedProjectedChild.class.getName(), 2),
+                                RevisionedProjectedChild.class.getSimpleName(), 2),
                         new io.fluxzero.common.api.modeling.ModelGraphProjectionConfiguration.ModelRevision(
-                                RevisionedProjectedGrandchild.class.getName(), 3)),
+                                RevisionedProjectedGrandchild.class.getSimpleName(), 3)),
                 configuration.getModelRevisions());
     }
 
@@ -304,11 +304,12 @@ class EntityMetadataTest {
                                                      "document",
                                                      "graphProjection",
                                                      "materializeGraph",
+                                                     "name",
                                                      "persistence")
                                                      .contains(name))
                              .collect(toSet()));
         Set<String> expectedConfiguration = new java.util.HashSet<>(modelSettings);
-        expectedConfiguration.removeAll(Set.of("document", "persistence"));
+        expectedConfiguration.removeAll(Set.of("document", "name", "persistence"));
         expectedConfiguration.addAll(Set.of(
                 "eventSourced", "directDocument", "publicDocument", "collection", "timestampPath", "endPath"));
         assertEquals(expectedConfiguration, configurationSettings);

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelEntityParameterResolverTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelEntityParameterResolverTest.java
@@ -888,7 +888,7 @@ class ModelEntityParameterResolverTest {
                                                     .targets(List.of(
                                                             ModelCommitTarget.builder()
                                                                     .modelId(accountId.toString())
-                                                                    .modelType(Account.class.getName())
+                                                                    .modelType(Account.class.getSimpleName())
                                                                     .storeEvent(true)
                                                                     .updateState(true)
                                                                     .relationships(List.of())
@@ -943,7 +943,7 @@ class ModelEntityParameterResolverTest {
                                                     .targets(List.of(
                                                             ModelCommitTarget.builder()
                                                                     .modelId(accountId.toString())
-                                                                    .modelType(Account.class.getName())
+                                                                    .modelType(Account.class.getSimpleName())
                                                                     .storeEvent(true)
                                                                     .updateState(true)
                                                                     .relationships(List.of())

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
@@ -263,7 +263,9 @@ class ModelGraphComponentSearchTest {
         }
     }
 
-    @Model
+    @Model(
+            persistence = {ModelPersistence.EVENT_SOURCED, ModelPersistence.DOCUMENT},
+            document = @DocumentProjection(searchable = false))
     private record PrivateChild(
             @EntityId PrivateChildId privateChildId,
             @Parent(pathInParent = "privateChildren") SearchRootId searchRootId,

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelGraphComponentSearchTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.fluxzero.common.api.search.constraints.MatchConstraint.match;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -142,14 +143,14 @@ class ModelGraphComponentSearchTest {
     }
 
     @Test
-    void givesEveryPrivateComponentTypeItsOwnInternalCollection() {
+    void resolvesDirectAndGraphOnlyPrivateComponentCollectionsIndependently() {
         String first = EntityMetadata.validate(PrivateChild.class)
                 .modelDocumentCollection().orElseThrow();
         String second = EntityMetadata.validate(OtherPrivateChild.class)
                 .modelDocumentCollection().orElseThrow();
 
         assertNotEquals(first, second);
-        assertTrue(first.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), first);
+        assertEquals("PrivateChild", first);
         assertTrue(second.startsWith(ModelDocumentMutation.PRIVATE_MODEL_DOCUMENT_COLLECTION_PREFIX), second);
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
@@ -163,7 +163,7 @@ class ModelTest {
         assertFalse(metadata.rootConfiguration().orElseThrow().publicDocument());
         assertEquals(
                 io.fluxzero.common.api.modeling.ModelDocumentMutation
-                        .privateModelDocumentCollection(
+                        .referenceModelDocumentCollection(
                                 ReferenceOnlyDocumentModel.class.getName()),
                 metadata.modelDocumentCollection().orElseThrow());
         assertFalse(search.isSearchable());

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
@@ -153,7 +153,7 @@ class ModelTest {
     }
 
     @Test
-    void keepsReferenceOnlyDocumentsOutOfThePublicModelCollection() {
+    void keepsReferenceOnlyDocumentsInTheirResolvedCollection() {
         EntityMetadata metadata = EntityMetadata.validate(
                 ReferenceOnlyDocumentModel.class);
         SearchParameters search = ClientUtils.getSearchParameters(
@@ -161,12 +161,13 @@ class ModelTest {
 
         assertTrue(metadata.rootConfiguration().orElseThrow().directDocument());
         assertFalse(metadata.rootConfiguration().orElseThrow().publicDocument());
-        assertEquals(
-                io.fluxzero.common.api.modeling.ModelDocumentMutation
-                        .referenceModelDocumentCollection(
-                                ReferenceOnlyDocumentModel.class.getName()),
-                metadata.modelDocumentCollection().orElseThrow());
+        assertEquals("ReferenceOnlyDocumentModel",
+                     metadata.modelDocumentCollection().orElseThrow());
         assertFalse(search.isSearchable());
+        assertEquals("ReferenceOnlyDocumentModel", search.getCollection());
+        assertEquals("private-models",
+                     EntityMetadata.validate(PrivateDocumentWithConfiguredCollection.class)
+                             .modelDocumentCollection().orElseThrow());
     }
 
     @Test
@@ -181,8 +182,6 @@ class ModelTest {
     void rejectsDocumentProjectionSettingsWithoutMatchingPersistence() {
         assertThrows(IllegalStateException.class,
                      () -> EntityMetadata.validate(InvalidReferenceOnlyProjection.class));
-        assertThrows(IllegalStateException.class,
-                     () -> EntityMetadata.validate(PrivateDocumentWithPublicCollection.class));
     }
 
     @Test
@@ -297,8 +296,9 @@ class ModelTest {
             persistence = ModelPersistence.DOCUMENT,
             document = @DocumentProjection(
                     searchable = false,
-                    collection = "public-models"))
-    private static class PrivateDocumentWithPublicCollection {
+                    collection = "private-models"))
+    private record PrivateDocumentWithConfiguredCollection(
+            @EntityId String id) {
     }
 
     @Model(persistence = ModelPersistence.DOCUMENT, ignoreUnknownEvents = true)

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelTest.java
@@ -20,6 +20,8 @@ import io.fluxzero.common.api.modeling.ModelConflictPolicy;
 import io.fluxzero.common.reflection.ReflectionUtils;
 import io.fluxzero.sdk.common.ClientUtils;
 import io.fluxzero.sdk.persisting.eventsourcing.Apply;
+import io.fluxzero.sdk.persisting.search.DefaultIndexOperation;
+import io.fluxzero.sdk.persisting.search.DocumentStore;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -36,6 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 class ModelTest {
 
@@ -57,6 +62,7 @@ class ModelTest {
         assertEquals(EventPublicationStrategy.DEFAULT, model.publicationStrategy());
         assertEquals(ModelConflictPolicy.DEFAULT, model.conflictPolicy());
         assertEquals(AutomaticModelHandling.DEFAULT, model.automaticHandling());
+        assertEquals("", model.name());
         assertFalse(model.materializeGraph());
         assertTrue(model.document().searchable());
         assertEquals("", model.document().collection());
@@ -115,6 +121,7 @@ class ModelTest {
                         "document",
                         "graphProjection",
                         "materializeGraph",
+                        "name",
                         "persistence"),
                 modelSettings.stream()
                         .filter(setting ->
@@ -126,7 +133,34 @@ class ModelTest {
                      aggregateSettings.stream()
                              .filter(setting -> !modelSettings.contains(setting))
                              .collect(Collectors.toSet()));
-        assertFalse(modelSettings.contains("name"));
+    }
+
+    @Test
+    void resolvesStableLogicalNamesPerConcreteType() {
+        assertEquals("NamedModel", ModelNames.name(NamedModel.class));
+        assertEquals("OriginalName", ModelNames.name(RenamedModel.class));
+        assertEquals("ConcreteNamedModel", ModelNames.name(ConcreteNamedModel.class));
+        assertEquals("billingOriginalName", ModelNames.name(RenamedModel.class, "billing"));
+    }
+
+    @Test
+    void letsTheDocumentStoreOwnModelCollectionResolution() {
+        DocumentStore documentStore = mock(DocumentStore.class, CALLS_REAL_METHODS);
+        doReturn("billingOriginalName")
+                .when(documentStore).determineCollection(RenamedModel.class);
+
+        DefaultIndexOperation operation = DefaultIndexOperation.prepare(
+                documentStore, new RenamedModel());
+
+        assertEquals("billingOriginalName", operation.collection());
+    }
+
+    @Test
+    void rejectsAmbiguousConfiguredModelNamesAndPrefixes() {
+        assertThrows(IllegalStateException.class,
+                     () -> EntityMetadata.validate(BlankNamedModel.class));
+        assertThrows(IllegalArgumentException.class,
+                     () -> ModelNames.name(NamedModel.class, "  "));
     }
 
     @Test
@@ -163,6 +197,8 @@ class ModelTest {
         assertFalse(metadata.rootConfiguration().orElseThrow().publicDocument());
         assertEquals("ReferenceOnlyDocumentModel",
                      metadata.modelDocumentCollection().orElseThrow());
+        assertEquals("billingReferenceOnlyDocumentModel",
+                     metadata.modelDocumentCollection("billing").orElseThrow());
         assertFalse(search.isSearchable());
         assertEquals("ReferenceOnlyDocumentModel", search.getCollection());
         assertEquals("private-models",
@@ -318,6 +354,33 @@ class ModelTest {
     }
 
     private static class InheritedModel extends BaseModel {
+    }
+
+    @Model
+    private static class NamedModel {
+        @EntityId
+        String id;
+    }
+
+    @Model(name = "OriginalName")
+    private static class RenamedModel {
+        @EntityId
+        String id = "id";
+    }
+
+    @Model(name = "BaseName")
+    private static class NamedBaseModel {
+        @EntityId
+        String id;
+    }
+
+    private static class ConcreteNamedModel extends NamedBaseModel {
+    }
+
+    @Model(name = " ")
+    private static class BlankNamedModel {
+        @EntityId
+        String id;
     }
 
     @Model

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1097,6 +1097,7 @@ class DefaultModelRepositoryTest {
                             id, "first-code", 5))).join();
             String collection = EntityMetadata.validate(AliasAccount.class)
                     .modelDocumentCollection().orElseThrow();
+            assertEquals("AliasAccount", collection);
             SerializedDocument stored = client.getSearchClient()
                     .fetchModelDocument(new GetDocument(
                             id.toString(), collection))
@@ -1105,6 +1106,12 @@ class DefaultModelRepositoryTest {
             assertNull(stored.getSummary());
             assertTrue(stored.getFacets().isEmpty());
             assertTrue(stored.getIndexes().isEmpty());
+            assertEquals(new AliasAccount(id, "first-code", 5),
+                         fluxzero.documentStore()
+                                 .fetchDocument(id, AliasAccount.class, AliasAccount.class)
+                                 .orElseThrow());
+            assertTrue(fluxzero.documentStore().search(AliasAccount.class)
+                               .fetchAll().isEmpty());
             ((DefaultModelRepository) fluxzero.modelRepository())
                     .invalidateModels(List.of(id.toString()));
 

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -155,7 +155,7 @@ class DefaultModelRepositoryTest {
                     value == null ? null : serializer.toDocument(
                             value, request.getId(), request.getCollection(), null, null, Metadata.empty()),
                     value == null ? null : new ModelHeadState(
-                            request.getId(), Product.class.getName(), 0L, 0L, true, false));
+                            request.getId(), Product.class.getSimpleName(), 0L, 0L, true, false));
         });
         return new DefaultModelRepository(
                 client, documentStore, serializer,
@@ -268,7 +268,7 @@ class DefaultModelRepositoryTest {
     @Test
     void pluralMigrationAdoptionRebuildsApplicationGraphProjectionsEvenWhenResumed() {
         ModelHeadState migratedHead = new ModelHeadState(
-                "root-1", ProjectedRoot.class.getName(),
+                "root-1", ProjectedRoot.class.getSimpleName(),
                 0L, 5L, true, false);
         SerializedDocument migratedDocument = serializer.toDocument(
                 new ProjectedRoot("root-1"), "root-1", "ProjectedRoot",
@@ -297,6 +297,38 @@ class DefaultModelRepositoryTest {
                 .registerModelGraphProjection(registrations.capture());
         assertTrue(registrations.getAllValues().stream()
                            .allMatch(io.fluxzero.common.api.modeling.RegisterModelGraphProjection::isRebuild));
+    }
+
+    @Test
+    void rejectsDuplicateLogicalModelNamesAtCatalogRegistration() {
+        @Model(name = "DuplicateLogicalName")
+        record First(@EntityId String id) {
+        }
+        @Model(name = "DuplicateLogicalName")
+        record Second(@EntityId String id) {
+        }
+        IllegalStateException failure = assertThrows(
+                IllegalStateException.class,
+                () -> repository.configureModelTypes(
+                        () -> List.of(First.class, Second.class)));
+
+        assertTrue(failure.getMessage().contains("DuplicateLogicalName"));
+        assertTrue(failure.getMessage().contains(First.class.getName()));
+        assertTrue(failure.getMessage().contains(Second.class.getName()));
+    }
+
+    @Test
+    void appliesTheRepositoryScopedPrefixToLogicalModelNames() {
+        DefaultModelRepository prefixedRepository = new DefaultModelRepository(
+                client, documentStore, serializer,
+                new DefaultEntityHelper(List.of(), false), null,
+                NoOpCache.INSTANCE, List.of(), "billing");
+
+        assertEquals("billingRenamedAccount",
+                     prefixedRepository.modelName(AliasedAccount.class));
+        assertEquals(AliasedAccount.class,
+                     prefixedRepository.modelType(
+                             "billingRenamedAccount", "test lookup"));
     }
 
     @Test
@@ -498,16 +530,13 @@ class DefaultModelRepositoryTest {
     }
 
     @Test
-    void untypedLoadResolvesStoredModelTypeThroughSerializerAlias() {
+    void untypedLoadResolvesStoredLogicalModelNameWithoutAClassNameAlias() {
         AliasedAccountId id =
                 new AliasedAccountId("renamed-type");
         try (Fluxzero fluxzero = configuredFluxzero()) {
-            fluxzero.serializer().registerTypeCaster(
-                    "legacy.example.AliasedAccount",
-                    AliasedAccount.class.getName());
             commitDirectDocument(
                     fluxzero, "renamed-type", id.toString(),
-                    "legacy.example.AliasedAccount", "aliasedAccounts",
+                    io.fluxzero.sdk.modeling.ModelNames.name(AliasedAccount.class), "aliasedAccounts",
                     new AliasedAccount(id, 7));
 
             Entity<Object> loaded =
@@ -935,7 +964,7 @@ class DefaultModelRepositoryTest {
                 .build(LocalClient.newInstance(null))) {
             commitDirectDocument(
                     fluxzero, "configured-product", id.toString(),
-                    Product.class.getName(), "products", product);
+                    Product.class.getSimpleName(), "products", product);
 
             var result = fluxzero.modelRepository().load(id);
 
@@ -967,12 +996,12 @@ class DefaultModelRepositoryTest {
             commitDirectDocument(
                     client, serializer, documentSerializer,
                     "enveloped-first", firstId.toString(),
-                    Product.class.getName(), "products", first,
+                    Product.class.getSimpleName(), "products", first,
                     timestamp, end, metadata);
             commitDirectDocument(
                     client, serializer, documentSerializer,
                     "enveloped-second", secondId.toString(),
-                    Product.class.getName(), "products", second,
+                    Product.class.getSimpleName(), "products", second,
                     timestamp, end, metadata);
 
             DefaultModelRepository restarted =
@@ -996,7 +1025,7 @@ class DefaultModelRepositoryTest {
             commitDirectDocument(
                     client.forNamespace(namespace), serializer,
                     documentSerializer, "enveloped-namespaced",
-                    namespacedId.toString(), Product.class.getName(),
+                    namespacedId.toString(), Product.class.getSimpleName(),
                     "products", namespaced, timestamp, end, metadata);
             assertEquals(
                     namespaced,
@@ -2196,7 +2225,7 @@ class DefaultModelRepositoryTest {
                 .targets(java.util.Arrays.stream(targetIds)
                                  .map(modelId -> ModelCommitTarget.builder()
                                          .modelId(modelId)
-                                         .modelType(modelType.getName())
+                                         .modelType(io.fluxzero.sdk.modeling.ModelNames.name(modelType))
                                          .storeEvent(true)
                                          .updateState(true)
                                          .relationships(List.of())
@@ -2375,7 +2404,7 @@ class DefaultModelRepositoryTest {
                         .publishEvent(false)
                         .targets(List.of(ModelCommitTarget.builder()
                                                  .modelId(event.targetId())
-                                                 .modelType(event.modelType().getName())
+                                                 .modelType(io.fluxzero.sdk.modeling.ModelNames.name(event.modelType()))
                                                  .storeEvent(true)
                                                  .updateState(true)
                                                  .relationships(List.of())
@@ -2489,7 +2518,8 @@ class DefaultModelRepositoryTest {
         }
     }
 
-    @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "aliasedAccounts"))
+    @Model(name = "RenamedAccount", persistence = ModelPersistence.DOCUMENT,
+            document = @DocumentProjection(collection = "aliasedAccounts"))
     private record AliasedAccount(
             @EntityId AliasedAccountId accountId,
             int balance) {

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1625,7 +1625,12 @@ class DefaultModelRepositoryTest {
             GetModelEventsResult result =
                     (GetModelEventsResult)
                             invocation.callRealMethod();
-            if (intercept.compareAndSet(true, false)) {
+            GetModelEvents request = invocation.getArgument(0);
+            boolean reconstructsTarget = request.getRequests().stream()
+                    .anyMatch(stream -> id.toString().equals(stream.getModelId())
+                                        && stream.getMaxSize() > 0);
+            if (reconstructsTarget
+                && intercept.compareAndSet(true, false)) {
                 reconstructionLoaded.countDown();
                 allowReconstructionCompletion.await();
             }

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -131,6 +131,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static io.fluxzero.common.MessageType.EVENT;
 import static io.fluxzero.common.MessageType.COMMAND;
+import static io.fluxzero.common.reflection.ReflectionUtils.getFieldValue;
 
 class DefaultModelRepositoryTest {
 
@@ -1651,6 +1652,11 @@ class DefaultModelRepositoryTest {
             DefaultModelRepository repository =
                     (DefaultModelRepository)
                             fluxzero.modelRepository();
+            getFieldValue(
+                    "modelCacheTracker", repository)
+                    .map(ModelCacheTracker.class::cast)
+                    .orElseThrow()
+                    .close();
             repository.invalidateModels(
                     List.of(id.toString()));
             intercept.set(true);
@@ -1672,9 +1678,22 @@ class DefaultModelRepositoryTest {
             assertEquals(
                     new Account(id, 5),
                     olderReconstruction.join().get());
+            AtomicReference<Entity<?>> cached =
+                    new AtomicReference<>();
+            cache.<Object>modifyEach((ignored, value) -> {
+                if (value instanceof Entity<?> entity) {
+                    cached.set(entity);
+                }
+                return value;
+            });
+            assertNotNull(cached.get());
             assertEquals(
                     new Account(id, 20),
-                    repository.load(id).get());
+                    cached.get().get());
+            assertEquals(
+                    oldStateIndex + 1L,
+                    ((ModelRoot<?>) cached.get())
+                            .stateIndex());
         } finally {
             allowReconstructionCompletion.countDown();
         }

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/DefaultModelRepositoryTest.java
@@ -1082,10 +1082,29 @@ class DefaultModelRepositoryTest {
     @Test
     void loadsIndependentModelByCurrentAliasWithoutSearch() {
         AliasAccountId id = new AliasAccountId("1");
-        try (Fluxzero fluxzero = configuredFluxzero()) {
+        JacksonSerializer serializer = new JacksonSerializer();
+        EnvelopeDocumentSerializer documentSerializer =
+                new EnvelopeDocumentSerializer(serializer);
+        LocalClient client = LocalClient.newInstance(null);
+        try (Fluxzero fluxzero = withModelHandlers(DefaultFluxzero.builder()
+                .replaceSerializer(serializer)
+                .replaceDocumentSerializer(documentSerializer)
+                .disableKeepalive()
+                .disableShutdownHook()
+                .build(client))) {
             fluxzero.executeModelCommit(
                     new Message(new CreateAliasAccount(
                             id, "first-code", 5))).join();
+            String collection = EntityMetadata.validate(AliasAccount.class)
+                    .modelDocumentCollection().orElseThrow();
+            SerializedDocument stored = client.getSearchClient()
+                    .fetchModelDocument(new GetDocument(
+                            id.toString(), collection))
+                    .getDocument();
+            assertNotNull(stored);
+            assertNull(stored.getSummary());
+            assertTrue(stored.getFacets().isEmpty());
+            assertTrue(stored.getIndexes().isEmpty());
             ((DefaultModelRepository) fluxzero.modelRepository())
                     .invalidateModels(List.of(id.toString()));
 
@@ -1116,6 +1135,9 @@ class DefaultModelRepositoryTest {
                             "second-code", AliasAccount.class));
             assertEquals(id.toString(), renamed.id());
             assertEquals("second-code", renamed.get().code());
+            assertTrue(documentSerializer.reads().stream()
+                               .anyMatch(read -> id.toString().equals(read.id())
+                                                 && collection.equals(read.collection())));
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursorTest.java
@@ -73,7 +73,7 @@ class ModelReplayCursorTest {
         String modelId = "incomplete-document";
         long boundary = 42L;
         ModelHeadState head = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 1L, 40L, false, false);
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelEvents(any())).thenAnswer(invocation -> {
@@ -92,7 +92,8 @@ class ModelReplayCursorTest {
                         head));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
         MutationPlan.Resolution resolution = new MutationPlan.Resolution(
                 List.of(new MutationPlan.ResolvedModel(
                         modelId, CurrentDocument.class,
@@ -112,10 +113,10 @@ class ModelReplayCursorTest {
         String modelId = "moved-incomplete-document";
         long boundary = 42L;
         ModelHeadState historicalHead = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 1L, 40L, false, false);
         ModelHeadState currentHead = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 2L, 43L, false, false);
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelEvents(any())).thenAnswer(invocation -> {
@@ -135,7 +136,8 @@ class ModelReplayCursorTest {
                         currentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
         MutationPlan.Resolution resolution = new MutationPlan.Resolution(
                 List.of(new MutationPlan.ResolvedModel(
                         modelId, CurrentDocument.class,
@@ -158,10 +160,10 @@ class ModelReplayCursorTest {
         long requestedBoundary = 42L;
         long currentBoundary = 43L;
         ModelHeadState historicalHead = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 1L, 40L, false, false);
         ModelHeadState currentHead = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 2L, currentBoundary, false, false);
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelEvents(any())).thenAnswer(invocation -> {
@@ -183,7 +185,8 @@ class ModelReplayCursorTest {
                         currentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
         MutationPlan.Resolution resolution = new MutationPlan.Resolution(
                 List.of(new MutationPlan.ResolvedModel(
                         modelId, CurrentDocument.class,
@@ -204,7 +207,7 @@ class ModelReplayCursorTest {
         String modelId = "lagging-incomplete-document";
         long boundary = 42L;
         ModelHeadState head = new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 1L, 40L, false, false);
         EventStoreClient client = mock(EventStoreClient.class);
         when(client.getModelEvents(any())).thenAnswer(invocation -> {
@@ -232,7 +235,8 @@ class ModelReplayCursorTest {
                                     head));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
         MutationPlan.Resolution resolution = new MutationPlan.Resolution(
                 List.of(new MutationPlan.ResolvedModel(
                         modelId, CurrentDocument.class,
@@ -281,7 +285,8 @@ class ModelReplayCursorTest {
                         currentDocumentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         Graph<CurrentDocument> result = loader.graph(
                 modelId, CurrentDocument.class, Graph.Options.DEFAULT,
@@ -310,7 +315,8 @@ class ModelReplayCursorTest {
                         head));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         Graph<CurrentDocument> result = loader.graph(
                 modelId, CurrentDocument.class, Graph.Options.DEFAULT,
@@ -345,7 +351,8 @@ class ModelReplayCursorTest {
                         head));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         Graph<CurrentDocument> result = loader.graph(
                 modelId, CurrentDocument.class, Graph.Options.DEFAULT,
@@ -382,7 +389,8 @@ class ModelReplayCursorTest {
                         documentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         Graph<CurrentDocument> result = loader.graph(
                 modelId, CurrentDocument.class, Graph.Options.DEFAULT,
@@ -421,7 +429,8 @@ class ModelReplayCursorTest {
                                 head));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         Graph<CurrentDocument> result = loader.graph(
                 modelId, CurrentDocument.class, Graph.Options.DEFAULT,
@@ -453,7 +462,8 @@ class ModelReplayCursorTest {
                         currentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         EventSourcingException failure = assertThrows(
                 EventSourcingException.class,
@@ -491,7 +501,8 @@ class ModelReplayCursorTest {
                         currentHead));
         ModelReplayCursor loader = new ModelReplayCursor(
                 client, new JacksonSerializer(), null, null, null, null,
-                documentReader, mock(ModelRepository.class));
+                documentReader, mock(ModelRepository.class),
+                ModelReplayCursor.EventBoundaryBarrier.NONE, currentDocumentTypes());
 
         assertThrows(
                 EventSourcingException.class,
@@ -518,7 +529,7 @@ class ModelReplayCursorTest {
             long sequenceNumber,
             long stateIndex) {
         return new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 sequenceNumber, stateIndex, true, false);
     }
 
@@ -527,8 +538,26 @@ class ModelReplayCursorTest {
             long sequenceNumber,
             long stateIndex) {
         return new ModelHeadState(
-                modelId, CurrentDocument.class.getName(),
+                modelId, CurrentDocument.class.getSimpleName(),
                 sequenceNumber, stateIndex, false, false);
+    }
+
+    private static ModelTypeResolver currentDocumentTypes() {
+        return new ModelTypeResolver() {
+            @Override
+            public String modelName(Class<?> modelType) {
+                return modelType.getSimpleName();
+            }
+
+            @Override
+            public Class<?> modelType(String modelName, String modelId) {
+                if (!CurrentDocument.class.getSimpleName().equals(modelName)) {
+                    throw new IllegalStateException(
+                            "Unknown Model type " + modelName + " for " + modelId);
+                }
+                return CurrentDocument.class;
+            }
+        };
     }
 
     @Model(persistence = ModelPersistence.DOCUMENT, document = @DocumentProjection(collection = "currentDocuments"))

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/search/MaterializedGraphFactoryTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/search/MaterializedGraphFactoryTest.java
@@ -66,14 +66,15 @@ class MaterializedGraphFactoryTest {
                 .put("oldValue", "current child");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
                 41L,
+                List.of("RevisionedRoot", "RevisionedChild"),
                 List.of("legacy.RevisionedRoot",
                         "legacy.RevisionedChild"),
                 List.of("children"),
                 List.of(
                         new ModelGraphDocumentManifest.Node(
-                                "root", 0, 0, -1, -1, 0),
+                                "root", 0, 0, 0, -1, -1, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "child", 1, 0, 0, 0, 0)));
+                                "child", 1, 1, 0, 0, 0, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "root", "revisioned-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -155,14 +156,15 @@ class MaterializedGraphFactoryTest {
         ModelGraphDocumentManifest manifest =
                 new ModelGraphDocumentManifest(
                         41L,
+                        List.of("CountingRoot", "CountingChild"),
                         List.of(CountingRoot.class.getName(),
                                 CountingChild.class.getName()),
                         List.of("children"),
                         List.of(
                                 new ModelGraphDocumentManifest.Node(
-                                        "root", 0, 0, -1, -1, 0),
+                                        "root", 0, 0, 0, -1, -1, 0),
                                 new ModelGraphDocumentManifest.Node(
-                                        "child", 1, 0, 0, 0, 0)));
+                                        "child", 1, 1, 0, 0, 0, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "root", "root-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -195,9 +197,9 @@ class MaterializedGraphFactoryTest {
         ObjectNode json = serializer.getObjectMapper().createObjectNode()
                 .put("id", "child").put("rootId", "root");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
-                41L, List.of(CountingChild.class.getName()), List.of(),
+                41L, List.of("CountingChild"), List.of(CountingChild.class.getName()), List.of(),
                 List.of(new ModelGraphDocumentManifest.Node(
-                        "child", 0, 0, -1, -1, 0)));
+                        "child", 0, 0, 0, -1, -1, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "child", "child-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -244,6 +246,7 @@ class MaterializedGraphFactoryTest {
                 .put("id", "secondary").put("rootId", "root");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
                 41L,
+                List.of("MultiParentRoot", "PrimaryParent", "SecondaryParent", "MultiParentChild"),
                 List.of(MultiParentRoot.class.getName(),
                         PrimaryParent.class.getName(),
                         SecondaryParent.class.getName(),
@@ -251,15 +254,15 @@ class MaterializedGraphFactoryTest {
                 List.of("primaryParents", "secondaryParents", "children"),
                 List.of(
                         new ModelGraphDocumentManifest.Node(
-                                "root", 0, 0, -1, -1, 0),
+                                "root", 0, 0, 0, -1, -1, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "primary", 1, 0, 0, 0, 0),
+                                "primary", 1, 1, 0, 0, 0, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "child", 3, 0, 1, 2, 0),
+                                "child", 3, 3, 0, 1, 2, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "secondary", 2, 0, 0, 1, 0),
+                                "secondary", 2, 2, 0, 0, 1, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "alternate-primary", 1, 0, 0, 0, 1)));
+                                "alternate-primary", 1, 1, 0, 0, 0, 1)));
         SerializedDocument document = serializer.toDocument(
                 json, "root", "multi-parent-root-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -299,14 +302,15 @@ class MaterializedGraphFactoryTest {
                 .put("alternatePrimaryId", "external-primary");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
                 41L,
+                List.of("PrimaryParent", "MultiParentChild"),
                 List.of(PrimaryParent.class.getName(),
                         MultiParentChild.class.getName()),
                 List.of("children"),
                 List.of(
                         new ModelGraphDocumentManifest.Node(
-                                "primary", 0, 0, -1, -1, 0),
+                                "primary", 0, 0, 0, -1, -1, 0),
                         new ModelGraphDocumentManifest.Node(
-                                "child", 1, 0, 0, 0, 0)));
+                                "child", 1, 1, 0, 0, 0, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "primary", "primary-parent-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -333,9 +337,9 @@ class MaterializedGraphFactoryTest {
         ObjectNode json = serializer.getObjectMapper().createObjectNode()
                 .put("id", "child").put("rootId", "root");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
-                41L, List.of(CountingChild.class.getName()), List.of(),
+                41L, List.of("CountingChild"), List.of(CountingChild.class.getName()), List.of(),
                 List.of(new ModelGraphDocumentManifest.Node(
-                        "child", 0, 0, -1, -1, 0)));
+                        "child", 0, 0, 0, -1, -1, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "child", "child-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,
@@ -367,9 +371,9 @@ class MaterializedGraphFactoryTest {
         ObjectNode json = serializer.getObjectMapper().createObjectNode()
                 .put("id", "root");
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
-                41L, List.of(CountingRoot.class.getName()), List.of(),
+                41L, List.of("CountingRoot"), List.of(CountingRoot.class.getName()), List.of(),
                 List.of(new ModelGraphDocumentManifest.Node(
-                        "root", 0, 0, -1, -1, 0)));
+                        "root", 0, 0, 0, -1, -1, 0)));
         SerializedDocument document = serializer.toDocument(
                 json, "root", "root-graphs", null, null,
                 Metadata.of(ModelGraphDocumentManifest.METADATA_KEY,

--- a/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreModelMaterializationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/persisting/search/client/InMemorySearchStoreModelMaterializationTest.java
@@ -147,17 +147,12 @@ class InMemorySearchStoreModelMaterializationTest {
                                                 .toUnmodifiableMap(
                                                         Map.Entry::getKey,
                                                         Map.Entry::getValue)));
-        graphStore.index(
-                        List.of(
-                                structuredDocument(
-                                        rootId, "roots",
-                                        "root"),
-                                structuredDocument(
-                                        childId,
-                                        childCollection,
-                                        "first")),
-                        STORED, false)
-                .join();
+        materialize(graphStore, rootId, 1L,
+                    new ModelDocumentMutation("roots",
+                                              structuredDocument(rootId, "roots", "root")));
+        materialize(graphStore, childId, 2L,
+                    new ModelDocumentMutation(childCollection,
+                                              structuredDocument(childId, childCollection, "first")));
         ModelGraphProjectionConfiguration configuration =
                 new ModelGraphProjectionConfiguration(
                         "Root", "roots",
@@ -388,8 +383,9 @@ class InMemorySearchStoreModelMaterializationTest {
                 Duration.ofDays(1), null,
                 (ignored, composition) -> List.of(),
                 ignored -> Map.of(rootId, "roots"));
-        graphStore.index(List.of(structuredDocument(
-                rootId, "roots", "original")), STORED, false).join();
+        materialize(graphStore, rootId, 1L,
+                    new ModelDocumentMutation("roots",
+                                              structuredDocument(rootId, "roots", "original")));
         ModelGraphProjectionConfiguration configuration =
                 new ModelGraphProjectionConfiguration(
                         "TestModel", "roots", "rootGraphs",
@@ -535,6 +531,7 @@ class InMemorySearchStoreModelMaterializationTest {
                         .build());
         return ModelGraphDocumentStitcher.stitch(
                 List.of(direct), List.of(), Map.of(id, direct),
+                Map.of(id, type.substring(type.lastIndexOf('.') + 1)),
                 ModelGraphComposition.builder().build(), stateIndex)
                 .getFirst();
     }

--- a/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/tracking/handling/HandleDocumentTest.java
@@ -140,6 +140,7 @@ public class HandleDocumentTest {
                                     .build());
                     SerializedDocument oldGraph = ModelGraphDocumentStitcher.stitch(
                             List.of(direct), List.of(), Map.of("root", direct),
+                            Map.of("root", "GraphRoot"),
                             ModelGraphComposition.builder().build(), 41L)
                             .getFirst().withCollection("graph-roots-graphs");
                     fc.client().getSearchClient().index(
@@ -379,9 +380,9 @@ public class HandleDocumentTest {
     private static DeserializingMessage graphDocumentMessage(
             JacksonSerializer serializer) {
         ModelGraphDocumentManifest manifest = new ModelGraphDocumentManifest(
-                41L, List.of(GraphRoot.class.getName()), List.of(),
+                41L, List.of("GraphRoot"), List.of(GraphRoot.class.getName()), List.of(),
                 List.of(new ModelGraphDocumentManifest.Node(
-                        "root", 0, 0, -1, -1, 0)));
+                        "root", 0, 0, 0, -1, -1, 0)));
         var payload = serializer.getObjectMapper().createObjectNode()
                 .put("id", "root");
         return new DeserializingMessage(


### PR DESCRIPTION
## Summary

- persist one logical Model identity from `@Model.name`, defaulting to the concrete simple class name
- support an application-scoped literal `fluxzero.model.namePrefix`
- use the resolved identity for Model heads, commits, relationships, projections, Graphs, traversal and untyped loads
- keep serializer payload types independent and intentionally omit aliases or FQN fallback before 2.0 GA

## Validation

- full nine-module SDK reactor
- Java and Kotlin downstream compatibility
- focused Model rename, prefix, collision, replay, Graph and document tests
- Javadoc/site validation
- interleaved persistence and Graph performance qualification