### PR TITLE
chore(release): merge main into next/2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5147,6 +5147,19 @@ when a custom `CorrelationDataProvider` is configured. Applications that omit th
 correlation behavior without the extra entry. Calling `disableMessageCorrelation()` disables this metadata together
 with the other automatic correlation fields.
 
+### Task and Client Identity
+
+`FLUXZERO_TASK_ID` identifies the platform task or pod that hosts an application. When present, Fluxzero publishes its
+value as authoritative `$taskId` correlation metadata on every outgoing message, including when a custom
+`CorrelationDataProvider` is configured. A caller-supplied `$taskId` cannot override the platform value. Calling
+`disableMessageCorrelation()` disables this field together with the other automatic correlation metadata.
+
+The WebSocket client ID identifies one concrete client/process incarnation and must remain unique across process
+restarts. Configure it explicitly with `FLUXZERO_CLIENT_ID` (`FLUX_CLIENT_ID` is the legacy alias), or let the SDK
+generate it. With a task ID, the generated form is `<taskId>_<random UUID>`; without a task ID it is a random UUID. The
+generated ID remains stable for normal WebSocket reconnects and namespace-specific clients derived from the same
+application client.
+
 ### Example Usage
 
 ```java
@@ -5722,7 +5735,7 @@ Key options include:
 | `runtimeBaseUrl` | Base URL for all subsystems, e.g. `wss://my.flux.host` | `FLUXZERO_BASE_URL` or `FLUX_BASE_URL` |
 | `name` | Name of the application | `FLUXZERO_APPLICATION_NAME` or `FLUX_APPLICATION_NAME` |
 | `applicationId` | Optional application ID | `FLUXZERO_APPLICATION_ID` or `FLUX_APPLICATION_ID` |
-| `id` | Unique client instance ID | `FLUXZERO_TASK_ID`, `FLUX_TASK_ID`, or UUID |
+| `id` | Unique client/process instance ID | `FLUXZERO_CLIENT_ID`, legacy alias; otherwise task-ID-prefixed UUID or UUID |
 | `supportedCompressionAlgorithms` | Preferred and fallback compression algorithms | ZSTD, then LZ4 |
 | `pingDelay` / `pingTimeout` | Heartbeat intervals for WebSocket health | 10s / 15s |
 | `maxConcurrentRuntimeWebSocketMessages` | Runtime messages decoded or waiting for completion-dispatcher admission per session | `fluxzero.runtime.ingress.maxConcurrency` or `3` |

--- a/docs/developer/guides/Configuration/275-configuring-websocket-client.mdx
+++ b/docs/developer/guides/Configuration/275-configuring-websocket-client.mdx
@@ -60,7 +60,7 @@ Key options include:
 | `runtimeBaseUrl`                             | Base URL for all subsystems <br/>(e.g. `wss://my.flux.host`)                     | `FLUXZERO_BASE_URL` or `FLUX_BASE_URL`   |
 | `name`                                       | Name of the application                                                          | `FLUXZERO_APPLICATION_NAME` or legacy alias |
 | `applicationId`                              | Optional app ID                                                                  | `FLUXZERO_APPLICATION_ID` or legacy alias |
-| `id`                                         | Unique client instance ID                                                        | `FLUXZERO_TASK_ID`, legacy alias, or UUID |
+| `id`                                         | Unique client/process instance ID                                                | `FLUXZERO_CLIENT_ID`, legacy alias; otherwise task-ID-prefixed UUID or UUID |
 | `supportedCompressionAlgorithms`             | Preferred and fallback compression algorithms                                   | ZSTD, then LZ4                           |
 | `pingDelay` / `pingTimeout`                  | Heartbeat intervals for WebSocket health                                         | 10s / 15s                                |
 | `maxConcurrentRuntimeWebSocketMessages`      | Messages decoded or waiting for completion-dispatcher admission per session     | `3`                                      |
@@ -70,6 +70,12 @@ Key options include:
 | `runtimeIngressStallCloseTimeout`            | Optional close delay after ingress is diagnosed as stalled                      | Disabled                                 |
 | `disableMetrics`                             | Whether to suppress all outgoing metrics                                         | `false`                                  |
 | `typeFilter`                                 | Optional message type restriction                                                | `null`                                   |
+
+`FLUXZERO_TASK_ID` identifies the hosting platform task or pod; it is not itself a unique process incarnation. When
+present, the SDK uses it as the recognizable prefix of a generated client ID and publishes the unchanged value as
+authoritative `$taskId` correlation metadata. The generated client ID remains stable across WebSocket reconnects, but
+a newly constructed client receives a new UUID suffix. Set `FLUXZERO_CLIENT_ID` only when supplying an explicitly
+unique client-instance ID; `FLUX_CLIENT_ID` remains available as a legacy alias.
 
 ---
 

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -38,7 +38,7 @@
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>
         <maven.resources.version>3.5.0</maven.resources.version>
-        <maven.surefire.version>3.5.6</maven.surefire.version>
+        <maven.surefire.version>3.6.0</maven.surefire.version>
     </properties>
 
     <dependencyManagement>

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -33,7 +33,7 @@
         <junit.version>6.1.3</junit.version>
         <logback.version>1.6.3</logback.version>
         <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
-        <maven.compiler.version>3.15.0</maven.compiler.version>
+        <maven.compiler.version>3.16.0</maven.compiler.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>6.1.3</junit.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.3</fluxzero.maven.plugin.version>
         <maven.compiler.version>3.16.0</maven.compiler.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>

--- a/kotlin-downstream-project/pom.xml
+++ b/kotlin-downstream-project/pom.xml
@@ -20,7 +20,7 @@
         <junit.version>6.1.3</junit.version>
         <kotlin.version>2.4.10</kotlin.version>
         <logback.version>1.6.3</logback.version>
-        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.3</fluxzero.maven.plugin.version>
         <maven.deploy.version>3.1.4</maven.deploy.version>
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>

--- a/kotlin-downstream-project/pom.xml
+++ b/kotlin-downstream-project/pom.xml
@@ -25,7 +25,7 @@
         <maven.enforcer.version>3.6.3</maven.enforcer.version>
         <maven.install.version>3.1.4</maven.install.version>
         <maven.resources.version>3.5.0</maven.resources.version>
-        <maven.surefire.version>3.5.6</maven.surefire.version>
+        <maven.surefire.version>3.6.0</maven.surefire.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <junit.parallelism>2</junit.parallelism>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <fluxzero.maven.plugin.version>1.17.0</fluxzero.maven.plugin.version>
+        <fluxzero.maven.plugin.version>1.17.3</fluxzero.maven.plugin.version>
         <fluxzero.package.channel-tag>latest</fluxzero.package.channel-tag>
         <fluxzero.package.base-image>gcr.io/distroless/java25-debian13:nonroot@sha256:9ccf2b8bce700d9f450523e2055afabe4d4ee795e6d69a0647a2dcd6e180e411</fluxzero.package.base-image>
         <argLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.6</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <excludes>
                             <exclude/>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.15.0</version>
+                    <version>3.16.0</version>
                     <configuration>
                         <annotationProcessorPaths>
                             <path>

--- a/project-files/java/agents/rules/configuration.md
+++ b/project-files/java/agents/rules/configuration.md
@@ -59,7 +59,8 @@ The following properties are used by the SDK to configure its connection and beh
 | `FLUXZERO_APPLICATION_NAME` | The logical name of your application.                              | `inMemory` (local)           |
 | `FLUXZERO_NAMESPACE`        | The project or tenant namespace.                                   | `default`                    |
 | `FLUXZERO_APPLICATION_ID`   | A unique identifier for the application deployment.                | `null`                       |
-| `FLUXZERO_TASK_ID`          | A unique ID for the specific client instance (for tracking).       | Random UUID                  |
+| `FLUXZERO_TASK_ID`          | Platform task/pod ID; published as authoritative `$taskId` correlation metadata and used as the generated client-ID prefix. | `null` |
+| `FLUXZERO_CLIENT_ID`        | Optional explicitly unique client/process instance ID.            | Task-ID-prefixed UUID or random UUID |
 | `ENCRYPTION_KEY`            | The key used for automatic decryption of `encrypted` values.       | `null`                       |
 
 `FLUXZERO_NAMESPACE` sets the app-wide default namespace (not just one consumer). It applies to runtime interactions

--- a/project-files/kotlin/agents/rules/configuration.md
+++ b/project-files/kotlin/agents/rules/configuration.md
@@ -57,7 +57,8 @@ The following properties are used by the SDK to configure its connection and beh
 | `FLUXZERO_APPLICATION_NAME` | The logical name of your application.                              | `inMemory` (local)           |
 | `FLUXZERO_NAMESPACE`        | The project or tenant namespace.                                   | `default`                    |
 | `FLUXZERO_APPLICATION_ID`   | A unique identifier for the application deployment.                | `null`                       |
-| `FLUXZERO_TASK_ID`          | A unique ID for the specific client instance (for tracking).       | Random UUID                  |
+| `FLUXZERO_TASK_ID`          | Platform task/pod ID; published as authoritative `$taskId` correlation metadata and used as the generated client-ID prefix. | `null` |
+| `FLUXZERO_CLIENT_ID`        | Optional explicitly unique client/process instance ID.            | Task-ID-prefixed UUID or random UUID |
 | `ENCRYPTION_KEY`            | The key used for automatic decryption of `encrypted` values.       | `null`                       |
 
 `FLUXZERO_NAMESPACE` sets the app-wide default namespace (not just one consumer). It applies to runtime interactions

--- a/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
+++ b/proxy/src/main/java/io/fluxzero/proxy/ForwardProxyConsumer.java
@@ -385,8 +385,8 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     private ActiveRequest handleAsync(SerializedMessage request, URI uri, WebRequestSettings settings,
                                       ScheduledRequest scheduledRequest) {
         Instant start = Instant.now();
-        Map<String, String> correlationData = DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
-                client, request, MessageType.WEBREQUEST);
+        Map<String, String> correlationData = scheduledRequest == null
+                ? captureCorrelationData(request) : scheduledRequest.correlationData();
         Instant deadline = IndexUtils.timestampFromIndex(request.getIndex())
                 .plus(Optional.ofNullable(settings.getTimeout()).orElse(MAX_TIMEOUT));
         CancellableResponseFuture execution = new CancellableResponseFuture();
@@ -678,8 +678,11 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
     }
 
     protected void sendResponse(WebResponse response, SerializedMessage request) {
-        sendResponseAsync(response, request, DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
-                client, request, MessageType.WEBREQUEST));
+        sendResponseAsync(response, request, captureCorrelationData(request));
+    }
+
+    private Map<String, String> captureCorrelationData(SerializedMessage request) {
+        return DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(client, request, MessageType.WEBREQUEST);
     }
 
     private CompletableFuture<Void> sendResponseAsync(WebResponse response, SerializedMessage request,
@@ -842,6 +845,8 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
         private final WebRequestSettings settings;
         private final Throwable initialFailure;
         private final int segment;
+        // A queued request may start on its predecessor's completion thread, after the tracker context has gone.
+        private final Map<String, String> correlationData;
         private final AtomicReference<RequestState> state = new AtomicReference<>(RequestState.QUEUED);
         private final AtomicReference<CancellableResponseFuture> execution = new AtomicReference<>();
         private final CompletableFuture<Void> completion = new CompletableFuture<>();
@@ -852,6 +857,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             this.settings = settings;
             this.initialFailure = null;
             this.segment = requestSegment(request);
+            this.correlationData = captureCorrelationData(request);
         }
 
         private ScheduledRequest(SerializedMessage request, Throwable initialFailure) {
@@ -860,6 +866,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             this.settings = null;
             this.initialFailure = initialFailure;
             this.segment = requestSegment(request);
+            this.correlationData = captureCorrelationData(request);
         }
 
         private int requestSegment(SerializedMessage request) {
@@ -907,9 +914,7 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
             CompletableFuture<Void> publication;
             try {
                 publication = sendResponseAsync(
-                        asWebResponse(initialFailure), request,
-                        DefaultCorrelationDataProvider.INSTANCE.getCorrelationData(
-                                client, request, MessageType.WEBREQUEST));
+                        asWebResponse(initialFailure), request, correlationData);
             } catch (Throwable e) {
                 publication = CompletableFuture.failedFuture(e);
             }
@@ -982,6 +987,10 @@ public class ForwardProxyConsumer implements Consumer<List<SerializedMessage>> {
 
         private SerializedMessage request() {
             return request;
+        }
+
+        private Map<String, String> correlationData() {
+            return correlationData;
         }
     }
 

--- a/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ForwardProxyConsumerTest.java
@@ -29,6 +29,7 @@ import io.fluxzero.sdk.test.TestFixture;
 import io.fluxzero.sdk.tracking.BatchProcessingException;
 import io.fluxzero.sdk.tracking.ConsumerConfiguration;
 import io.fluxzero.sdk.tracking.IndexUtils;
+import io.fluxzero.sdk.tracking.Tracker;
 import io.fluxzero.sdk.web.RedirectPolicy;
 import io.fluxzero.sdk.web.WebRequest;
 import io.fluxzero.sdk.web.WebRequestSettings;
@@ -584,6 +585,111 @@ class ForwardProxyConsumerTest {
     }
 
     @Test
+    void directScheduledRequestPublishesFullTrackerContext() {
+        Client client = mockForwardingClient();
+        GatewayClient responseGateway = client.getGatewayClient(MessageType.WEBRESPONSE);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        Tracker tracker = tracker("direct-consumer", "direct-tracker");
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 4, Duration.ZERO);
+
+        SerializedMessage request = serializedRequest("direct", CONSUMER_NAME);
+        request.setMetadata(request.getMetadata().withTrace("origin", "direct"));
+        withTracker(tracker, () -> consumer.accept(List.of(request)));
+
+        ArgumentCaptor<SerializedMessage> forwarded = ArgumentCaptor.forClass(SerializedMessage.class);
+        verify(responseGateway).append(eq(STORED), forwarded.capture());
+        assertForwardCorrelation(forwarded.getValue(), request, "direct-consumer", "direct-tracker", "direct");
+        assertTrue(Tracker.current().isEmpty());
+    }
+
+    @Test
+    void sameSegmentRequestRetainsTrackerContextWhenStartedFromCompletionThread() throws Exception {
+        Client client = mockForwardingClient();
+        GatewayClient responseGateway = client.getGatewayClient(MessageType.WEBRESPONSE);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<HttpResponse<byte[]>> firstAttempt = new CompletableFuture<>();
+        Tracker tracker = tracker("serial-consumer", "serial-tracker");
+        AtomicInteger attempt = new AtomicInteger();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenAnswer(invocation -> {
+            return attempt.getAndIncrement() == 0
+                    ? firstAttempt : CompletableFuture.completedFuture(response);
+        });
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 4, Duration.ZERO);
+        SerializedMessage first = serializedRequest("serial-first", CONSUMER_NAME);
+        first.setSegment(17);
+        first.setMetadata(first.getMetadata().withTrace("origin", "serial-first"));
+        SerializedMessage second = serializedRequest("serial-second", CONSUMER_NAME);
+        second.setSegment(17);
+        second.setMetadata(second.getMetadata().withTrace("origin", "serial-second"));
+
+        withTracker(tracker, () -> consumer.accept(List.of(first, second)));
+        firstAttempt.complete(response);
+        consumer.awaitActiveRequests();
+
+        ArgumentCaptor<SerializedMessage> forwarded = ArgumentCaptor.forClass(SerializedMessage.class);
+        verify(responseGateway, times(2)).append(eq(STORED), forwarded.capture());
+        assertForwardCorrelation(
+                forwarded.getAllValues().get(0), first, "serial-consumer", "serial-tracker", "serial-first");
+        assertForwardCorrelation(
+                forwarded.getAllValues().get(1), second, "serial-consumer", "serial-tracker", "serial-second");
+    }
+
+    @Test
+    void delayedRequestContextDoesNotReplaceCompletionThreadOrIndependentRequestContext() throws Exception {
+        Client client = mockForwardingClient();
+        GatewayClient responseGateway = client.getGatewayClient(MessageType.WEBRESPONSE);
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<byte[]> response = httpResponse(200, "ok");
+        CompletableFuture<HttpResponse<byte[]>> firstAttempt = new CompletableFuture<>();
+        Tracker firstTracker = tracker("first-consumer", "first-tracker");
+        Tracker secondTracker = tracker("second-consumer", "second-tracker");
+        Tracker completionTracker = tracker("completion-consumer", "completion-tracker");
+        AtomicInteger attempt = new AtomicInteger();
+        AtomicReference<Tracker> delayedExecutionContext = new AtomicReference<>();
+        when(httpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenAnswer(invocation -> {
+            if (attempt.getAndIncrement() == 0) {
+                return firstAttempt;
+            }
+            delayedExecutionContext.set(Tracker.current().orElse(null));
+            return CompletableFuture.completedFuture(response);
+        });
+        ForwardProxyConsumer consumer = new ForwardProxyConsumer(
+                client, CONSUMER_NAME, 0L, true, false, httpClient, new AtomicBoolean(),
+                1, 4, Duration.ZERO);
+        SerializedMessage first = serializedRequest("isolated-first", CONSUMER_NAME);
+        first.setSegment(1);
+        first.setMetadata(first.getMetadata().withTrace("origin", "isolated-first"));
+        SerializedMessage second = serializedRequest("isolated-second", CONSUMER_NAME);
+        second.setSegment(2);
+        second.setMetadata(second.getMetadata().withTrace("origin", "isolated-second"));
+
+        withTracker(firstTracker, () -> consumer.accept(List.of(first)));
+        withTracker(secondTracker, () -> consumer.accept(List.of(second)));
+        withTracker(completionTracker, () -> {
+            firstAttempt.complete(response);
+            assertEquals(completionTracker, Tracker.current().orElseThrow());
+        });
+        consumer.awaitActiveRequests();
+
+        assertEquals(completionTracker, delayedExecutionContext.get());
+        ArgumentCaptor<SerializedMessage> forwarded = ArgumentCaptor.forClass(SerializedMessage.class);
+        verify(responseGateway, times(2)).append(eq(STORED), forwarded.capture());
+        assertForwardCorrelation(
+                forwarded.getAllValues().get(0), first, "first-consumer", "first-tracker", "isolated-first");
+        assertForwardCorrelation(
+                forwarded.getAllValues().get(1), second, "second-consumer", "second-tracker", "isolated-second");
+        assertTrue(Tracker.current().isEmpty());
+    }
+
+    @Test
     void softBatchCompletionKeepsLateRequestInGlobalCapacity() throws Exception {
         Client client = mockForwardingClient();
         HttpClient httpClient = mock(HttpClient.class);
@@ -940,6 +1046,39 @@ class ForwardProxyConsumerTest {
         when(requestGateway.append(eq(STORED), any(SerializedMessage[].class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
         return client;
+    }
+
+    private static Tracker tracker(String consumer, String trackerId) {
+        return new Tracker(trackerId, MessageType.WEBREQUEST, null,
+                           ConsumerConfiguration.builder().name(consumer).build(), null);
+    }
+
+    private static void assertForwardCorrelation(SerializedMessage response, SerializedMessage request,
+                                                 String consumer, String tracker, String traceOrigin) {
+        Metadata metadata = response.getMetadata();
+        assertEquals("client", metadata.get("$clientId"));
+        assertEquals("proxy", metadata.get("$clientName"));
+        assertEquals(consumer, metadata.get("$consumer"));
+        assertEquals(tracker, metadata.get("$tracker"));
+        assertEquals(request.getIndex().toString(), metadata.get("$correlationId"));
+        assertEquals(request.getIndex().toString(), metadata.get("$traceId"));
+        assertEquals(request.getData().getType(), metadata.get("$trigger"));
+        assertEquals(MessageType.WEBREQUEST.name(), metadata.get("$triggerType"));
+        assertEquals(traceOrigin, metadata.get("$trace.origin"));
+    }
+
+    private static void withTracker(Tracker tracker, Runnable task) {
+        Tracker previous = Tracker.current.get();
+        Tracker.current.set(tracker);
+        try {
+            task.run();
+        } finally {
+            if (previous == null) {
+                Tracker.current.remove();
+            } else {
+                Tracker.current.set(previous);
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/ApplicationProperties.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/ApplicationProperties.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -68,6 +69,24 @@ import java.util.function.Supplier;
  * @see DecryptingPropertySource
  */
 public class ApplicationProperties {
+
+    /**
+     * Identity of the platform task that hosts the application. The default environment-variable name is
+     * {@code FLUXZERO_TASK_ID}; {@code FLUX_TASK_ID} remains supported as a legacy alias.
+     */
+    public static final String TASK_ID_PROPERTY = "FLUXZERO_TASK_ID";
+
+    /** Legacy alias for {@link #TASK_ID_PROPERTY}. */
+    public static final String LEGACY_TASK_ID_PROPERTY = "FLUX_TASK_ID";
+
+    /**
+     * Optional explicit unique client-instance ID. The default environment-variable name is
+     * {@code FLUXZERO_CLIENT_ID}; {@code FLUX_CLIENT_ID} remains supported as a legacy alias.
+     */
+    public static final String CLIENT_ID_PROPERTY = "FLUXZERO_CLIENT_ID";
+
+    /** Legacy alias for {@link #CLIENT_ID_PROPERTY}. */
+    public static final String LEGACY_CLIENT_ID_PROPERTY = "FLUX_CLIENT_ID";
 
     /**
      * Optional version of the deployed application. When configured, Fluxzero adds the value to the correlation
@@ -226,6 +245,47 @@ public class ApplicationProperties {
     public static String getFirstAvailableProperty(String... propertyNames) {
         return Arrays.stream(propertyNames)
                 .map(ApplicationProperties::getProperty).filter(Objects::nonNull).findFirst().orElse(null);
+    }
+
+    /**
+     * Returns the configured platform task ID, or {@code null} when the application does not run as a known task.
+     */
+    public static String getTaskId() {
+        return getTaskId(getPropertySource());
+    }
+
+    /**
+     * Returns the platform task ID from the given property source, or {@code null} when absent or blank.
+     */
+    public static String getTaskId(PropertySource propertySource) {
+        return Arrays.stream(new String[]{TASK_ID_PROPERTY, LEGACY_TASK_ID_PROPERTY})
+                .map(propertySource::get).filter(Objects::nonNull).map(String::strip)
+                .filter(value -> !value.isEmpty()).findFirst().orElse(null);
+    }
+
+    /**
+     * Creates a unique ID for a client instance. An explicitly configured {@code FLUXZERO_CLIENT_ID} is used when
+     * present. Otherwise, a random UUID is generated and prefixed with {@code FLUXZERO_TASK_ID} when available.
+     * Callers should create this ID once and retain it across reconnects.
+     */
+    public static String createClientId() {
+        return createClientId(getPropertySource());
+    }
+
+    /**
+     * Creates a unique ID for a client instance from the given property source.
+     */
+    public static String createClientId(PropertySource propertySource) {
+        Objects.requireNonNull(propertySource, "propertySource");
+        String configuredClientId = Arrays.stream(new String[]{CLIENT_ID_PROPERTY, LEGACY_CLIENT_ID_PROPERTY})
+                .map(propertySource::get).filter(Objects::nonNull).map(String::strip)
+                .filter(value -> !value.isEmpty()).findFirst().orElse(null);
+        if (configuredClientId != null) {
+            return configuredClientId;
+        }
+        String instanceId = UUID.randomUUID().toString();
+        String taskId = getTaskId(propertySource);
+        return taskId == null ? instanceId : taskId + "_" + instanceId;
     }
 
     /**

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/DefaultFluxzero.java
@@ -66,6 +66,7 @@ import io.fluxzero.sdk.publishing.correlation.ApplicationVersionCorrelationDataP
 import io.fluxzero.sdk.publishing.correlation.CorrelatingInterceptor;
 import io.fluxzero.sdk.publishing.correlation.CorrelationDataProvider;
 import io.fluxzero.sdk.publishing.correlation.DefaultCorrelationDataProvider;
+import io.fluxzero.sdk.publishing.correlation.TaskIdCorrelationDataProvider;
 import io.fluxzero.sdk.publishing.dataprotection.DataProtectionInterceptor;
 import io.fluxzero.sdk.publishing.dataprotection.MissingProtectedDataPolicy;
 import io.fluxzero.sdk.publishing.routing.MessageRoutingInterceptor;
@@ -351,7 +352,9 @@ public class DefaultFluxzero implements Fluxzero {
 
         @Override
         public CorrelationDataProvider correlationDataProvider() {
-            return ApplicationVersionCorrelationDataProvider.decorate(correlationDataProvider, propertySource);
+            return TaskIdCorrelationDataProvider.decorate(
+                    ApplicationVersionCorrelationDataProvider.decorate(correlationDataProvider, propertySource),
+                    propertySource);
         }
 
         @Override

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/client/LocalClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/client/LocalClient.java
@@ -63,7 +63,7 @@ import static io.fluxzero.common.tracking.DefaultTrackingStrategy.DEFAULT_INITIA
  * <ul>
  *   <li>Simulates gateway clients for all {@link MessageType}s</li>
  *   <li>Provides in-memory implementations of event store, scheduling, key-value, and search clients</li>
- *   <li>Uses the {@code FLUXZERO_TASK_ID} environment property or the JVM process name as the client ID</li>
+ *   <li>Uses the {@code FLUXZERO_TASK_ID} environment property or the JVM process name as its local-only ID</li>
  *   <li>Reads {@code FLUXZERO_APPLICATION_NAME} and {@code FLUXZERO_APPLICATION_ID} from environment or system properties</li>
  * </ul>
  *

--- a/sdk/src/main/java/io/fluxzero/sdk/configuration/client/WebSocketClient.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/configuration/client/WebSocketClient.java
@@ -45,8 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 
 import static io.fluxzero.common.serialization.compression.CompressionAlgorithm.LZ4;
@@ -59,6 +57,7 @@ import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.keyValueUrl;
 import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.schedulingUrl;
 import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.searchUrl;
 import static io.fluxzero.sdk.common.websocket.ServiceUrlBuilder.trackingUrl;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.createClientId;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getFirstAvailableProperty;
 import static io.fluxzero.sdk.configuration.ApplicationProperties.getIntegerProperty;
 import static java.util.stream.Collectors.toMap;
@@ -233,12 +232,13 @@ public class WebSocketClient extends AbstractClient {
         String applicationId = getFirstAvailableProperty("FLUXZERO_APPLICATION_ID", "FLUX_APPLICATION_ID");
 
         /**
-         * A unique ID for the client instance. Defaults to {@code FLUXZERO_TASK_ID} or a randomly generated UUID.
+         * A unique ID for this client instance. Defaults to {@code FLUXZERO_CLIENT_ID} when configured. Otherwise a
+         * random UUID is generated, prefixed with {@code FLUXZERO_TASK_ID} when that task identity is available.
+         * Namespace-specific clients and reconnecting websocket sessions retain the same ID.
          */
         @NonNull
         @Default
-        String id = Optional.ofNullable(getFirstAvailableProperty(
-                "FLUXZERO_TASK_ID", "FLUX_TASK_ID")).orElseGet(UUID.randomUUID()::toString);
+        String id = createClientId();
 
         /**
          * Ordered list of compression algorithms the client supports for websocket communication, with the preferred

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/CorrelatingInterceptor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/CorrelatingInterceptor.java
@@ -58,6 +58,7 @@ import static io.fluxzero.sdk.publishing.dataprotection.DataProtectionIntercepto
  * The published event will automatically contain metadata such as:
  * <ul>
  *   <li>{@code $applicationVersion}, when configured</li>
+ *   <li>{@code $taskId}, when configured</li>
  *   <li>{@code $correlationId}</li>
  *   <li>{@code $traceId}</li>
  *   <li>{@code $trigger}</li>
@@ -101,7 +102,9 @@ public class CorrelatingInterceptor implements DispatchInterceptor {
                         .orElse(DefaultCorrelationDataProvider.INSTANCE);
                 if (provider != DefaultCorrelationDataProvider.INSTANCE
                     && !(provider instanceof ApplicationVersionCorrelationDataProvider applicationVersionProvider
-                         && applicationVersionProvider.decoratesDefaultProvider())) {
+                         && applicationVersionProvider.decoratesDefaultProvider())
+                    && !(provider instanceof TaskIdCorrelationDataProvider taskIdProvider
+                         && taskIdProvider.decoratesDefaultProvider())) {
                     return false;
                 }
                 if (correlationMetadata == null) {

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/CorrelationDataProvider.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/CorrelationDataProvider.java
@@ -57,6 +57,7 @@ import static java.util.Optional.ofNullable;
  * <ul>
  *   <li><b>{@code $applicationId}</b> – ID of the application this client belongs to (optional)</li>
  *   <li><b>{@code $applicationVersion}</b> – Deployed version configured for the application (optional)</li>
+ *   <li><b>{@code $taskId}</b> – Platform task identity configured for the application (optional)</li>
  *   <li><b>{@code $clientId}</b> – Unique identifier for this Fluxzero client instance</li>
  *   <li><b>{@code $clientName}</b> – Logical name of the client (e.g. "service-A")</li>
  *   <li><b>{@code $consumer}</b> – Consumer name of the current {@link Tracker}, if active</li>
@@ -188,6 +189,15 @@ public interface CorrelationDataProvider {
      */
     default String getApplicationVersionKey() {
         return "$applicationVersion";
+    }
+
+    /**
+     * Retrieves the key used to identify the platform task in correlation metadata.
+     *
+     * @return a string representing the task ID key
+     */
+    default String getTaskIdKey() {
+        return "$taskId";
     }
 
     /**

--- a/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/TaskIdCorrelationDataProvider.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/publishing/correlation/TaskIdCorrelationDataProvider.java
@@ -18,6 +18,7 @@ import io.fluxzero.common.MessageType;
 import io.fluxzero.common.api.SerializedMessage;
 import io.fluxzero.common.application.PropertySource;
 import io.fluxzero.sdk.common.serialization.DeserializingMessage;
+import io.fluxzero.sdk.configuration.ApplicationProperties;
 import io.fluxzero.sdk.configuration.client.Client;
 import jakarta.annotation.Nullable;
 
@@ -25,55 +26,53 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static io.fluxzero.sdk.configuration.ApplicationProperties.APPLICATION_VERSION_PROPERTY;
-
 /**
- * Adds the configured application version to another correlation data provider.
+ * Adds the platform task identity to another correlation data provider.
  */
-public final class ApplicationVersionCorrelationDataProvider implements CorrelationDataProvider {
+public final class TaskIdCorrelationDataProvider implements CorrelationDataProvider {
     private final CorrelationDataProvider delegate;
-    private final String applicationVersion;
+    private final String taskId;
 
     /**
-     * Decorates the given provider when {@code fluxzero.application.version} is configured. Returns the original
-     * provider unchanged when the property is absent or blank.
+     * Decorates the given provider when {@code FLUXZERO_TASK_ID} is configured. Returns the original provider unchanged
+     * when the property and its legacy alias are absent or blank.
      *
      * @param delegate provider that supplies the existing correlation data
-     * @param propertySource source that may contain the application version
-     * @return the decorated provider, or {@code delegate} when no version is configured
+     * @param propertySource source that may contain the platform task ID
+     * @return the decorated provider, or {@code delegate} when no task ID is configured
      */
     public static CorrelationDataProvider decorate(CorrelationDataProvider delegate, PropertySource propertySource) {
         Objects.requireNonNull(delegate, "delegate");
         Objects.requireNonNull(propertySource, "propertySource");
-        String configuredVersion = propertySource.get(APPLICATION_VERSION_PROPERTY);
-        return configuredVersion == null || configuredVersion.isBlank()
-                ? delegate : new ApplicationVersionCorrelationDataProvider(delegate, configuredVersion.strip());
+        String taskId = ApplicationProperties.getTaskId(propertySource);
+        return taskId == null ? delegate : new TaskIdCorrelationDataProvider(delegate, taskId);
     }
 
-    private ApplicationVersionCorrelationDataProvider(CorrelationDataProvider delegate, String applicationVersion) {
+    private TaskIdCorrelationDataProvider(CorrelationDataProvider delegate, String taskId) {
         this.delegate = delegate;
-        this.applicationVersion = applicationVersion;
+        this.taskId = taskId;
     }
 
     @Override
     public Map<String, String> getCorrelationData(@Nullable DeserializingMessage currentMessage) {
-        return addApplicationVersion(delegate.getCorrelationData(currentMessage));
+        return addTaskId(delegate.getCorrelationData(currentMessage));
     }
 
     @Override
     public Map<String, String> getCorrelationData(@Nullable Client client, @Nullable SerializedMessage currentMessage,
                                                   @Nullable MessageType messageType) {
-        return addApplicationVersion(delegate.getCorrelationData(client, currentMessage, messageType));
+        return addTaskId(delegate.getCorrelationData(client, currentMessage, messageType));
     }
 
     boolean decoratesDefaultProvider() {
-        return delegate == DefaultCorrelationDataProvider.INSTANCE;
+        return delegate == DefaultCorrelationDataProvider.INSTANCE
+               || delegate instanceof ApplicationVersionCorrelationDataProvider applicationVersionProvider
+                  && applicationVersionProvider.decoratesDefaultProvider();
     }
 
-    private Map<String, String> addApplicationVersion(Map<String, String> correlationData) {
-        Map<String, String> result = decoratesDefaultProvider()
-                ? correlationData : new HashMap<>(correlationData);
-        result.put(getApplicationVersionKey(), applicationVersion);
+    private Map<String, String> addTaskId(Map<String, String> correlationData) {
+        Map<String, String> result = decoratesDefaultProvider() ? correlationData : new HashMap<>(correlationData);
+        result.put(getTaskIdKey(), taskId);
         return result;
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/configuration/client/WebSocketClientConfigTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/configuration/client/WebSocketClientConfigTest.java
@@ -22,13 +22,76 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 
+import static io.fluxzero.sdk.configuration.ApplicationProperties.CLIENT_ID_PROPERTY;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.LEGACY_CLIENT_ID_PROPERTY;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.LEGACY_TASK_ID_PROPERTY;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.TASK_ID_PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WebSocketClientConfigTest {
+
+    @Test
+    void taskIdentityPrefixesUniqueClientInstanceIds() {
+        withProperties(Map.of(TASK_ID_PROPERTY, "task-123"), () -> {
+            WebSocketClient.ClientConfig first = clientConfig();
+            WebSocketClient.ClientConfig second = clientConfig();
+
+            assertTrue(first.getId().startsWith("task-123_"));
+            assertTrue(second.getId().startsWith("task-123_"));
+            assertNotEquals(first.getId(), second.getId());
+            assertDoesNotThrow(() -> UUID.fromString(first.getId().substring("task-123_".length())));
+        });
+    }
+
+    @Test
+    void legacyTaskIdentityAlsoPrefixesClientInstanceId() {
+        withProperties(Map.of(LEGACY_TASK_ID_PROPERTY, "legacy-task"),
+                       () -> assertTrue(clientConfig().getId().startsWith("legacy-task_")));
+    }
+
+    @Test
+    void configuredClientIdTakesPrecedenceOverTaskIdentity() {
+        withProperties(Map.of(CLIENT_ID_PROPERTY, " client-instance ", TASK_ID_PROPERTY, "task-123"),
+                       () -> assertEquals("client-instance", clientConfig().getId()));
+    }
+
+    @Test
+    void legacyConfiguredClientIdTakesPrecedenceOverTaskIdentity() {
+        withProperties(Map.of(LEGACY_CLIENT_ID_PROPERTY, "legacy-client", TASK_ID_PROPERTY, "task-123"),
+                       () -> assertEquals("legacy-client", clientConfig().getId()));
+    }
+
+    @Test
+    void blankConfiguredClientIdFallsBackToTaskPrefixedIdentity() {
+        withProperties(Map.of(CLIENT_ID_PROPERTY, " \t ", TASK_ID_PROPERTY, "task-123"),
+                       () -> assertTrue(clientConfig().getId().startsWith("task-123_")));
+    }
+
+    @Test
+    void explicitBuilderClientIdTakesPrecedenceOverConfiguredIdentity() {
+        withProperties(Map.of(CLIENT_ID_PROPERTY, "configured", TASK_ID_PROPERTY, "task-123"),
+                       () -> assertEquals("explicit", clientConfigBuilder().id("explicit").build().getId()));
+    }
+
+    @Test
+    void derivedConfigurationRetainsClientInstanceId() {
+        withProperties(Map.of(TASK_ID_PROPERTY, "task-123"), () -> {
+            WebSocketClient.ClientConfig original = clientConfig();
+
+            assertEquals(original.getId(), original.toBuilder().namespace("other").build().getId());
+        });
+    }
+
+    @Test
+    void generatesUuidWithoutConfiguredClientOrTaskIdentity() {
+        withProperties(Map.of(), () -> assertDoesNotThrow(() -> UUID.fromString(clientConfig().getId())));
+    }
 
     @Test
     void defaultsToBoundedRuntimeWebSocketCapacity() {

--- a/sdk/src/test/java/io/fluxzero/sdk/publishing/correlation/CorrelationDataProviderTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/publishing/correlation/CorrelationDataProviderTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import static io.fluxzero.sdk.configuration.ApplicationProperties.APPLICATION_VERSION_PROPERTY;
+import static io.fluxzero.sdk.configuration.ApplicationProperties.TASK_ID_PROPERTY;
 import static io.fluxzero.sdk.publishing.dataprotection.DataProtectionInterceptor.METADATA_KEY;
 import static io.fluxzero.sdk.publishing.dataprotection.DataProtectionInterceptor.NAMESPACE_METADATA_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,11 +108,59 @@ class CorrelationDataProviderTest {
     }
 
     @Test
+    void configuredTaskIdIsAvailableThroughEveryCorrelationDataPath() {
+        var builder = DefaultFluxzero.builder()
+                .replacePropertySource(ignored -> new SimplePropertySource(Map.of(
+                        TASK_ID_PROPERTY, " task-123 ")))
+                .replaceCorrelationDataProvider(ignored -> testProvider);
+
+        try (Fluxzero fluxzero = builder.build(LocalClient.newInstance())) {
+            CorrelationDataProvider provider = fluxzero.correlationDataProvider();
+            for (MessageType messageType : MessageType.values()) {
+                Map<String, String> correlationData = provider.getCorrelationData(
+                        fluxzero.client(), null, messageType);
+                assertEquals("task-123", correlationData.get(provider.getTaskIdKey()));
+                assertEquals("bar", correlationData.get("foo"));
+            }
+            assertEquals("task-123", provider.getCorrelationData((DeserializingMessage) null)
+                    .get(provider.getTaskIdKey()));
+            assertEquals("task-123", fluxzero.configuration().correlationDataProvider()
+                    .getCorrelationData((DeserializingMessage) null).get(provider.getTaskIdKey()));
+        }
+    }
+
+    @Test
+    void configuredTaskIdIsAuthoritativeOnPublishedMessages() {
+        String metadataKey = defaultProvider.getTaskIdKey();
+        String versionKey = defaultProvider.getApplicationVersionKey();
+        var command = new Message("bla").addMetadata(
+                metadataKey, "caller-supplied", versionKey, "caller-supplied");
+        var builder = DefaultFluxzero.builder().replacePropertySource(ignored -> new SimplePropertySource(Map.of(
+                TASK_ID_PROPERTY, "task-123", APPLICATION_VERSION_PROPERTY, "1.2.3")));
+
+        TestFixture.create(builder, new CommandHandler())
+                .whenExecuting(fc -> fc.commandGateway().sendAndForget(command))
+                .expectCommands((Predicate<Message>) message ->
+                        "task-123".equals(message.getMetadata().get(metadataKey))
+                        && "1.2.3".equals(message.getMetadata().get(versionKey)))
+                .<Message>expectEvent(message -> "task-123".equals(message.getMetadata().get(metadataKey))
+                                                && "1.2.3".equals(message.getMetadata().get(versionKey)));
+    }
+
+    @Test
     void absentOrBlankApplicationVersionDoesNotDecorateCorrelationData() {
         assertSame(testProvider, ApplicationVersionCorrelationDataProvider.decorate(
                 testProvider, new SimplePropertySource(Map.of())));
         assertSame(testProvider, ApplicationVersionCorrelationDataProvider.decorate(
                 testProvider, new SimplePropertySource(Map.of(APPLICATION_VERSION_PROPERTY, " \t "))));
+    }
+
+    @Test
+    void absentOrBlankTaskIdDoesNotDecorateCorrelationData() {
+        assertSame(testProvider, TaskIdCorrelationDataProvider.decorate(
+                testProvider, new SimplePropertySource(Map.of())));
+        assertSame(testProvider, TaskIdCorrelationDataProvider.decorate(
+                testProvider, new SimplePropertySource(Map.of(TASK_ID_PROPERTY, " \t "))));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- integrate the current 1.x main line into the protected 2.0 line
- retain all existing 2.0 Model, Graph and release-channel contracts
- include the task/client identity and delayed proxy-correlation fixes plus current build dependency updates

## Verification

- full nine-module SDK reactor
- Java and Kotlin downstream compatibility modules
- test-server and Proxy suites

This integration does not publish a release or alter stable channels.