### PR TITLE
ci(release): retain complete Maven files as GitHub assets

### DIFF
--- a/.github/scripts/collect-maven-assets.py
+++ b/.github/scripts/collect-maven-assets.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Collect exact Packages publication bytes as flat GitHub Release assets."""
+import argparse
+import hashlib
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import tempfile
+
+PUBLISH_URL = "https://packages.fluxzero.io/publish/maven/"
+DOWNLOAD_URL = "https://packages.fluxzero.io/maven/"
+CHECKSUMS = ("md5", "sha1", "sha256", "sha512")
+
+
+def publication_paths(log):
+    # Maven logs the completed artifact transfers, including attached signatures.
+    paths = set(re.findall(r"Uploaded to fluxzero: " + re.escape(PUBLISH_URL) + r"([^\s]+)",
+                           re.sub(r"\x1b\[[0-9;]*m", "", log)))
+    paths = {p for p in paths if not PurePosixPath(p).name.startswith("maven-metadata")}
+    if not paths or not any(p.endswith(".pom") for p in paths):
+        raise ValueError("No completed Maven publication found in deploy log")
+    return sorted(paths)
+
+
+def validate_paths(paths):
+    names = set()
+    for path in paths:
+        parts = PurePosixPath(path).parts
+        if (not path.startswith("io/fluxzero/") or len(parts) < 5
+                or any(not re.fullmatch(r"[A-Za-z0-9_.+-]+", p) or p in (".", "..") for p in parts)
+                or str(PurePosixPath(path)) != path or "SNAPSHOT" in parts[-2]):
+            raise ValueError(f"Invalid release path: {path}")
+        if parts[-1] in names:
+            raise ValueError(f"GitHub asset filename collision: {parts[-1]}")
+        names.add(parts[-1])
+
+
+def download(path, destination, optional=False):
+    result = subprocess.run([
+        "curl", "--silent", "--show-error", "--location", "--fail",
+        "--retry", "4", "--retry-delay", "2", "--connect-timeout", "15",
+        "--max-time", "120", "--output", str(destination), "--write-out", "%{http_code}",
+        DOWNLOAD_URL + path,
+    ], capture_output=True, text=True)
+    if optional and result.stdout == "404":
+        destination.unlink(missing_ok=True)
+        return False
+    if result.returncode or result.stdout != "200":
+        raise RuntimeError(f"Download failed for {path}: HTTP {result.stdout}; {result.stderr.strip()}")
+    return True
+
+
+def collect(paths, output, fetch=download):
+    paths = sorted(set(paths))
+    validate_paths(paths)
+    # Signatures must come from Packages too, never from a later Central rebuild.
+    files = {p for p in paths if not p.endswith(tuple("." + h for h in CHECKSUMS))}
+    files |= {p + ".asc" for p in files if not p.endswith(".asc")}
+    validate_paths(sorted(files))
+    if output.exists() and any(output.iterdir()):
+        raise ValueError(f"Output directory must be empty: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=output.parent) as staging:
+        staging = Path(staging)
+        for path in sorted(files):
+            target = staging / PurePosixPath(path).name
+            fetch(path, target)
+            for algorithm in CHECKSUMS:
+                checksum_path = path + "." + algorithm
+                checksum = staging / (target.name + "." + algorithm)
+                optional = checksum_path not in paths and (path.endswith(".asc") or algorithm in ("sha256", "sha512"))
+                if fetch(checksum_path, checksum, optional=optional):
+                    actual = hashlib.new(algorithm, target.read_bytes()).hexdigest()
+                    if checksum.read_text().strip().lower() != actual:
+                        raise ValueError(f"Checksum mismatch: {checksum_path}")
+        output.mkdir(exist_ok=True)
+        for item in staging.iterdir():
+            item.replace(output / item.name)
+    print(f"Collected {len(list(output.iterdir()))} exact Maven release assets")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--deploy-log", type=Path)
+    source.add_argument("--paths", nargs="+")
+    parser.add_argument("--output", type=Path, default=Path("maven-release-assets"))
+    args = parser.parse_args()
+    paths = publication_paths(args.deploy_log.read_text()) if args.deploy_log else args.paths
+    collect(paths, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_release_assets.py
+++ b/.github/scripts/test_release_assets.py
@@ -1,0 +1,130 @@
+"""Publication-byte preservation and failure boundaries; no live uploads."""
+import hashlib
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+import subprocess
+
+spec = importlib.util.spec_from_file_location("assets", Path(__file__).with_name("collect-maven-assets.py"))
+assets = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(assets)
+
+POM = "io/fluxzero/example/1.2.3/example-1.2.3.pom"
+JAR = "io/fluxzero/example/1.2.3/example-1.2.3-tests.jar"
+SBOM = "io/fluxzero/example/1.2.3/example-1.2.3-cyclonedx.json"
+MODULE = "io/fluxzero/tools/plugin/1.2.3/plugin-1.2.3.module"
+
+
+def repository(paths):
+    result = {}
+    for path in paths:
+        for suffix in ("", ".asc"):
+            key = path + suffix
+            result[key] = b"published bytes, not a local rebuild: " + key.encode()
+            # Maven does not normally publish checksum sidecars for signatures.
+            if not suffix:
+                for algorithm in assets.CHECKSUMS:
+                    result[key + "." + algorithm] = hashlib.new(algorithm, result[key]).hexdigest().encode()
+    return result
+
+
+class ReleaseAssetsTest(unittest.TestCase):
+    def collect(self, paths, remote):
+        def fetch(path, destination, optional=False):
+            if optional and path not in remote:
+                return False
+            destination.write_bytes(remote[path])
+            return True
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "assets"
+            assets.collect(paths, output, fetch)
+            return {p.name: p.read_bytes() for p in output.iterdir()}
+
+    def test_completed_maven_transfers_only(self):
+        lines = [f"[INFO] Uploaded to fluxzero: {assets.PUBLISH_URL}{p} (12 kB at 1 kB/s)"
+                 for p in (POM, JAR, SBOM, POM + ".asc", POM)]
+        lines += [f"Uploading to fluxzero: {assets.PUBLISH_URL}io/fluxzero/incomplete/1/incomplete-1.jar",
+                  f"Uploaded to fluxzero: {assets.PUBLISH_URL}io/fluxzero/example/maven-metadata.xml",
+                  "Downloaded from central: https://repo.maven.apache.org/maven2/third-party.jar"]
+        log = "\x1b[0m" + "\n".join(lines)
+        self.assertEqual(sorted(set((POM, JAR, SBOM, POM + ".asc"))), assets.publication_paths(log))
+
+    def test_exact_bytes_for_multiple_modules_and_extra_attachments(self):
+        paths = [POM, JAR, SBOM, MODULE]
+        remote = repository(paths)
+        self.assertEqual({Path(p).name: data for p, data in remote.items()}, self.collect(paths, remote))
+
+    def test_maven_without_optional_checksums(self):
+        remote = repository([POM])
+        del remote[POM + ".sha256"]
+        del remote[POM + ".sha512"]
+        self.assertEqual(4, len(self.collect([POM], remote)))
+
+    def test_missing_signature_or_required_checksum_fails(self):
+        for suffix in (".asc", ".sha1", ".md5"):
+            with self.subTest(suffix=suffix):
+                remote = repository([POM])
+                del remote[POM + suffix]
+                with self.assertRaises(KeyError):
+                    self.collect([POM], remote)
+
+    def test_explicitly_uploaded_checksum_cannot_be_missing(self):
+        remote = repository([POM])
+        del remote[POM + ".sha256"]
+        with self.assertRaises(KeyError):
+            self.collect([POM, POM + ".sha256"], remote)
+
+    def test_corruption_fails(self):
+        remote = repository([POM])
+        remote[POM] = b"different bytes"
+        with self.assertRaisesRegex(ValueError, "Checksum mismatch"):
+            self.collect([POM], remote)
+
+    def test_optional_http_404_only_is_ignored(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "checksum"
+            for exit_code in (22, 56):
+                result = subprocess.CompletedProcess([], exit_code, "404", "not found")
+                with patch.object(assets.subprocess, "run", return_value=result):
+                    self.assertFalse(assets.download(POM + ".sha256", target, optional=True))
+                    with self.assertRaises(RuntimeError):
+                        assets.download(POM, target)
+            for status in ("403", "500", "000"):
+                result = subprocess.CompletedProcess([], 22, status, "failure")
+                with patch.object(assets.subprocess, "run", return_value=result):
+                    with self.assertRaises(RuntimeError):
+                        assets.download(POM + ".sha256", target, optional=True)
+
+    def test_failure_does_not_leave_partial_upload_directory(self):
+        def fail(path, destination, optional=False):
+            if path.endswith(".asc"):
+                raise RuntimeError("missing signature")
+            if optional:
+                return False
+            if path.endswith(".md5"):
+                destination.write_text(hashlib.md5(b"pom").hexdigest())
+            elif path.endswith(".sha1"):
+                destination.write_text(hashlib.sha1(b"pom").hexdigest())
+            else:
+                destination.write_bytes(b"pom")
+            return True
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "assets"
+            with self.assertRaises(RuntimeError):
+                assets.collect([POM], output, fail)
+            self.assertFalse(output.exists())
+
+    def test_empty_log_path_traversal_snapshots_and_collisions_fail(self):
+        with self.assertRaises(ValueError):
+            assets.publication_paths("BUILD SUCCESS without publication")
+        for paths in ([POM.replace("example/1.2.3", "../1.2.3")],
+                      [POM.replace("1.2.3", "1-SNAPSHOT")],
+                      [POM, POM.replace("io/fluxzero/", "io/fluxzero/other/")]):
+            with self.subTest(paths=paths), self.assertRaises(ValueError):
+                assets.validate_paths(paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,7 +212,19 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -er '.value')
           echo "::add-mask::$token"
           export MAVEN_DEPLOY_TOKEN="$token"
-          ./mvnw -P sign -B deploy -DskipTests
+          set -o pipefail
+          ./mvnw -P sign -B deploy -DskipTests | tee "$RUNNER_TEMP/packages-deploy.log"
+
+      - name: Collect exact Maven release assets from Packages
+        run: python3 .github/scripts/collect-maven-assets.py --deploy-log "$RUNNER_TEMP/packages-deploy.log"
+
+      - name: Retain Maven release assets for the GitHub release
+        uses: actions/upload-artifact@v7
+        with:
+          name: maven-release-assets
+          path: maven-release-assets/*
+          if-no-files-found: error
+          retention-days: 1
 
   repair-main-ci:
     name: Repair failed main build
@@ -312,6 +324,8 @@ jobs:
   github-release:
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7
@@ -322,6 +336,12 @@ jobs:
           name: project-files
           path: release-assets
 
+      - name: Download complete Maven release assets
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-release-assets
+          path: maven-release-assets
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
@@ -329,7 +349,9 @@ jobs:
           name: Fluxzero ${{ needs.build-and-test.outputs.version }}
           body: ${{ needs.build-and-test.outputs.version-changelog }}
           prerelease: ${{ needs.build-and-test.outputs.prerelease }}
+          fail_on_unmatched_files: true
           files: |
+            maven-release-assets/*
             release-assets/project-java.zip
             release-assets/project-kotlin.zip
 

--- a/.github/workflows/release-assets-test.yml
+++ b/.github/workflows/release-assets-test.yml
@@ -1,0 +1,26 @@
+name: Maven release assets
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/collect-maven-assets.py'
+      - '.github/scripts/test_release_assets.py'
+      - '.github/workflows/release-assets-test.yml'
+      - '.github/workflows/deploy.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/collect-maven-assets.py'
+      - '.github/scripts/test_release_assets.py'
+      - '.github/workflows/release-assets-test.yml'
+      - '.github/workflows/deploy.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: python3 .github/scripts/test_release_assets.py

--- a/README.md
+++ b/README.md
@@ -6157,3 +6157,18 @@ site on release.
 ## Publishing SDK releases
 
 See [releasing the SDK](docs/releasing.md) for Maven deployment commands and GitHub OIDC publication.
+
+## Maven files in GitHub Releases
+
+Future GitHub Releases also retain the exact files published to Fluxzero
+Packages: POMs, JARs and attached artifacts, signatures, and available checksum
+sidecars. The workflow downloads these bytes from Packages rather than taking
+files from a later Central build. Existing distribution assets are preserved.
+Use an exact asset filename when downloading a particular JAR; a broad `*.jar`
+pattern also matches sources, Javadoc and other modules.
+
+The collector (`.github/scripts/collect-maven-assets.py`) verifies checksums and
+fails on missing required files or duplicate flat asset names. Maven workflows
+obtain the file list from completed deploy transfers. Mutable repository-wide
+`maven-metadata.xml` and directory indexes are not release assets. No manifest,
+archive, historical backfill or restore tool is generated.


### PR DESCRIPTION
GitHub Releases currently omit files needed to recover the Maven publication. Future releases now attach the exact bytes downloaded from Fluxzero Packages, including POMs, JARs and additional publications, signatures, and available checksum sidecars. Existing distribution assets remain available.

The collector verifies checksums and refuses missing required files or filename collisions. Maven inventories come from successful deploy transfers; CLI inventories explicitly include both plugins, their Gradle module metadata, and the marker POM. Build/signing behavior and release gates remain unchanged. This adds no historical backfill, manifest, archive format, or restore tool.

Validation: nine focused collector tests per repository; Actionlint has no new findings. A real successful Maven publication log produced the expected inventory. Read-only checks retrieved and verified an existing Maven POM/signature and Gradle module/signature with their available checksums. No product release or live upload was used for verification.

Backlog: Packages A23, `work-backlog/docs/fluxzero-packages/A23/README.md`.
