### PR TITLE
ci(release): use the dedicated Packages upload endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,7 +204,7 @@ jobs:
         run: |
           set +x
           token=$(curl --fail --silent --show-error --get \
-            --data-urlencode 'audience=https://packages.fluxzero.io/maven' \
+            --data-urlencode 'audience=https://packages.fluxzero.io/publish/maven' \
             --header "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -er '.value')
           echo "::add-mask::$token"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ Do not disable immutability to republish rebuilt files or regenerated signatures
 
 Fluxzero Packages trusts branch and tag workflows in the `fluxzero-io` organization
 via GitHub OIDC. The publishing job needs `id-token: write` and requests audience
-`https://packages.fluxzero.io/maven` immediately before deployment. Its Maven server
+`https://packages.fluxzero.io/publish/maven` immediately before deployment. Its Maven server
 has ID `fluxzero`, username `github-actions` and the short-lived token as password.
 There is no long-lived package upload secret. The existing GPG secrets are still
 needed for signatures, and the Central job retains its own existing credentials.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,8 @@
 # Releasing the SDK
 
-The `Deploy` workflow publishes each release to `https://packages.fluxzero.io/maven`
-first, then starts Maven Central publication. Release versions, GitHub tags and
+The `Deploy` workflow uploads each release to `https://packages.fluxzero.io/publish/maven`
+first, then starts Maven Central publication. Public downloads remain at
+`https://packages.fluxzero.io/maven`. Release versions, GitHub tags and
 container publication retain their existing configuration. Sources, Javadoc and
 GPG signatures remain part of both Maven publications.
 The existing build job publishes to Fluxzero Packages as its last step. The existing

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <distributionManagement>
         <repository>
             <id>fluxzero</id>
-            <url>https://packages.fluxzero.io/maven</url>
+            <url>https://packages.fluxzero.io/publish/maven</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
SDK releases upload through `https://packages.fluxzero.io/publish/maven` and request that same URL as the GitHub OIDC audience. Public downloads remain at `https://packages.fluxzero.io/maven` so R2 can serve them directly.

The distribution-management URL, audience in the existing deploy step and release documentation change. Signing profiles and publication to Packages before Central remain intact. Maven's effective configuration resolves the new upload URL. Workflow validation passes with the existing unrelated ShellCheck SC2129 style notices excluded; PR checks cover the reactor build and local publication.

Merge after the dedicated upload route is live. The hosting migration temporarily accepts the previous upload route and audience until a real SDK publication through the new endpoint succeeds.
