### PR TITLE
docs(packages): align setup, policies, and checksum publishing

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -T1C
+-Daether.checksums.algorithms.fluxzero=SHA-256,SHA-512,SHA-1,MD5

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Fluxzero Java SDK
 
 [![Build](https://github.com/fluxzero-io/fluxzero-sdk-java/actions/workflows/deploy.yml/badge.svg)](https://github.com/fluxzero-io/fluxzero-sdk-java/actions)
-[![Maven Central](https://img.shields.io/maven-central/v/io.fluxzero/fluxzero-sdk-java)](https://central.sonatype.com/artifact/io.fluxzero/fluxzero-sdk-java?smo=true)
+[![Packages](https://img.shields.io/badge/packages-releases-blue)](https://packages.fluxzero.io/maven/io/fluxzero/fluxzero-bom/)
 [![Javadoc](https://img.shields.io/badge/javadoc-main-blue)](https://fluxzero-io.github.io/fluxzero-sdk-java/javadoc/apidocs/)
 [![Cheatsheet](https://img.shields.io/badge/cheatsheet-PDF-red.svg)](https://raw.githubusercontent.com/fluxzero-io/fluxzero-sdk-java/refs/heads/main/docs/cheatsheet.pdf)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
@@ -19,22 +19,32 @@ functionalities, check out this [cheatsheet](docs/cheatsheet.pdf).
 
 ### Maven Users
 
-Add the Fluxzero repository to your POM to receive releases as soon as they are published:
+Add Fluxzero Packages to your `pom.xml`, inside `<project>`. Merge these entries
+with any existing repository sections. Dependencies and Maven build plugins
+use separate repository lists:
 
 ```xml
 <repositories>
     <repository>
         <id>fluxzero</id>
         <url>https://packages.fluxzero.io/maven</url>
-        <releases><enabled>true</enabled></releases>
         <snapshots><enabled>false</enabled></snapshots>
     </repository>
 </repositories>
+<pluginRepositories>
+    <pluginRepository>
+        <id>fluxzero-plugins</id>
+        <url>https://packages.fluxzero.io/maven</url>
+        <snapshots><enabled>false</enabled></snapshots>
+    </pluginRepository>
+</pluginRepositories>
 ```
 
-Releases are published here before Maven Central. Existing Maven coordinates stay the same.
+Downloads are public and require no account or credentials. Existing artifacts
+remain on Maven Central; from **1 October 2026**, new Fluxzero releases will be
+published only at [Fluxzero Packages](https://packages.fluxzero.io/).
 
-Import the [Fluxzero BOM](https://mvnrepository.com/artifact/io.fluxzero/fluxzero-bom) in your
+Import the [Fluxzero BOM](https://packages.fluxzero.io/maven/io/fluxzero/fluxzero-bom/) in your
 `dependencyManagement` section to centralize version management:
 
 ```xml
@@ -44,7 +54,7 @@ Import the [Fluxzero BOM](https://mvnrepository.com/artifact/io.fluxzero/fluxzer
         <dependency>
             <groupId>io.fluxzero</groupId>
             <artifactId>fluxzero-bom</artifactId>
-            <version>${fluxzero.version}</version> <!-- See version badge above -->
+            <version>${fluxzero.version}</version> <!-- Choose a release from the BOM directory -->
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -59,11 +69,11 @@ Then declare only the dependencies you actually need (no version required):
 <dependencies>
     <dependency>
         <groupId>io.fluxzero</groupId>
-        <artifactId>java-client</artifactId>
+        <artifactId>sdk</artifactId>
     </dependency>
     <dependency>
         <groupId>io.fluxzero</groupId>
-        <artifactId>java-client</artifactId>
+        <artifactId>sdk</artifactId>
         <classifier>tests</classifier>
         <scope>test</scope>
     </dependency>
@@ -87,6 +97,27 @@ Then declare only the dependencies you actually need (no version required):
 
 ### Gradle Users
 
+Add the Packages repository before Maven Central in `build.gradle.kts` or
+`build.gradle`. Maven Central remains available for other libraries. If your
+build centralizes repositories in `settings.gradle(.kts)`, put these entries in
+`dependencyResolutionManagement.repositories` instead.
+
+For Fluxzero Gradle plugins used through `plugins {}`, also add Packages in
+`pluginManagement.repositories` in `settings.gradle.kts`, before the Plugin Portal:
+
+```kotlin
+pluginManagement {
+    repositories {
+        maven { url = uri("https://packages.fluxzero.io/maven") }
+        gradlePluginPortal()
+    }
+}
+```
+
+Keep `pluginManagement` at the start of the settings file. It is only needed for
+Gradle plugin resolution, not for using the SDK as a dependency. The same
+repository declarations work in Groovy settings with single-quoted strings.
+
 Use [platform BOM support](https://docs.gradle.org/current/userguide/platforms.html) to align dependency versions
 automatically:
 
@@ -98,10 +129,13 @@ repositories {
     maven { url = uri("https://packages.fluxzero.io/maven") }
     mavenCentral()
 }
+
 dependencies {
     implementation(platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}"))
-    implementation("io.fluxzero:java-client")
-    testImplementation("io.fluxzero:java-client", classifier = "tests")
+    implementation("io.fluxzero:sdk")
+    testImplementation("io.fluxzero:sdk") {
+        artifact { classifier = "tests" }
+    }
     testImplementation("io.fluxzero:test-server")
     testImplementation("io.fluxzero:proxy")
 }
@@ -114,14 +148,15 @@ dependencies {
 
 ```groovy
 repositories {
-    maven { url 'https://packages.fluxzero.io/maven' }
+    maven { url = uri('https://packages.fluxzero.io/maven') }
     mavenCentral()
 }
+
 dependencies {
     implementation platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}")
-    implementation 'io.fluxzero:java-client'
-    testImplementation('io.fluxzero:java-client') {
-        classifier = 'tests'
+    implementation 'io.fluxzero:sdk'
+    testImplementation('io.fluxzero:sdk') {
+        artifact { classifier = 'tests' }
     }
     testImplementation 'io.fluxzero:test-server'
     testImplementation 'io.fluxzero:proxy'

--- a/docs/developer/about/cookies.mdx
+++ b/docs/developer/about/cookies.mdx
@@ -7,11 +7,11 @@ sidebar:
 
 **Last update:** September 2026
 
-At Fluxzero, your privacy matters. This page explains how the public Fluxzero website, documentation and package repository use cookies and similar browser technologies.
+At Fluxzero, your privacy matters. This page explains how our public websites use cookies and similar browser technologies.
 
 ## Summary
 
-The public Fluxzero website, documentation and package repository only use cookies when they are necessary for the website to work or for functionality you explicitly use, such as signing in with GitHub to submit documentation feedback.
+Our public websites only use cookies when they are necessary for the website to work or for functionality you explicitly use, such as signing in with GitHub to submit documentation feedback.
 
 We do not use optional cookies on the public website. That means we do not currently show a cookie banner.
 
@@ -23,25 +23,15 @@ Similar browser technologies, such as local storage and session storage, can sto
 
 ## Cookies We Use
 
-### Public Package Repository
+### Security Cookies
 
-Browsing and downloading from https://packages.fluxzero.io requires no sign-in.
-The repository pages do not set application cookies or store preferences in
-local storage or session storage. Pagination uses the page URL fragment.
-
-Cloudflare provides security for this service. If a security challenge is shown,
-a `cf_clearance` cookie can record that it has been completed, so the browser does
-not have to repeat it during the configured challenge-passage period.
-
-Cloudflare's standard error pages can load a favicon from `cloudflare.com`.
-That request can set Cloudflare's `__cf_bm` bot-protection cookie on that domain;
-it expires after 30 minutes of inactivity. It is separate from the normal
-repository pages. See [Cloudflare's cookie documentation](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/).
-
-Browsers may send technical network-error reports to Cloudflare. These reports
-do not use a repository cookie or browser storage for tracking; see our
-[Privacy Notice](/docs/about/privacy/) for the purpose and processing of these
-requests.
+Cloudflare protects our public websites and may set strictly necessary security
+cookies when it presents a challenge or standard error page:
+`cf_clearance` remembers a completed challenge for the configured period, while
+`__cf_bm` may be set on `cloudflare.com` by a standard error page and expires
+after 30 minutes of inactivity. These cookies are not used for advertising or
+cross-site tracking. See our [Privacy Notice](/docs/about/privacy/) and
+[Cloudflare's cookie documentation](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/).
 
 ### GitHub Feedback Login Cookies
 

--- a/docs/developer/about/cookies.mdx
+++ b/docs/developer/about/cookies.mdx
@@ -5,13 +5,13 @@ sidebar:
    order: 120
 ---
 
-**Last update:** July 2026
+**Last update:** September 2026
 
-At Fluxzero, your privacy matters. This page explains how the public Fluxzero website and documentation use cookies and similar browser technologies.
+At Fluxzero, your privacy matters. This page explains how the public Fluxzero website, documentation and package repository use cookies and similar browser technologies.
 
 ## Summary
 
-The public Fluxzero website and documentation only use cookies when they are necessary for the website to work or for functionality you explicitly use, such as signing in with GitHub to submit documentation feedback.
+The public Fluxzero website, documentation and package repository only use cookies when they are necessary for the website to work or for functionality you explicitly use, such as signing in with GitHub to submit documentation feedback.
 
 We do not use optional cookies on the public website. That means we do not currently show a cookie banner.
 
@@ -22,6 +22,26 @@ Cookies are small text files stored on your device when you visit a website. The
 Similar browser technologies, such as local storage and session storage, can store small pieces of information in your browser without using cookies.
 
 ## Cookies We Use
+
+### Public Package Repository
+
+Browsing and downloading from https://packages.fluxzero.io requires no sign-in.
+The repository pages do not set application cookies or store preferences in
+local storage or session storage. Pagination uses the page URL fragment.
+
+Cloudflare provides security for this service. If a security challenge is shown,
+a `cf_clearance` cookie can record that it has been completed, so the browser does
+not have to repeat it during the configured challenge-passage period.
+
+Cloudflare's standard error pages can load a favicon from `cloudflare.com`.
+That request can set Cloudflare's `__cf_bm` bot-protection cookie on that domain;
+it expires after 30 minutes of inactivity. It is separate from the normal
+repository pages. See [Cloudflare's cookie documentation](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/).
+
+Browsers may send technical network-error reports to Cloudflare. These reports
+do not use a repository cookie or browser storage for tracking; see our
+[Privacy Notice](/docs/about/privacy/) for the purpose and processing of these
+requests.
 
 ### GitHub Feedback Login Cookies
 

--- a/docs/developer/about/privacy.mdx
+++ b/docs/developer/about/privacy.mdx
@@ -7,11 +7,16 @@ sidebar:
 
 # Privacy Notice — Fluxzero
 
-**Version:** July 2026
+**Version:** September 2026
 
 ## 1. Who Are We and What Do We Offer?
 
 We are Fluxzero B.V. (Fluxzero). We provide a cloud runtime platform for backend software, designed to let you build your application logic – including with your AI coding tools – while Fluxzero takes care of execution, scaling, persistence, security and deployment (the Platform). You can access our Platform via our Website: https://www.fluxzero.io (and the use of the Platform, the Website, the SDK, the CLI and related services collectively: our Services).
+
+Our public websites also include the developer documentation and the package
+repository at https://packages.fluxzero.io. This notice covers browsing and
+public package downloads, including downloads made by build tools such as Maven
+and Gradle. Downloading public packages does not require a Platform account.
 
 ## 2. Personal Data and Controller
 
@@ -231,6 +236,27 @@ We use this information to:
 
 We may process this Personal Data because we have a legitimate interest to do so, i.e. to provide you with a good functioning Website and improve our Services for our customers.
 
+#### If You Browse or Download Public Packages
+
+**Personal Data**
+
+- Technical request information, such as IP address, request time, requested
+  package path, and browser or build-tool information;
+- security-event details when a request is flagged or blocked.
+
+**Purpose(s)**
+
+We use this information to deliver public files, protect the repository against
+abuse and investigate availability or security problems. Cloudflare provides
+hosting, content delivery and security for the repository. Browsers may also
+send network-error reports to Cloudflare to diagnose connection failures; this
+is separate from cookies and advertising analytics.
+
+**Legal basis**
+
+We have a legitimate interest in providing a functioning, secure public package
+repository and diagnosing problems with file delivery.
+
 #### If You Use Documentation Feedback
 
 **Personal Data**
@@ -318,9 +344,9 @@ When you use our Services, it may be required that you provide us with certain P
 
 We use functional cookies and similar browser technologies on our Website. A cookie is a simple small text file that can be stored on your device when visiting the Website.
 
-We do not use cookies or similar browser technologies for advertising, retargeting, cross-site profiling, social media tracking, heatmaps, session replay or optional analytics on the public Website and documentation.
+We do not use cookies or similar browser technologies for advertising, retargeting, cross-site profiling, social media tracking, heatmaps, session replay or optional analytics on the public Website, documentation or package repository.
 
-We use strictly necessary cookies where required for functionality you request, including documentation feedback. We may also use browser storage for functional documentation preferences.
+We use strictly necessary cookies where required for functionality you request, including documentation feedback and security challenges. We may also use browser storage for functional documentation preferences.
 
 For more information on our use of cookies, please refer to our Cookie Notice: https://fluxzero.io/docs/about/cookies/.
 
@@ -334,7 +360,17 @@ We will not process or store any Personal Data that we do not need. We store Per
 - **Personal Data in our correspondence**: We retain the Personal Data as long as necessary to handle your message/question/complaint and for a period of 2 years thereafter.
 - **Personal Data in our records for the (tax) authorities**: We retain the Personal Data for 7 years, unless we are legally obliged to retain the data for a longer period.
 - **Personal Data of Applicants**: We retain the Personal Data for a maximum of 4 weeks after the application process, unless the Applicant has given us permission to store the Personal Data for (up to) 1 year.
-- **Service logs**: We retain service logs for 90 days after generation, unless a longer period is required for security investigations.
+- **Platform service logs**: We retain Platform service logs for 90 days after generation, unless a longer period is required for security investigations.
+
+For the package repository, Cloudflare currently makes sampled security events
+available to us for up to 24 hours. This dashboard window is separate from the
+Platform service-log retention period above. If we retain information from an
+event to investigate an incident, we keep it only for as long as needed for that
+investigation and any resulting legal obligations or claims.
+
+Cloudflare's network-error reporting processes the client IP address only while
+handling the report and does not retain it in that reporting pipeline. This does
+not describe retention in other Cloudflare security or delivery services.
 
 After expiry of the aforementioned retention period(s), we may process and retain certain Personal Data to comply with legal retention obligations and/or for fraud/misuse investigations or to substantiate a (judicial) claim. In such events, we will retain the Personal Data separately and only use such Personal Data for the aforementioned purposes.
 
@@ -351,6 +387,11 @@ For instance, we use Processors for:
 - cloud hosting and infrastructure;
 - payment processing;
 - sending newsletters.
+
+For public package delivery we use Cloudflare for storage, CDN distribution,
+security and network-error diagnostics. Cloudflare's
+[Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/)
+sets out the data-protection terms for its processing on our behalf.
 
 ### Controllers
 
@@ -370,6 +411,12 @@ Apart from the above, we will only share Personal Data with third parties if the
 ## 8. Export of Personal Data Outside the European Union/European Economic Area
 
 We primarily process and store your Personal Data in the EU/EEA. We may transmit or give access to Personal Data to parties outside the EU/EEA, if one of our Processors or other Controllers is established there. Personal Data will only be transferred to countries and/or parties that provide an adequate level of protection as decided by the European Commission, or if we have Standard Contractual Clauses (SCCs) and/or other appropriate safeguards in place. You may contact us if you wish to receive more information or a copy of the safeguards we have put in place.
+
+Public package delivery uses Cloudflare's global network. Requests and security
+information may therefore be processed outside the EU/EEA, subject to the
+applicable safeguards described above and in Cloudflare's Data Processing
+Addendum. Storing package files in a European region does not limit all network
+processing to that region.
 
 ## 9. Third Party Websites
 

--- a/docs/developer/about/privacy.mdx
+++ b/docs/developer/about/privacy.mdx
@@ -13,10 +13,9 @@ sidebar:
 
 We are Fluxzero B.V. (Fluxzero). We provide a cloud runtime platform for backend software, designed to let you build your application logic – including with your AI coding tools – while Fluxzero takes care of execution, scaling, persistence, security and deployment (the Platform). You can access our Platform via our Website: https://www.fluxzero.io (and the use of the Platform, the Website, the SDK, the CLI and related services collectively: our Services).
 
-Our public websites also include the developer documentation and the package
-repository at https://packages.fluxzero.io. This notice covers browsing and
-public package downloads, including downloads made by build tools such as Maven
-and Gradle. Downloading public packages does not require a Platform account.
+Our public websites include the developer documentation and the package
+repository at https://packages.fluxzero.io. Public package downloads do not
+require a Platform account.
 
 ## 2. Personal Data and Controller
 
@@ -217,11 +216,13 @@ We process this Personal Data because it is necessary for the (preparation of th
 
 ### Personal Data We May Process in General
 
-#### If You Visit Our Website
+#### If You Visit Our Public Websites
 
 **Personal Data**
 
-- Information on your device type, session date and time, IP address, and browser type.
+- Information on your device type, session date and time, IP address, browser
+  or other client type, and the requested page or file;
+- security-event details if a request is flagged or blocked.
 
 **Purpose(s)**
 
@@ -229,33 +230,15 @@ We use this information to:
 
 - communicate in the same language of the browser;
 - adapt our Website to the used device;
-- enable you to use our Website; and
+- deliver our Website and public files;
+- protect our Services and diagnose availability or security problems; and
 - improve our Services.
 
 **Legal basis**
 
-We may process this Personal Data because we have a legitimate interest to do so, i.e. to provide you with a good functioning Website and improve our Services for our customers.
-
-#### If You Browse or Download Public Packages
-
-**Personal Data**
-
-- Technical request information, such as IP address, request time, requested
-  package path, and browser or build-tool information;
-- security-event details when a request is flagged or blocked.
-
-**Purpose(s)**
-
-We use this information to deliver public files, protect the repository against
-abuse and investigate availability or security problems. Cloudflare provides
-hosting, content delivery and security for the repository. Browsers may also
-send network-error reports to Cloudflare to diagnose connection failures; this
-is separate from cookies and advertising analytics.
-
-**Legal basis**
-
-We have a legitimate interest in providing a functioning, secure public package
-repository and diagnosing problems with file delivery.
+We may process this Personal Data because we have a legitimate interest in
+providing functioning and secure public Services and improving them for our
+customers.
 
 #### If You Use Documentation Feedback
 
@@ -361,16 +344,9 @@ We will not process or store any Personal Data that we do not need. We store Per
 - **Personal Data in our records for the (tax) authorities**: We retain the Personal Data for 7 years, unless we are legally obliged to retain the data for a longer period.
 - **Personal Data of Applicants**: We retain the Personal Data for a maximum of 4 weeks after the application process, unless the Applicant has given us permission to store the Personal Data for (up to) 1 year.
 - **Platform service logs**: We retain Platform service logs for 90 days after generation, unless a longer period is required for security investigations.
-
-For the package repository, Cloudflare currently makes sampled security events
-available to us for up to 24 hours. This dashboard window is separate from the
-Platform service-log retention period above. If we retain information from an
-event to investigate an incident, we keep it only for as long as needed for that
-investigation and any resulting legal obligations or claims.
-
-Cloudflare's network-error reporting processes the client IP address only while
-handling the report and does not retain it in that reporting pipeline. This does
-not describe retention in other Cloudflare security or delivery services.
+- **Public website security events**: Cloudflare makes sampled events available
+  to us for up to 24 hours. We retain incident information longer only as needed
+  for the investigation and resulting legal obligations or claims.
 
 After expiry of the aforementioned retention period(s), we may process and retain certain Personal Data to comply with legal retention obligations and/or for fraud/misuse investigations or to substantiate a (judicial) claim. In such events, we will retain the Personal Data separately and only use such Personal Data for the aforementioned purposes.
 
@@ -388,8 +364,8 @@ For instance, we use Processors for:
 - payment processing;
 - sending newsletters.
 
-For public package delivery we use Cloudflare for storage, CDN distribution,
-security and network-error diagnostics. Cloudflare's
+Cloudflare provides storage, content delivery, security and network-error
+diagnostics for our public websites. Cloudflare's
 [Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/)
 sets out the data-protection terms for its processing on our behalf.
 
@@ -412,11 +388,9 @@ Apart from the above, we will only share Personal Data with third parties if the
 
 We primarily process and store your Personal Data in the EU/EEA. We may transmit or give access to Personal Data to parties outside the EU/EEA, if one of our Processors or other Controllers is established there. Personal Data will only be transferred to countries and/or parties that provide an adequate level of protection as decided by the European Commission, or if we have Standard Contractual Clauses (SCCs) and/or other appropriate safeguards in place. You may contact us if you wish to receive more information or a copy of the safeguards we have put in place.
 
-Public package delivery uses Cloudflare's global network. Requests and security
-information may therefore be processed outside the EU/EEA, subject to the
-applicable safeguards described above and in Cloudflare's Data Processing
-Addendum. Storing package files in a European region does not limit all network
-processing to that region.
+Our public websites use Cloudflare's global network, so request and security
+information may be processed outside the EU/EEA under the safeguards described
+above and in Cloudflare's Data Processing Addendum.
 
 ## 9. Third Party Websites
 

--- a/docs/developer/about/terms.mdx
+++ b/docs/developer/about/terms.mdx
@@ -9,12 +9,6 @@ sidebar:
 
 **Last update:** September 2026
 
-Public packages at https://packages.fluxzero.io are distributed under their
-respective software licenses. Browsing, downloading or using those packages
-under their licenses does not by itself create a paid Platform subscription or
-require a Platform account or acceptance of these Platform Terms. These Terms
-do not add restrictions to the rights granted by those software licenses.
-
 ## Article 1 - Definitions and general
 
 **1.1 Defined terms**
@@ -110,7 +104,7 @@ do not add restrictions to the rights granted by those software licenses.
 
 ## Article 5 - Intellectual property
 
-**5.1** The SDK is open source under its applicable license. The Runtime is proprietary.
+**5.1** The SDK and other public packages available through https://packages.fluxzero.io are distributed under their applicable software licenses. Accessing or using them under those licenses does not by itself create a paid Platform subscription or require a Platform account or acceptance of these Terms, and these Terms do not restrict the rights granted by those licenses. The Runtime is proprietary.
 
 **5.2** All IP in Customer's Application Code and Applications remains Customer's property. Customer grants Fluxzero a limited license to execute, host, and process Application Code solely to provide the Services.
 

--- a/docs/developer/about/terms.mdx
+++ b/docs/developer/about/terms.mdx
@@ -7,7 +7,13 @@ sidebar:
 
 # Fluxzero Platform Terms
 
-**Last update:** June 2026
+**Last update:** September 2026
+
+Public packages at https://packages.fluxzero.io are distributed under their
+respective software licenses. Browsing, downloading or using those packages
+under their licenses does not by itself create a paid Platform subscription or
+require a Platform account or acceptance of these Platform Terms. These Terms
+do not add restrictions to the rights granted by those software licenses.
 
 ## Article 1 - Definitions and general
 

--- a/docs/developer/getting-started/installation.mdx
+++ b/docs/developer/getting-started/installation.mdx
@@ -124,8 +124,34 @@ The CLI itself is a native executable and does not require Java. Generated Fluxz
 
 ### Maven
 
-Import the [Fluxzero BOM](https://mvnrepository.com/artifact/io.fluxzero/fluxzero-bom) in your
-`dependencyManagement` section to centralize version management:
+Add Fluxzero Packages to your `pom.xml`, inside `<project>`. Merge these entries
+with any existing repository sections. Dependencies and Maven build plugins
+use separate repository lists:
+
+```xml
+<repositories>
+    <repository>
+        <id>fluxzero</id>
+        <url>https://packages.fluxzero.io/maven</url>
+        <snapshots><enabled>false</enabled></snapshots>
+    </repository>
+</repositories>
+<pluginRepositories>
+    <pluginRepository>
+        <id>fluxzero-plugins</id>
+        <url>https://packages.fluxzero.io/maven</url>
+        <snapshots><enabled>false</enabled></snapshots>
+    </pluginRepository>
+</pluginRepositories>
+```
+
+Downloads are public and require no account or credentials. Existing artifacts
+remain on Maven Central; from **1 October 2026**, new Fluxzero releases will be
+published only at [Fluxzero Packages](https://packages.fluxzero.io/).
+
+Import the [Fluxzero BOM](https://packages.fluxzero.io/maven/io/fluxzero/fluxzero-bom/) in your
+`dependencyManagement` section to centralize version management. Set
+`fluxzero.version` to the release you want from the BOM directory:
 
 ```xml
 
@@ -206,6 +232,27 @@ in the same list as shown above.
 
 ### Gradle
 
+Add the Packages repository before Maven Central in `build.gradle.kts` or
+`build.gradle`. Maven Central remains available for other libraries. If your
+build centralizes repositories in `settings.gradle(.kts)`, put these entries in
+`dependencyResolutionManagement.repositories` instead.
+
+For Fluxzero Gradle plugins used through `plugins {}`, also add Packages in
+`pluginManagement.repositories` in `settings.gradle.kts`, before the Plugin Portal:
+
+```kotlin
+pluginManagement {
+    repositories {
+        maven { url = uri("https://packages.fluxzero.io/maven") }
+        gradlePluginPortal()
+    }
+}
+```
+
+Keep `pluginManagement` at the start of the settings file. It is only needed for
+Gradle plugin resolution, not for using the SDK as a dependency. The same
+repository declarations work in Groovy settings with single-quoted strings.
+
 Use [platform BOM support](https://docs.gradle.org/current/userguide/platforms.html) to align dependency versions
 automatically:
 
@@ -213,10 +260,17 @@ automatically:
 <summary><strong>Kotlin DSL (build.gradle.kts)</strong></summary>
 
 ```kotlin
+repositories {
+    maven { url = uri("https://packages.fluxzero.io/maven") }
+    mavenCentral()
+}
+
 dependencies {
     implementation(platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}"))
     implementation("io.fluxzero:sdk")
-    testImplementation("io.fluxzero:sdk", classifier = "tests")
+    testImplementation("io.fluxzero:sdk") {
+        artifact { classifier = "tests" }
+    }
     testImplementation("io.fluxzero:test-server")
     testImplementation("io.fluxzero:proxy")
     annotationProcessor("io.fluxzero:sdk")
@@ -229,11 +283,16 @@ dependencies {
 <summary><strong>Groovy DSL (build.gradle)</strong></summary>
 
 ```groovy
+repositories {
+    maven { url = uri('https://packages.fluxzero.io/maven') }
+    mavenCentral()
+}
+
 dependencies {
     implementation platform("io.fluxzero:fluxzero-bom:${fluxzeroVersion}")
     implementation 'io.fluxzero:sdk'
     testImplementation('io.fluxzero:sdk') {
-        classifier = 'tests'
+        artifact { classifier = 'tests' }
     }
     testImplementation 'io.fluxzero:test-server'
     testImplementation 'io.fluxzero:proxy'


### PR DESCRIPTION
Developers need complete Maven and Gradle setup instructions for `packages.fluxzero.io`, and future Maven publications should match the checksum coverage already produced for Central. This updates the README and installation guide, keeps the public-site policy text proportionate to the repository's actual processing, and configures Maven Resolver to publish MD5, SHA-1, SHA-256, and SHA-512 sidecars.

Validation: documentation site build and internal-link checks; local Maven deployment with all eight expected checksum sidecars for a POM and JAR; Packages worker publication and empty-cache consumption probes with Maven 3 and Maven 4.
