### PR TITLE
ci(release): use source commit time for Maven archives

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set release timestamp
+        run: echo "RELEASE_TIMESTAMP=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
+
       - name: Verify repository normalization
         run: |
           git add --renormalize .
@@ -138,7 +141,7 @@ jobs:
 
       - name: Build and test
         id: maven-build
-        run: ./mvnw -B install
+        run: ./mvnw -B install -Dproject.build.outputTimestamp="$RELEASE_TIMESTAMP"
 
       - name: Reserve release tag
         env:
@@ -209,7 +212,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -er '.value')
           echo "::add-mask::$token"
           export MAVEN_DEPLOY_TOKEN="$token"
-          ./mvnw -P sign -B deploy -DskipTests
+          ./mvnw -P sign -B deploy -DskipTests -Dproject.build.outputTimestamp="$RELEASE_TIMESTAMP"
 
   repair-main-ci:
     name: Repair failed main build
@@ -235,6 +238,9 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7
+
+      - name: Set release timestamp
+        run: echo "RELEASE_TIMESTAMP=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
 
       - name: Install Java and Maven
         uses: actions/setup-java@v6
@@ -263,7 +269,7 @@ jobs:
           deployment_log="$(mktemp)"
           trap 'rm -f "$deployment_log"' EXIT
 
-          maven_arguments=(-P "sign,central" -B deploy -DskipTests)
+          maven_arguments=(-P "sign,central" -B deploy -DskipTests "-Dproject.build.outputTimestamp=$RELEASE_TIMESTAMP")
           if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
             # A previous attempt may have completed the immutable publication
             # after losing its final status response.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Build and test
         id: maven-build
-        run: ./mvnw -B install -Dproject.build.outputTimestamp="$RELEASE_TIMESTAMP"
+        run: ./mvnw -B install
 
       - name: Reserve release tag
         env:
@@ -212,7 +212,7 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -er '.value')
           echo "::add-mask::$token"
           export MAVEN_DEPLOY_TOKEN="$token"
-          ./mvnw -P sign -B deploy -DskipTests -Dproject.build.outputTimestamp="$RELEASE_TIMESTAMP"
+          ./mvnw -P sign -B deploy -DskipTests
 
   repair-main-ci:
     name: Repair failed main build
@@ -269,7 +269,7 @@ jobs:
           deployment_log="$(mktemp)"
           trap 'rm -f "$deployment_log"' EXIT
 
-          maven_arguments=(-P "sign,central" -B deploy -DskipTests "-Dproject.build.outputTimestamp=$RELEASE_TIMESTAMP")
+          maven_arguments=(-P "sign,central" -B deploy -DskipTests)
           if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
             # A previous attempt may have completed the immutable publication
             # after losing its final status response.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
     <url>https://github.com/fluxzero-io/fluxzero-sdk-java</url>
 
     <properties>
+        <project.build.outputTimestamp>${env.RELEASE_TIMESTAMP}</project.build.outputTimestamp>
+        <updateBuildOutputTimestampPolicy>never</updateBuildOutputTimestampPolicy>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
De publicatiejobs bouwen archieven op verschillende tijdstippen, waardoor dezelfde release op Packages en Central andere JAR-checksums kan krijgen. De POM leest nu de commit-timestamp uit `RELEASE_TIMESTAMP`; iedere relevante job stelt die na de broncheckout in.

`updateBuildOutputTimestampPolicy=never` voorkomt dat `versions:set` deze waarde vervangt door de huidige tijd. De Maven-buildcommando’s behouden hun bestaande vorm. Packages blijft vóór Central; signing en releasevoorwaarden blijven behouden.

Validatie: twee schone lokale builds via de POM-configuratie leverden byte-identieke JARs op, inclusief sources en Javadoc. Bouwen zonder `RELEASE_TIMESTAMP` slaagt ook. `versions:set` op tijdelijke kopieën van de project-POMs wijzigt de releaseversie en behoudt de timestamp-expressie. De gewijzigde workflow introduceert geen nieuwe Actionlint-meldingen.

Alle 16 JARs van de vier releasemodules zijn identiek, inclusief test- en runnable-JARs. De eerdere SDK-basisbuild inclusief tests en downstreammodules slaagde.
