### PR TITLE
ci(release): stop Central publishing on 1 October 2026

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,18 +226,37 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Job 2: Deploy to Maven Central (runs in parallel after tagging and image publication)
+  # Job 2: Deploy to Maven Central before the 1 October 2026 cutoff
   maven-central:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
+      - name: Determine Maven Central publication window
+        id: central_window
+        shell: bash
+        run: |
+          release_date="$(TZ=Europe/Amsterdam date +%F)"
+          if [[ "$release_date" < "2026-10-01" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Maven Central publication"
+              echo
+              echo "Skipped: releases started on or after 1 October 2026 are published only to https://packages.fluxzero.io/maven."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Check out Git repository
+        if: steps.central_window.outputs.publish == 'true'
         uses: actions/checkout@v7
 
       - name: Set release timestamp
+        if: steps.central_window.outputs.publish == 'true'
         run: echo "RELEASE_TIMESTAMP=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
 
       - name: Install Java and Maven
+        if: steps.central_window.outputs.publish == 'true'
         uses: actions/setup-java@v6
         with:
           distribution: temurin
@@ -248,6 +267,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Download artifacts
+        if: steps.central_window.outputs.publish == 'true'
         uses: actions/download-artifact@v8
         with:
           name: maven-artifacts
@@ -255,10 +275,12 @@ jobs:
       # setting versions again as we checked out the sources clean in this step
       # the artifacts only contain the built jars
       - name: Set maven version
+        if: steps.central_window.outputs.publish == 'true'
         run: |
           ./mvnw -B versions:set -DnewVersion=${{ needs.build-and-test.outputs.version-tag }} -DprocessAllModules=true
 
       - name: Deploy to Maven Central
+        if: steps.central_window.outputs.publish == 'true'
         shell: bash
         run: |
           maven_arguments=(-P "sign,central" -B deploy -DskipTests)


### PR DESCRIPTION
The SDK release job would otherwise continue uploading every release to Maven Central after the announced cutoff.

This change checks the calendar date in Europe/Amsterdam immediately before the Central job. Releases started on or after 1 October 2026 skip all Central setup and upload steps; Packages and the other release jobs continue normally. The README already documents the cutoff.

Validation: `actionlint -ignore 'SC2129' .github/workflows/deploy.yml`; boundary check for 30 September, 1 October, and 2 October.
