### PR TITLE
ci(release): publish SDK to Fluxzero Packages before Central

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,9 @@ jobs:
           distribution: temurin
           java-version: "25"
           cache: maven
+          server-id: fluxzero
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_DEPLOY_TOKEN
 
       - name: Find existing release tag
         id: existing_tag
@@ -135,7 +138,7 @@ jobs:
 
       - name: Build and test
         id: maven-build
-        run: ./mvnw -Dgpg.skip -DskipPublishing=true -B install -P deploy
+        run: ./mvnw -B install
 
       - name: Reserve release tag
         env:
@@ -193,6 +196,21 @@ jobs:
             target/project-kotlin.zip
           retention-days: 1
 
+      - name: Deploy to packages.fluxzero.io with GitHub OIDC
+        env:
+          MAVEN_USERNAME: github-actions
+          MAVEN_GPG_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_SIGNING_PASSPHRASE }}
+        run: |
+          set +x
+          token=$(curl --fail --silent --show-error --get \
+            --data-urlencode 'audience=https://packages.fluxzero.io/maven' \
+            --header "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -er '.value')
+          echo "::add-mask::$token"
+          export MAVEN_DEPLOY_TOKEN="$token"
+          ./mvnw -P sign -B deploy -DskipTests
+
   repair-main-ci:
     name: Repair failed main build
     needs: build-and-test
@@ -245,7 +263,7 @@ jobs:
           deployment_log="$(mktemp)"
           trap 'rm -f "$deployment_log"' EXIT
 
-          maven_arguments=(-P deploy -B deploy -DskipTests)
+          maven_arguments=(-P "sign,central" -B deploy -DskipTests)
           if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
             # A previous attempt may have completed the immutable publication
             # after losing its final status response.

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -38,3 +38,19 @@ jobs:
 
       - name: Run Maven build
         run: ./mvnw -B install
+
+      - name: Verify standard Maven publication and release attachments
+        run: |
+          repository="$RUNNER_TEMP/maven-publication"
+          ./mvnw -B -Dgpg.skip -DskipTests deploy \
+            "-DaltDeploymentRepository=fluxzero::file://$repository"
+          for artifact in fluxzero-sdk-java fluxzero-bom common sdk test-server proxy; do
+            test -d "$repository/io/fluxzero/$artifact"
+          done
+          for artifact in common sdk test-server proxy; do
+            test "$(find "$repository/io/fluxzero/$artifact" -name '*-sources.jar' | wc -l)" -gt 0
+            test "$(find "$repository/io/fluxzero/$artifact" -name '*-javadoc.jar' | wc -l)" -gt 0
+          done
+          for artifact in annotation-processor-tests java-downstream-project kotlin-downstream-project; do
+            test ! -e "$repository/io/fluxzero/$artifact"
+          done

--- a/.github/workflows/repair-main-ci.yml
+++ b/.github/workflows/repair-main-ci.yml
@@ -357,7 +357,7 @@ jobs:
           - Do not push, commit, or open a PR; the workflow will do that.
           - If there is no safe minimal fix, leave the worktree unchanged and explain why.
           - Prefer fixing tests only when the evidence shows a test race rather than a production defect.
-          - Do not run the full deploy command yourself. The workflow will run ./mvnw -Dgpg.skip -DskipPublishing=true -B install -P deploy after Codex exits with repository changes.
+          - Do not run the full deploy command yourself. The workflow will run ./mvnw -B install after Codex exits with repository changes.
 
           Efficiency guidance:
           - Use the pre-collected failure context before spending tokens or time on broad log searches.
@@ -482,7 +482,7 @@ jobs:
 
       - name: Verify changed worktree
         if: steps.gate.outputs.skip != 'true' && steps.duplicate.outputs.exists == 'false' && steps.changes.outputs.has_changes == 'true'
-        run: ./mvnw -Dgpg.skip -DskipPublishing=true -B install -P deploy
+        run: ./mvnw -B install
 
       - name: Commit and push repair branch
         if: steps.gate.outputs.skip != 'true' && steps.duplicate.outputs.exists == 'false' && steps.changes.outputs.has_changes == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ For wire or persisted formats, also test old-data reads and new-data round trips
 - Full PR-equivalent verification is `./mvnw -B install`.
 - For focused work, prefer targeted Maven runs such as `./mvnw -pl sdk -am test` or `./mvnw -pl proxy -am -Dtest=ProxyServerTest test`.
 - Apply the Regression Safety workflow for code changes and run checks proportionate to the affected modules, execution paths, and downstream projects.
-- Run `./mvnw -Dgpg.skip -DskipPublishing=true -B install -P deploy` before changes that affect release packaging, generated artifacts, or Maven Central metadata.
+- Before changes that affect release packaging, generated artifacts, or Maven Central metadata, run `./mvnw -B install` and qualify `./mvnw -B -Dgpg.skip -DskipTests deploy -DaltDeploymentRepository=fluxzero::file:///absolute/path/to/temporary-repository`. Sources and Javadoc are built by default; the `sign` profile adds signatures. Never use the public destination for a packaging check.
 - Javadoc/site work should be checked with `./mvnw -B site -Pjavadoc`.
 
 ## Coding Guidelines

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ functionalities, check out this [cheatsheet](docs/cheatsheet.pdf).
 
 ### Maven Users
 
+Add the Fluxzero repository to your POM to receive releases as soon as they are published:
+
+```xml
+<repositories>
+    <repository>
+        <id>fluxzero</id>
+        <url>https://packages.fluxzero.io/maven</url>
+        <releases><enabled>true</enabled></releases>
+        <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+</repositories>
+```
+
+Releases are published here before Maven Central. Existing Maven coordinates stay the same.
+
 Import the [Fluxzero BOM](https://mvnrepository.com/artifact/io.fluxzero/fluxzero-bom) in your
 `dependencyManagement` section to centralize version management:
 
@@ -79,6 +94,10 @@ automatically:
 <summary><strong>Kotlin DSL (build.gradle.kts)</strong></summary>
 
 ```kotlin
+repositories {
+    maven { url = uri("https://packages.fluxzero.io/maven") }
+    mavenCentral()
+}
 dependencies {
     implementation(platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}"))
     implementation("io.fluxzero:java-client")
@@ -94,6 +113,10 @@ dependencies {
 <summary><strong>Groovy DSL (build.gradle)</strong></summary>
 
 ```groovy
+repositories {
+    maven { url 'https://packages.fluxzero.io/maven' }
+    mavenCentral()
+}
 dependencies {
     implementation platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}")
     implementation 'io.fluxzero:java-client'
@@ -6085,3 +6108,7 @@ Then generate both HTML and JSON docs locally with:
 
 The json-doclet output lands in `target/json-docs`; the `publish-javadoc` workflow copies it to the GitHub Pages
 site on release.
+
+## Publishing SDK releases
+
+See [releasing the SDK](docs/releasing.md) for Maven deployment commands and GitHub OIDC publication.

--- a/annotation-processor-tests/pom.xml
+++ b/annotation-processor-tests/pom.xml
@@ -14,6 +14,10 @@
 
     <name>annotation-processor-tests</name>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.fluxzero</groupId>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,48 @@
+# Releasing the SDK
+
+The `Deploy` workflow publishes each release to `https://packages.fluxzero.io/maven`
+first, then starts Maven Central publication. Release versions, GitHub tags and
+container publication retain their existing configuration. Sources, Javadoc and
+GPG signatures remain part of both Maven publications.
+The existing build job publishes to Fluxzero Packages as its last step. The existing
+Central job starts afterward; GitHub releases, Javadoc and the website notification
+can continue without waiting for Central.
+
+## Maven commands
+
+- `mvn -P sign deploy` publishes signed artifacts to Fluxzero Packages using
+  `distributionManagement`.
+- `mvn -P sign,central deploy` publishes signed artifacts to Central, retaining
+  automatic publication, completion polling and the existing recovery procedure.
+
+Sources and Javadoc are attached during packaging. The shared `sign` profile adds
+GPG signatures before deployment; both workflow steps enable it. Ordinary builds
+and tests need no signing key. Without `sign`, `mvn deploy` still publishes to
+Fluxzero Packages, but without signatures.
+
+The standard deploy plugin uses `deployAtEnd=true`: all modules must build before
+uploads start. Internal annotation-processor and downstream compatibility projects
+are excluded from publication. Uploads are separate operations; a network failure
+can leave a partial release. Maven retries transient deployment errors with the
+same built files. Changed release bytes are rejected by Fluxzero Packages, so an
+interrupted deployment must be recovered with its original files or a new version.
+Do not disable immutability to republish rebuilt files or regenerated signatures.
+
+## Authentication
+
+Fluxzero Packages trusts branch and tag workflows in the `fluxzero-io` organization
+via GitHub OIDC. The publishing job needs `id-token: write` and requests audience
+`https://packages.fluxzero.io/maven` immediately before deployment. Its Maven server
+has ID `fluxzero`, username `github-actions` and the short-lived token as password.
+There is no long-lived package upload secret. The existing GPG secrets are still
+needed for signatures, and the Central job retains its own existing credentials.
+
+For a local packaging check without publishing or signing:
+
+```sh
+repository="$(mktemp -d)"
+./mvnw -B -Dgpg.skip deploy "-DaltDeploymentRepository=fluxzero::file://$repository"
+```
+
+When Central publication is retired, remove the `maven-central` job and the `central`
+profile. The normal deploy step and shared signing profile remain in place.

--- a/java-downstream-project/pom.xml
+++ b/java-downstream-project/pom.xml
@@ -41,6 +41,15 @@
         <maven.surefire.version>3.6.0</maven.surefire.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>fluxzero</id>
+            <url>https://packages.fluxzero.io/maven</url>
+            <releases><enabled>true</enabled><checksumPolicy>fail</checksumPolicy></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/kotlin-downstream-project/pom.xml
+++ b/kotlin-downstream-project/pom.xml
@@ -28,6 +28,15 @@
         <maven.surefire.version>3.6.0</maven.surefire.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>fluxzero</id>
+            <url>https://packages.fluxzero.io/maven</url>
+            <releases><enabled>true</enabled><checksumPolicy>fail</checksumPolicy></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,13 @@
         <module>kotlin-downstream-project</module>
     </modules>
 
+    <distributionManagement>
+        <repository>
+            <id>fluxzero</id>
+            <url>https://packages.fluxzero.io/maven</url>
+        </repository>
+    </distributionManagement>
+
     <name>Fluxzero Java SDK</name>
     <description>Fluxzero provides messaging-as-a-service for distributed applications.</description>
     <url>https://github.com/fluxzero-io/fluxzero-sdk-java</url>
@@ -215,6 +222,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.4</version>
+                    <configuration>
+                        <deployAtEnd>true</deployAtEnd>
+                        <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -470,6 +481,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -502,23 +527,9 @@
 
     <profiles>
         <profile>
-            <id>deploy</id>
+            <id>sign</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -535,6 +546,13 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>central</id>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
SDK releases become available from `packages.fluxzero.io/maven` before Maven Central starts processing them. The existing Deploy workflow gains one GitHub OIDC publication step at the end of its build job; the existing Central job runs afterward.

Both destinations share the `sign` profile: `mvn -P sign deploy` publishes to Fluxzero Packages and `mvn -P sign,central deploy` publishes to Central. Sources, Javadoc, signatures, coordinates and the Central recovery procedure are retained. Ordinary builds need no signing key. Internal compatibility modules remain unpublished, and `deployAtEnd` delays uploads until the reactor has built.

Validation: the full nine-module build and Java/Kotlin checks passed. Local Maven deployment produced exactly six public modules; all 20 POM/JAR signatures were verified using a temporary test key. A Java consumer with an empty Maven cache resolved the published artifacts and passed its tests. Both final publishing profiles passed local qualification, with Central upload disabled. PR CI now checks standard Maven publication and its release attachments against a temporary file repository.

One initial full-build run hit the existing `TimeoutTest.defaultRequestHandlerCancelsTimeoutTaskAfterCompletion` timing assertion; the complete rerun passed without code changes.
