### PR TITLE
fix(modeling): resolve parent write targets through existing relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3875,6 +3875,12 @@ document, custom and web handlers use one current handler load context. Event-so
 repository boundary; document-loaded targets remain current-only direct-document reads. Use
 `@Association("alternativeId")` to select another payload or metadata field when IDs are ambiguous, or
 `@Association(value = "alternativeId", excludeMetadata = true)` to require the payload field.
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 An ordered ID collection can be loaded at that same pinned boundary without an application-side repository loop:
 
 ```java

--- a/docs/agents/articles/sdk/models/actions-java.md
+++ b/docs/agents/articles/sdk/models/actions-java.md
@@ -97,6 +97,12 @@ public record RenameProject(ProjectId projectId,
 Returning `null` from `@InterceptApply` suppresses that update. Assertions, interceptors and applies may inject every
 direct target and related ancestor resolved for the action. They must not perform nested model writes.
 
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 Interception selects the payloads to which assertions apply:
 
 | Interceptor outcome | Assertions and application |

--- a/docs/agents/articles/sdk/models/actions-kotlin.md
+++ b/docs/agents/articles/sdk/models/actions-kotlin.md
@@ -80,6 +80,12 @@ data class RenameProject(
 Returning `null` from `@InterceptApply` suppresses that update. Assertions, interceptors and applies may inject every
 direct target and related ancestor resolved for the action. They must not perform nested model writes.
 
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 Interception selects the payloads to which assertions apply:
 
 | Interceptor outcome | Assertions and application |

--- a/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
+++ b/docs/developer/guides/Modeling & persistence/200-model-persistence.mdx
@@ -238,6 +238,12 @@ The global event log is independent.
 
 ## The model commit package
 
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 The SDK evaluates one complete model commit and submits:
 
 - the original applied events;

--- a/project-files/java/agents/rules/handling.md
+++ b/project-files/java/agents/rules/handling.md
@@ -217,6 +217,12 @@ class AnalyticsHandler {
 [//]: # (@formatter:on)
 
 Directly addressed models and their parents, grandparents or further ancestors can be injected as `T` or `Graph<T>`.
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 For events and notifications carrying a model-commit boundary, Fluxzero loads the exact historical model state and
 relations for that event. Use `@Association("property")` to select another payload or metadata ID or to qualify an
 ancestor path; add `excludeMetadata = true` to require the payload. `Graph<T>` can be empty after logical deletion;

--- a/project-files/kotlin/agents/rules/handling.md
+++ b/project-files/kotlin/agents/rules/handling.md
@@ -229,6 +229,12 @@ class AnalyticsHandler {
 [//]: # (@formatter:on)
 
 Directly addressed models and their parents, grandparents or further ancestors can be injected as `T` or `Graph<T>`.
+A singular Model-returning `@Apply` may update an injected parent or further ancestor through the existing `@Parent`
+relation. A directly supplied write-target ID keeps precedence; when none exists, the selected ancestor supplies the
+write identity without duplicating its ID in the command. Merely injecting an ancestor does not update it. Selection
+uses the pinned state before applying the changes, so a command may delete a child and update its parent atomically.
+Ambiguous ancestors must be qualified with `@Association("parentPath")`; replay retains the corresponding dependencies.
+
 For events and notifications carrying a model-commit boundary, Fluxzero loads the exact historical model state and
 relations for that event. Use `@Association("property")` to select another payload or metadata ID or to qualify an
 ancestor path; add `excludeMetadata = true` to require the payload. `Graph<T>` can be empty after logical deletion;

--- a/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
+++ b/proxy/src/test/java/io/fluxzero/proxy/ProxyServerTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -79,6 +80,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -2328,40 +2330,54 @@ class ProxyServerTest {
         return payload;
     }
 
+    @Test
+    void smallPartsPublisherPreservesBytesWithReentrantDemand() {
+        byte[] payload = requestPayload(29);
+        var received = new ByteArrayOutputStream();
+        var completed = new AtomicInteger();
+        var publisher = chunkedBodyPublisher(payload, 3);
+        assertEquals(payload.length, publisher.contentLength());
+        publisher.subscribe(new Flow.Subscriber<>() {
+            private Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(ByteBuffer item) {
+                assertTrue(item.remaining() <= 3);
+                byte[] bytes = new byte[item.remaining()];
+                item.get(bytes);
+                received.writeBytes(bytes);
+                // Bound a broken publisher too, so duplication fails without overflowing the stack.
+                if (received.size() < payload.length * 2) {
+                    subscription.request(1);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                throw new AssertionError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.incrementAndGet();
+            }
+        });
+        assertArrayEquals(payload, received.toByteArray());
+        assertEquals(1, completed.get());
+    }
+
     private static HttpRequest.BodyPublisher chunkedBodyPublisher(byte[] payload, int publisherChunkSize) {
-        return new HttpRequest.BodyPublisher() {
-            @Override
-            public long contentLength() {
-                return payload.length;
-            }
-
-            @Override
-            public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
-                subscriber.onSubscribe(new Flow.Subscription() {
-                    private int offset;
-                    private boolean completed;
-
-                    @Override
-                    public void request(long n) {
-                        long remainingDemand = n;
-                        while (remainingDemand-- > 0 && offset < payload.length && !completed) {
-                            int length = Math.min(publisherChunkSize, payload.length - offset);
-                            subscriber.onNext(ByteBuffer.wrap(Arrays.copyOfRange(payload, offset, offset + length)));
-                            offset += length;
-                        }
-                        if (offset >= payload.length && !completed) {
-                            completed = true;
-                            subscriber.onComplete();
-                        }
-                    }
-
-                    @Override
-                    public void cancel() {
-                        completed = true;
-                    }
-                });
-            }
-        };
+        List<byte[]> parts = new ArrayList<>();
+        for (int offset = 0; offset < payload.length; offset += publisherChunkSize) {
+            parts.add(Arrays.copyOfRange(payload, offset, Math.min(payload.length, offset + publisherChunkSize)));
+        }
+        return BodyPublishers.fromPublisher(BodyPublishers.ofByteArrays(parts), payload.length);
     }
 
     private static class TestProxyRequestHandler extends ProxyRequestHandler {

--- a/sdk/src/main/java/io/fluxzero/sdk/modeling/MutationPlan.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/modeling/MutationPlan.java
@@ -44,7 +44,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import static io.fluxzero.common.ObjectUtils.memoize;
 import static io.fluxzero.common.handling.HandlerInspector.inspect;
 import static io.fluxzero.common.reflection.ReflectionUtils.getGenericPropertyType;
 import static io.fluxzero.common.reflection.ReflectionUtils.getPropertyName;
@@ -509,7 +511,7 @@ public final class MutationPlan {
                 ancestors.add(new AncestorDependency(
                         parameter.modelType(), parameter.associationProperty(),
                         plan.executable().toGenericString(),
-                        !ReflectionUtils.isNullable(parameter.parameter())));
+                        !ReflectionUtils.isNullable(parameter.parameter()), Access.READ_ONLY));
             } else if (direct.modelId() != null) {
                 String source = parameter.associationProperty() == null
                         ? EntityMetadata.of(parameter.modelType()).entityIdName()
@@ -725,9 +727,49 @@ public final class MutationPlan {
                     .forEach(type -> slots.add(new Slot(type, payload.required(type, "@AssertLegal fields"),
                                                        false, Access.READ_ONLY, null, true, false, null)));
         }
+        List<EntityMetadata.HandlerMethod> immutableHandlers = List.copyOf(handlers);
         return new TargetPlan(
                 payloadType, List.copyOf(slots), List.copyOf(deferred), List.copyOf(ancestors),
-                Map.copyOf(handlerMethods));
+                Map.copyOf(handlerMethods),
+                ancestors.stream().noneMatch(ancestor -> ancestor.dependency().access().writes())
+                        ? null : memoize(() -> ancestorSelectionRoots(payload, immutableHandlers, slots, ancestors)));
+    }
+
+    private static List<Slot> ancestorSelectionRoots(
+            Payload payload, Collection<EntityMetadata.HandlerMethod> handlers,
+            List<Slot> slots, Set<PlannedAncestor> ancestors) {
+        if (ancestors.stream().noneMatch(ancestor -> ancestor.dependency().access().writes())) {
+            return List.of();
+        }
+        // Replay executes only the handlers for its own stream, but ancestor selection still starts
+        // at the original payload's directly addressed models. These readers never authorize writes
+        // or execute another handler, and absent optional roots do not become required payload IDs.
+        List<Slot> roots = new ArrayList<>();
+        for (EntityMetadata.HandlerMethod handler : EntityMetadata.of(payload.type).handlerMethods()) {
+            if (!handlers.contains(handler)) {
+                compile(payload, handler, roots, new ArrayList<>(), new LinkedHashSet<>());
+            }
+        }
+        payload.properties.values().forEach(property -> property.modelType()
+                .filter(type -> EntityMetadata.of(type).isModel())
+                .filter(type -> ancestors.stream().noneMatch(ancestor ->
+                        EntityMetadata.compatibleTypes(type, ancestor.dependency().modelType())))
+                .ifPresent(type -> roots.add(
+                        new Slot(type, property, false, Access.READ_ONLY, null, false, true, null))));
+        List<Slot> unique = new ArrayList<>();
+        for (Slot root : roots) {
+            if (!root.property.missing()
+                && slots.stream().noneMatch(slot -> sameReader(slot, root))
+                && unique.stream().noneMatch(slot -> sameReader(slot, root))) {
+                unique.add(root);
+            }
+        }
+        return List.copyOf(unique);
+    }
+
+    private static boolean sameReader(Slot left, Slot right) {
+        return left.modelType.equals(right.modelType) && left.property.equals(right.property)
+               && left.collection == right.collection;
     }
 
     private static void compile(
@@ -739,6 +781,7 @@ public final class MutationPlan {
         String signature = handler.executable().toGenericString();
         boolean apply = handler.kind() == EntityMetadata.HandlerKind.APPLY;
         List<Slot> local = new ArrayList<>();
+        List<AncestorDependency> localAncestors = new ArrayList<>();
         if (handler.receiverModelType() != null) {
             local.add(new Slot(
                     handler.receiverModelType(), payload.required(handler.receiverModelType(), signature),
@@ -759,17 +802,19 @@ public final class MutationPlan {
                                 payload.type.getName(), parameter.associationProperty(), signature)),
                         true, Access.READ_ONLY, signature, false, apply, parameter));
             } else {
-                ancestors.add(new PlannedAncestor(new AncestorDependency(
+                localAncestors.add(new AncestorDependency(
                         parameter.modelType(), parameter.associationProperty(), signature,
-                        !ReflectionUtils.isNullable(parameter.parameter())), apply));
+                        !ReflectionUtils.isNullable(parameter.parameter()), Access.READ_ONLY));
             }
         }
         if (handler.kind() == EntityMetadata.HandlerKind.APPLY) {
             if (handler.dynamicApplyResult()) {
                 local.forEach(Slot::write);
             }
-            handler.targetModelTypes().forEach(type -> writeSlot(payload, handler, type, local, deferred));
+            handler.targetModelTypes().forEach(type ->
+                    writeSlot(payload, handler, type, local, localAncestors, deferred));
         }
+        localAncestors.forEach(dependency -> ancestors.add(new PlannedAncestor(dependency, apply)));
         slots.addAll(local);
     }
 
@@ -778,6 +823,7 @@ public final class MutationPlan {
             EntityMetadata.HandlerMethod handler,
             Class<?> type,
             List<Slot> slots,
+            List<AncestorDependency> ancestors,
             List<Deferred> deferred) {
         String signature = handler.executable().toGenericString();
         List<Slot> candidates = slots.stream().filter(slot -> slot.modelType.equals(type)).toList();
@@ -786,9 +832,16 @@ public final class MutationPlan {
             (receiver == null ? candidates.getFirst() : receiver).write();
         } else if (candidates.isEmpty()) {
             if (!handler.collectionApplyResult()) {
-                slots.add(new Slot(
-                        type, payload.required(type, signature), false,
-                        Access.WRITE_ONLY, signature, false, true, null));
+                Property direct = payload.direct(type, null);
+                if (direct == null && ancestors.stream().anyMatch(dependency -> dependency.modelType().equals(type))) {
+                    // Use the injected ancestor only when no direct return-target identity was supplied.
+                    ancestors.replaceAll(dependency -> dependency.modelType().equals(type)
+                            ? dependency.write() : dependency);
+                } else {
+                    slots.add(new Slot(
+                            type, direct == null ? payload.required(type, signature) : direct, false,
+                            Access.WRITE_ONLY, signature, false, true, null));
+                }
             }
         } else {
             Property exact = payload.exact(type);
@@ -892,6 +945,7 @@ public final class MutationPlan {
         private final List<Deferred> deferred;
         private final List<PlannedAncestor> ancestors;
         private final Map<String, EntityMetadata.HandlerMethod> handlerMethods;
+        private final Supplier<List<Slot>> ancestorRoots;
         private final Slot routingTarget;
 
         private TargetPlan(
@@ -899,12 +953,14 @@ public final class MutationPlan {
                 List<Slot> slots,
                 List<Deferred> deferred,
                 List<PlannedAncestor> ancestors,
-                Map<String, EntityMetadata.HandlerMethod> handlerMethods) {
+                Map<String, EntityMetadata.HandlerMethod> handlerMethods,
+                Supplier<List<Slot>> ancestorRoots) {
             this.payloadType = payloadType;
             this.slots = slots;
             this.deferred = deferred;
             this.ancestors = ancestors;
             this.handlerMethods = handlerMethods;
+            this.ancestorRoots = ancestorRoots;
             List<EntityMetadata.HandlerMethod> applies = handlerMethods.values().stream()
                     .filter(handler -> handler.kind() == EntityMetadata.HandlerKind.APPLY).toList();
             List<Slot> writes = slots.stream().filter(slot -> slot.access.writes()).toList();
@@ -950,6 +1006,14 @@ public final class MutationPlan {
             return resolve(input, null, false);
         }
 
+        /**
+         * Resolves replay inputs, binding a unique write ancestor to the authoritative stream identity.
+         * Multiple same-type dependencies still require historical relationship selection.
+         */
+        public Resolution resolveReplay(Object input, ResolvedModel replayTarget) {
+            return resolve(input, null, null, false, Objects.requireNonNull(replayTarget));
+        }
+
         Resolution resolve(Object input, Class<?> explicitType, boolean appliesOnly) {
             return resolve(input, null, explicitType, appliesOnly);
         }
@@ -959,6 +1023,12 @@ public final class MutationPlan {
                 String explicitId,
                 Class<?> explicitType,
                 boolean appliesOnly) {
+            return resolve(input, explicitId, explicitType, appliesOnly, null);
+        }
+
+        private Resolution resolve(
+                Object input, String explicitId, Class<?> explicitType, boolean appliesOnly,
+                ResolvedModel replayTarget) {
             // Apply ancestors can have been selected through a root injected only by an assertion.
             // Rebase must reload those selection roots without executing the assertion again.
             boolean applyOnlyTargets = appliesOnly && ancestors.stream().noneMatch(PlannedAncestor::apply);
@@ -1016,9 +1086,6 @@ public final class MutationPlan {
                 merge(result, new ResolvedModel(
                         explicitId, explicitType, Access.READ_WRITE, sources));
             }
-            if (!ancestors.isEmpty()) {
-                addProspectiveParents(payload, result);
-            }
             List<AncestorDependency> unresolvedAncestors = ancestors.stream()
                     .filter(dependency -> !appliesOnly || dependency.apply)
                     .filter(dependency -> acceptsExplicitTarget(
@@ -1026,6 +1093,37 @@ public final class MutationPlan {
                     .map(PlannedAncestor::dependency)
                     .filter(dependency -> !compatibleExplicit(
                             dependency.modelType(), explicitType)).toList();
+            if (replayTarget != null && ancestorRoots != null) {
+                List<AncestorDependency> matching = unresolvedAncestors.stream()
+                        .filter(dependency -> EntityMetadata.compatibleTypes(
+                                dependency.modelType(), replayTarget.modelType())).toList();
+                if (matching.size() == 1 && matching.getFirst().access().writes()) {
+                    AncestorDependency dependency = matching.getFirst();
+                    merge(result, new ResolvedModel(
+                            replayTarget.modelId(), replayTarget.modelType(), Access.READ_WRITE,
+                            List.of(dependency.association() == null
+                                    ? EntityMetadata.of(dependency.modelType()).entityIdName()
+                                    : dependency.association())));
+                    unresolvedAncestors = unresolvedAncestors.stream().filter(d -> d != dependency).toList();
+                }
+            }
+            if (ancestorRoots != null && !unresolvedAncestors.isEmpty()) {
+                for (Slot root : ancestorRoots.get()) {
+                    Object raw = root.property.read(payload);
+                    if (raw != null) {
+                        List<String> ids = root.collection
+                                ? ids(raw, root.modelType, root.property.name(), root.handler, payload)
+                                : List.of(repositoryId(raw, root, payload));
+                        for (String id : ids) {
+                            merge(result, new ResolvedModel(
+                                    id, root.modelType, Access.READ_ONLY, List.of(root.property.name())));
+                        }
+                    }
+                }
+            }
+            if (!ancestors.isEmpty()) {
+                addProspectiveParents(payload, result);
+            }
             return new Resolution(
                     List.copyOf(result.values()), unresolved,
                     unresolvedAncestors,
@@ -1156,16 +1254,22 @@ public final class MutationPlan {
         }
     }
 
-    /** Read-only dependency resolved through temporal parent relations. */
+    /** Dependency and its planned access, resolved through temporal parent relations. */
     public record AncestorDependency(
-            Class<?> modelType, String association, String handler, boolean required) {
+            Class<?> modelType, String association, String handler, boolean required, Access access) {
+        /** Creates a required read-only ancestor dependency for navigation or handler injection. */
         public AncestorDependency(Class<?> modelType, String association, String handler) {
-            this(modelType, association, handler, true);
+            this(modelType, association, handler, true, Access.READ_ONLY);
         }
 
         public AncestorDependency {
             Objects.requireNonNull(modelType, "modelType");
             Objects.requireNonNull(handler, "handler");
+            Objects.requireNonNull(access, "access");
+        }
+
+        private AncestorDependency write() {
+            return new AncestorDependency(modelType, association, handler, required, Access.READ_WRITE);
         }
     }
 

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/Apply.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/eventsourcing/Apply.java
@@ -83,6 +83,12 @@ import java.lang.annotation.Target;
  *     <li>Other context such as the {@link io.fluxzero.sdk.tracking.handling.authentication.User} performing the update</li>
  * </ul>
  * Injected models are read inputs. Only models returned by an apply are targeted by that apply.
+ * A singular Model-returning apply may use an injected parent or further ancestor as its write target when no
+ * direct write-target ID is supplied. The existing
+ * {@link io.fluxzero.sdk.modeling.Parent @Parent} relation supplies that identity at the pinned pre-apply boundary,
+ * including when another apply deletes the child in the same atomic commit. An explicit direct write ID retains
+ * precedence; ambiguous ancestors must be qualified with
+ * {@link io.fluxzero.sdk.tracking.handling.Association @Association}.
  *
  * <p>
  * Note that empty entities (where the value of the entity is {@code null}) are not injected unless the parameter

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelReplayCursor.java
@@ -1752,7 +1752,7 @@ final class ModelReplayCursor {
                         : dependency.association();
                 MutationPlan.merge(
                         selected, new MutationPlan.ResolvedModel(
-                                modelId, modelType, MutationPlan.Access.READ_ONLY,
+                                modelId, modelType, dependency.access(),
                                 List.of(sourceProperty)));
             }
         }
@@ -2565,8 +2565,7 @@ final class ModelReplayCursor {
                                 || definition.direct()
                                         ? null
                                         : definition.targets()
-                                                .resolve(
-                                                        event.getPayload()));
+                                                .resolveReplay(event.getPayload(), target));
                     })
                     .toList();
         }

--- a/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelRepository.java
+++ b/sdk/src/main/java/io/fluxzero/sdk/persisting/repository/ModelRepository.java
@@ -184,6 +184,9 @@ public interface ModelRepository extends Namespaced<ModelRepository> {
      * Event and notification handlers carrying model-commit metadata must be reconstructed at that exact commit
      * boundary. Other handlers use one current load context. Implementations should batch direct targets and ancestor
      * traversal rather than loading each parameter independently.
+     * Resolved ancestors must preserve their planned {@link MutationPlan.AncestorDependency#access() access}:
+     * reading a parent does not authorize a write, while a planned parent write must not be silently downgraded to
+     * read-only. Implementations unable to preserve the requested access and boundary must reject that capability.
      */
     default CommitAttempt loadContext(
             @NonNull MutationPlan.Resolution

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelCommitHandlerIntegrationTest.java
@@ -1173,6 +1173,7 @@ class ModelCommitHandlerIntegrationTest {
     @Test
     void receiverApplyUsesConsumerConfiguredForCommandRootPackage()
             throws Throwable {
+        RootConsumerModel.observedConsumer.set(null);
         LocalClient client = LocalClient.newInstance(null);
         try (Fluxzero fluxzero = DefaultFluxzero.builder()
                 .disableKeepalive()
@@ -1195,14 +1196,20 @@ class ModelCommitHandlerIntegrationTest {
 
                 assertEventually(() -> assertEquals(
                         new RootConsumerModel(
-                                modelId, "root"),
+                                modelId, "applied"),
                         fluxzero.modelRepository()
                                 .load(modelId,
                                       RootConsumerModel.class)
                                 .get()));
+                assertEquals("root", RootConsumerModel.observedConsumer.get());
+                fluxzero.cache().clear();
+                assertEquals(new RootConsumerModel(modelId, "applied"),
+                             fluxzero.modelRepository().load(modelId, RootConsumerModel.class).get());
             } finally {
                 registration.cancel();
             }
+        } finally {
+            RootConsumerModel.observedConsumer.set(null);
         }
     }
 
@@ -3257,14 +3264,16 @@ class ModelCommitHandlerIntegrationTest {
     @Model
     private record RootConsumerModel(
             @EntityId String rootConsumerModelId,
-            String consumerName) {
+            String state) {
+        private static final AtomicReference<String> observedConsumer = new AtomicReference<>();
+
         @Apply
         RootConsumerModel apply(
                 RootConsumerModelCommand command) {
-            return new RootConsumerModel(
-                    rootConsumerModelId,
-                    Tracker.current().orElseThrow()
-                            .getName());
+            if (!Entity.isLoading()) {
+                observedConsumer.set(Tracker.current().orElseThrow().getName());
+            }
+            return new RootConsumerModel(rootConsumerModelId, "applied");
         }
     }
 

--- a/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelParentWriteTest.java
+++ b/sdk/src/test/java/io/fluxzero/sdk/modeling/ModelParentWriteTest.java
@@ -1,0 +1,663 @@
+/*
+ * Copyright (c) Fluxzero IP B.V. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fluxzero.sdk.modeling;
+
+import io.fluxzero.common.api.modeling.CommitModels;
+import io.fluxzero.common.api.modeling.ModelConflictPolicy;
+import io.fluxzero.sdk.Fluxzero;
+import io.fluxzero.sdk.common.Message;
+import io.fluxzero.sdk.configuration.DefaultFluxzero;
+import io.fluxzero.sdk.configuration.client.LocalClient;
+import io.fluxzero.sdk.persisting.eventsourcing.Apply;
+import io.fluxzero.sdk.persisting.eventsourcing.client.EventStoreClient;
+import io.fluxzero.sdk.persisting.repository.DefaultModelRepository;
+import io.fluxzero.sdk.test.TestFixture;
+import io.fluxzero.sdk.tracking.handling.Association;
+import io.fluxzero.sdk.tracking.handling.PayloadParameterResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModelParentWriteTest {
+    private final ReservationId reservationId = new ReservationId("reservation-1");
+    private final TicketId ticketId = new TicketId("ticket-1");
+    private TestFixture fixture;
+
+    @AfterEach
+    void close() {
+        if (fixture != null) {
+            fixture.getFluxzero().close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void injectsAndUpdatesParentWhileDeletingChild(boolean async) {
+        fixture = async ? TestFixture.createAsync() : TestFixture.create();
+        var command = new ExpireReservation(reservationId);
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(command)
+                .expectSuccessfulResult()
+                .expectEvents(command)
+                .expectThat(fc -> assertExpired(fc, command))
+                .expectNoErrors();
+    }
+
+    @Test
+    void readOnlyParentInjectionDoesNotWriteParent() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(new RemoveWithParentRead(reservationId))
+                .expectSuccessfulResult()
+                .expectEvents(new RemoveWithParentRead(reservationId))
+                .expectThat(fc -> {
+                    assertNull(Fluxzero.loadModel(reservationId).get());
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(ticketId.toString()).count());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void directParentIdKeepsExistingWriteSelection() {
+        fixture = TestFixture.create();
+        var command = new ExpireWithDirectParent(reservationId, ticketId);
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(command)
+                .expectSuccessfulResult()
+                .expectEvents(command)
+                .expectThat(fc -> assertExpired(fc, command))
+                .expectNoErrors();
+    }
+
+    @Test
+    void replayRetainsStringIdSelectionRootWithoutExecutingTheOtherApply() {
+        fixture = TestFixture.create();
+        var command = new ExpireString(reservationId.toString());
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(command).expectSuccessfulResult().expectEvents(command)
+                .expectThat(fc -> assertExpired(fc, command)).expectNoErrors();
+    }
+
+    @Test
+    void deletingChildBeforeParentApplyKeepsItsPinnedParent() {
+        fixture = TestFixture.create();
+        var command = new ExpireChildFirst(reservationId);
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(command).expectSuccessfulResult().expectEvents(command)
+                .expectThat(fc -> assertExpired(fc, command)).expectNoErrors();
+    }
+
+    @Test
+    void graphParameterCanSupplyTheParentWriteTarget() {
+        fixture = TestFixture.create();
+        var command = new ExpireWithGraph(reservationId);
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(command).expectSuccessfulResult().expectEvents(command)
+                .expectThat(fc -> assertExpired(fc, command)).expectNoErrors();
+    }
+
+    @Test
+    void onlyTheParentNeedsAnApplyWhenChildIdSuppliesTheSelectionRoot() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(new ReleaseShared(reservationId, reservationId))
+                .expectSuccessfulResult().expectEvents(new ReleaseShared(reservationId, reservationId))
+                .expectThat(fc -> {
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(new Reservation(reservationId, ticketId), Fluxzero.loadModel(reservationId).get());
+                    assertEquals(1, fc.eventStore().getEvents(reservationId.toString()).count());
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(List.of(ticketId.toString()));
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void differentChildrenMayResolveOneSharedParent() {
+        var second = new ReservationId("reservation-2");
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId), new MoveReservation(second, ticketId))
+                .whenCommand(new ReleaseShared(reservationId, second))
+                .expectSuccessfulResult().expectEvents(new ReleaseShared(reservationId, second))
+                .expectThat(fc -> assertFalse(Fluxzero.loadModel(ticketId).get().reserved())).expectNoErrors();
+    }
+
+    @Test
+    void ambiguousParentsAreRejectedWithoutWrites() {
+        var second = new ReservationId("reservation-2");
+        var other = new TicketId("other-ticket");
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId), new CreateReservation(second, other))
+                .whenCommand(new ReleaseShared(reservationId, second))
+                .expectExceptionalResult(IllegalStateException.class).expectNoEvents()
+                .expectThat(fc -> {
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertTrue(Fluxzero.loadModel(other).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(ticketId.toString()).count());
+                    assertEquals(1, fc.eventStore().getEvents(other.toString()).count());
+                });
+    }
+
+    @Test
+    void missingRequiredParentDoesNotDeleteChild() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new MoveReservation(reservationId, null))
+                .whenCommand(new ExpireReservation(reservationId))
+                .expectExceptionalResult(IllegalStateException.class).expectNoEvents()
+                .expectThat(fc -> assertEquals(new Reservation(reservationId, null),
+                                              Fluxzero.loadModel(reservationId).get()));
+    }
+
+    @Test
+    void failureAfterChildApplyRollsBackTheCompleteAction() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(new FailAfterChild(reservationId))
+                .expectExceptionalResult(IllegalStateException.class).expectNoEvents()
+                .expectThat(fc -> {
+                    assertEquals(new Reservation(reservationId, ticketId), Fluxzero.loadModel(reservationId).get());
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(reservationId.toString()).count());
+                });
+    }
+
+    @Test
+    void returningAnUnrelatedReadOnlyModelCannotOverwriteIt() {
+        var other = new TicketId("other-ticket");
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId), new SetTicket(other, true))
+                .whenCommand(new WrongTicket(reservationId, other.toString()))
+                .expectExceptionalResult(IllegalStateException.class).expectNoEvents()
+                .expectThat(fc -> {
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertTrue(Fluxzero.loadModel(other).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(other.toString()).count());
+                });
+    }
+
+    @Test
+    void qualifiedParentSelectionAndReplayKeepTheOtherParentReadOnly() {
+        var other = new TicketId("other-ticket");
+        fixture = TestFixture.create();
+        fixture.givenCommands(new SetTicket(ticketId, true), new SetTicket(other, true),
+                              new CreateDual("dual", ticketId, other))
+                .whenCommand(new ReleasePrimary("dual"))
+                .expectSuccessfulResult().expectEvents(new ReleasePrimary("dual"))
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(
+                            List.of(ticketId.toString(), other.toString()));
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertTrue(Fluxzero.loadModel(other).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(other.toString()).count());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void planningKeepsAncestorWritesSeparateFromDirectRoutingAndReplayExecution() {
+        var plan = MutationPlan.compile(ExpireReservation.class,
+                                       EntityMetadata.of(ExpireReservation.class).handlerMethods());
+        var resolution = plan.resolve(new ExpireReservation(reservationId));
+        assertEquals(1, resolution.models().size());
+        assertEquals(MutationPlan.Access.READ_WRITE, resolution.ancestorDependencies().getFirst().access());
+        assertNull(plan.routingTarget(new Message(new ExpireReservation(reservationId))));
+
+        var replay = new MutationPlan.Compiler(List.of(new PayloadParameterResolver()))
+                .compileReplay(ExpireString.class, Ticket.class);
+        var replayResolution = replay.targets().resolve(new ExpireString(reservationId.toString()));
+        assertEquals(List.of(reservationId.toString()),
+                     replayResolution.models().stream().map(MutationPlan.ResolvedModel::modelId).toList());
+        assertEquals(MutationPlan.Access.READ_ONLY, replayResolution.models().getFirst().access());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void collectionAndDynamicAppliesKeepTheirExistingReadOnlyAncestorSelection(boolean collection) {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(collection ? new CreateAnotherTicket(reservationId, ticketId)
+                                        : new DynamicNoOp(reservationId, ticketId))
+                .expectSuccessfulResult()
+                .expectThat(fc -> {
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(new Reservation(reservationId, ticketId), Fluxzero.loadModel(reservationId).get());
+                    assertEquals(1, fc.eventStore().getEvents(ticketId.toString()).count());
+                    if (collection) {
+                        assertFalse(Fluxzero.loadModel(new TicketId("new-ticket")).get().reserved());
+                    }
+                }).expectNoErrors();
+    }
+
+    @Test
+    void aSelectionRootGetterIsNotReadAgainForTheAncestorWrite() {
+        var command = new CountingExpiry();
+        var plan = MutationPlan.compile(CountingExpiry.class, EntityMetadata.of(CountingExpiry.class).handlerMethods());
+        plan.resolve(command);
+        assertEquals(1, command.reads);
+    }
+
+    @Test
+    void aDirectWriteIdKeepsPrecedenceOverAQualifiedSameTypeAncestorRead() {
+        fixture = TestFixture.create();
+        var root = new NestedTicketId("nested-root");
+        var child = new NestedTicketId("nested-child");
+        fixture.givenCommands(new SeedNestedTicket(root, null, true), new SeedNestedTicket(child, root, false))
+                .whenCommand(new CopyParentState(child))
+                .expectSuccessfulResult().expectEvents(new CopyParentState(child))
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(List.of(child.toString()));
+                    assertTrue(Fluxzero.loadModel(child).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(root.toString()).count());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void anExplicitGraphTargetDoesNotRequireTheChildSelectionRoot() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new SetTicket(ticketId, true))
+                .whenExecuting(fc -> Fluxzero.loadGraph(ticketId).assertAndApply(new ExpireReservation(null)))
+                .expectSuccessfulResult()
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(List.of(ticketId.toString()));
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void updatesAGrandparentAndReplaysThroughTheIntermediateRelation() {
+        fixture = TestFixture.create();
+        var linkId = new LinkId("link");
+        var leafId = new LeafId("leaf");
+        fixture.givenCommands(new SetTicket(ticketId, true), new CreateLink(linkId, ticketId),
+                              new CreateLeaf(leafId, linkId))
+                .whenCommand(new ReleaseThroughLeaf(leafId))
+                .expectSuccessfulResult().expectEvents(new ReleaseThroughLeaf(leafId))
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(List.of(ticketId.toString()));
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(linkId.toString()).count());
+                    assertEquals(1, fc.eventStore().getEvents(leafId.toString()).count());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void returningNullMayDeleteTheSelectedParentAndCascadeNormally() {
+        fixture = TestFixture.create();
+        fixture.givenCommands(new CreateReservation(reservationId, ticketId))
+                .whenCommand(new DeleteParent(reservationId))
+                .expectSuccessfulResult()
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(
+                            List.of(ticketId.toString(), reservationId.toString()));
+                    assertNull(Fluxzero.loadModel(ticketId).get());
+                    assertNull(Fluxzero.loadModel(reservationId).get());
+                }).expectNoErrors();
+    }
+
+    @Test
+    void replayOfAnAncestorWriteRetainsADifferentlyTypedSiblingRead() {
+        fixture = TestFixture.create();
+        var link = new LinkId("sibling");
+        fixture.givenCommands(new SetTicket(ticketId, true), new CreateLink(link, null),
+                              new CreateMixedParents("mixed", ticketId, link))
+                .whenCommand(new ReleaseWithSibling("mixed"))
+                .expectSuccessfulResult().expectEvents(new ReleaseWithSibling("mixed"))
+                .expectThat(fc -> {
+                    ((DefaultModelRepository) fc.modelRepository()).invalidateModels(List.of(ticketId.toString()));
+                    assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+                    assertEquals(1, fc.eventStore().getEvents(link.toString()).count());
+                }).expectNoErrors();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ModelConflictPolicy.class, names = {"ACCEPT", "RETRY", "FAIL"})
+    @Timeout(15)
+    void reparentingBetweenEvaluationAndCommitUsesTheFreshParentOrFailsAtomically(ModelConflictPolicy policy) {
+        GateClient client = new GateClient();
+        var other = new TicketId("other-ticket");
+        try (Fluxzero fc = DefaultFluxzero.builder().disableKeepalive().disableShutdownHook()
+                .configureModelConflictHandling(policy, ModelConflictResolver.retryIfAllowed(), 3).build(client);
+             Fluxzero writer = DefaultFluxzero.builder().disableKeepalive().disableShutdownHook().build(client)) {
+            commit(fc, new CreateReservation(reservationId, ticketId));
+            commit(fc, new SetTicket(other, true));
+            ConflictExpiry.assertions.set(0);
+            ConflictExpiry.applies.set(0);
+            List<CommitModels> requests = new ArrayList<>();
+            client.beforeCommit = request -> {
+                if (request.getSubsteps().getFirst().getTargets().size() == 2) {
+                    requests.add(request);
+                    if (requests.size() == 1) {
+                        commit(writer, new MoveReservation(reservationId, other));
+                    }
+                }
+            };
+            if (policy == ModelConflictPolicy.FAIL) {
+                var failure = assertThrows(CompletionException.class,
+                                           () -> commit(fc, new ConflictExpiry(reservationId)));
+                assertInstanceOf(ModelCommitConflictException.class, failure.getCause());
+                assertEquals(1, requests.size());
+            } else {
+                commit(fc, new ConflictExpiry(reservationId));
+                assertEquals(2, requests.size());
+                assertTrue(requests.get(1).getReadStateIndex() > requests.getFirst().getReadStateIndex());
+                assertTrue(requests.get(1).getSubsteps().getFirst().getTargets().stream()
+                                   .anyMatch(t -> t.getModelId().equals(other.toString())));
+                assertFalse(requests.get(1).getSubsteps().getFirst().getTargets().stream()
+                                    .anyMatch(t -> t.getModelId().equals(ticketId.toString())));
+            }
+            assertEquals(policy == ModelConflictPolicy.RETRY ? 2 : 1, ConflictExpiry.assertions.get());
+            assertEquals(policy == ModelConflictPolicy.FAIL ? 1 : 2, ConflictExpiry.applies.get());
+            assertTrue(requests.getFirst().getReadModelIds().contains(reservationId.toString()));
+            assertTrue(requests.getFirst().getReadModelIds().contains(ticketId.toString()));
+            client.beforeCommit = ignored -> {};
+            // A new repository has no cached values or replay checkpoints from either writer.
+            try (Fluxzero reader = DefaultFluxzero.builder().disableKeepalive().disableShutdownHook().build(client)) {
+                reader.apply(ignored -> {
+                    assertTrue(Fluxzero.loadModel(ticketId).get().reserved(), "The former parent must not be updated");
+                    assertEquals(policy == ModelConflictPolicy.FAIL, Fluxzero.loadModel(other).get().reserved());
+                    assertEquals(policy == ModelConflictPolicy.FAIL ? new Reservation(reservationId, other) : null,
+                                 Fluxzero.loadModel(reservationId).get());
+                    return null;
+                });
+            }
+        }
+    }
+
+    private static void commit(Fluxzero fc, Object command) {
+        fc.apply(ignored -> fc.executeModelCommit(new Message(command)).join());
+    }
+
+    /** Changes transport timing only; conflict checking and state storage remain the real LocalClient implementation. */
+    private static class GateClient extends LocalClient {
+        Consumer<CommitModels> beforeCommit = ignored -> {};
+
+        GateClient() { super(null); }
+
+        @Override
+        protected EventStoreClient createEventStoreClient() {
+            EventStoreClient delegate = super.createEventStoreClient();
+            return (EventStoreClient) Proxy.newProxyInstance(EventStoreClient.class.getClassLoader(),
+                    new Class<?>[]{EventStoreClient.class}, (proxy, method, args) -> {
+                        if (method.getName().equals("commitModels")) {
+                            beforeCommit.accept((CommitModels) args[0]);
+                        }
+                        try {
+                            return method.invoke(delegate, args);
+                        } catch (InvocationTargetException e) {
+                            throw e.getCause();
+                        }
+                    });
+        }
+    }
+
+    private void assertExpired(Fluxzero fc, Object command) {
+        assertNull(Fluxzero.loadModel(reservationId).get());
+        assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+        for (var id : List.of(reservationId.toString(), ticketId.toString())) {
+            assertEquals(List.of(new CreateReservation(reservationId, ticketId), command),
+                         fc.eventStore().getEvents(id).map(event -> event.getPayload()).toList());
+        }
+        // Both streams must reconstruct independently after their cached values are gone.
+        ((DefaultModelRepository) fc.modelRepository()).invalidateModels(
+                List.of(reservationId.toString(), ticketId.toString()));
+        assertFalse(Fluxzero.loadModel(ticketId).get().reserved());
+        assertNull(Fluxzero.loadModel(reservationId).get());
+    }
+
+    @Model
+    record Ticket(@EntityId TicketId ticketId, boolean reserved) {}
+
+    @Model
+    record Reservation(@EntityId ReservationId reservationId,
+                       @Parent(pathInParent = "reservations") TicketId ticketId) {}
+
+    record CreateReservation(ReservationId reservationId, TicketId ticketId) {
+        @Apply
+        Ticket createTicket() { return new Ticket(ticketId, true); }
+        @Apply
+        Reservation createReservation() { return new Reservation(reservationId, ticketId); }
+    }
+
+    record ExpireReservation(ReservationId reservationId) {
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    record ExpireString(String reservationId) {
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    record ConflictExpiry(ReservationId reservationId) {
+        static final AtomicInteger assertions = new AtomicInteger();
+        static final AtomicInteger applies = new AtomicInteger();
+        @AssertLegal
+        void check(Reservation reservation) { assertions.incrementAndGet(); }
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Ticket ticket) {
+            applies.incrementAndGet();
+            return new Ticket(ticket.ticketId(), false);
+        }
+    }
+
+    static class CountingExpiry {
+        int reads;
+        public ReservationId getReservationId() {
+            reads++;
+            return new ReservationId("counting");
+        }
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    @Model
+    record Link(@EntityId LinkId linkId, @Parent TicketId ticketId) {}
+
+    static class LinkId extends Id<Link> {
+        LinkId(String id) { super(id); }
+    }
+
+    @Model
+    record Leaf(@EntityId LeafId leafId, @Parent LinkId linkId) {}
+
+    static class LeafId extends Id<Leaf> {
+        LeafId(String id) { super(id); }
+    }
+
+    record CreateLink(LinkId linkId, TicketId ticketId) {
+        @Apply
+        Link apply() { return new Link(linkId, ticketId); }
+    }
+
+    record CreateLeaf(LeafId leafId, LinkId linkId) {
+        @Apply
+        Leaf apply() { return new Leaf(leafId, linkId); }
+    }
+
+    record ReleaseThroughLeaf(LeafId leafId) {
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    record DeleteParent(ReservationId reservationId) {
+        @Apply
+        Ticket delete(Ticket ticket) { return null; }
+    }
+
+    @Model
+    record MixedParents(@EntityId String mixedId, @Parent TicketId ticketId, @Parent LinkId linkId) {}
+
+    record CreateMixedParents(String mixedId, TicketId ticketId, LinkId linkId) {
+        @Apply
+        MixedParents apply() { return new MixedParents(mixedId, ticketId, linkId); }
+    }
+
+    record ReleaseWithSibling(String mixedId) {
+        @AssertLegal
+        void root(MixedParents root) { assertEquals(mixedId, root.mixedId()); }
+        @Apply
+        Ticket release(Ticket ticket, Link sibling) {
+            assertEquals("sibling", sibling.linkId().toString());
+            return new Ticket(ticket.ticketId(), false);
+        }
+    }
+
+    record DynamicNoOp(ReservationId reservationId, TicketId auditTicketId) {
+        @Apply
+        Object apply(Reservation reservation, @Association("reservations") Ticket parent) {
+            assertEquals(auditTicketId, parent.ticketId());
+            return reservation;
+        }
+    }
+
+    record CreateAnotherTicket(ReservationId reservationId, TicketId auditTicketId) {
+        @Apply
+        List<Ticket> apply(Reservation reservation, @Association("reservations") Ticket parent) {
+            assertEquals(auditTicketId, parent.ticketId());
+            return List.of(new Ticket(new TicketId("new-ticket"), false));
+        }
+    }
+
+    record ExpireChildFirst(ReservationId reservationId) {
+        @Apply
+        Reservation aRemove(Reservation reservation) { return null; }
+        @Apply
+        Ticket zRelease(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    record ExpireWithGraph(ReservationId reservationId) {
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Graph<Ticket> ticket) { return new Ticket(ticket.get().ticketId(), false); }
+    }
+
+    record ReleaseShared(ReservationId first, ReservationId second) {
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    record FailAfterChild(ReservationId reservationId) {
+        @Apply
+        Reservation aRemove(Reservation reservation) { return null; }
+        @Apply
+        Ticket zRelease(Ticket ticket) { throw new IllegalStateException("Rejected"); }
+    }
+
+    record WrongTicket(ReservationId reservationId, String otherId) {
+        @AssertLegal
+        void readOther(@Association("otherId") Ticket ticket) { assertTrue(ticket.reserved()); }
+        @Apply
+        Ticket release(@Association("reservations") Ticket ticket) { return new Ticket(new TicketId(otherId), false); }
+    }
+
+    @Model
+    record NestedTicket(@EntityId NestedTicketId ticketId,
+                        @Parent(pathInParent = "tickets") NestedTicketId parentId, boolean reserved) {}
+
+    static class NestedTicketId extends Id<NestedTicket> {
+        NestedTicketId(String id) { super(id); }
+    }
+
+    record SeedNestedTicket(NestedTicketId ticketId, NestedTicketId parentId, boolean reserved) {
+        @Apply
+        NestedTicket apply() { return new NestedTicket(ticketId, parentId, reserved); }
+    }
+
+    record CopyParentState(NestedTicketId ticketId) {
+        @Apply
+        NestedTicket apply(@Association("tickets") NestedTicket parent) {
+            return new NestedTicket(ticketId, parent.ticketId(), parent.reserved());
+        }
+    }
+
+    record MoveReservation(ReservationId reservationId, TicketId ticketId) {
+        @Apply
+        Reservation apply() { return new Reservation(reservationId, ticketId); }
+    }
+
+    record SetTicket(TicketId ticketId, boolean reserved) {
+        @Apply
+        Ticket apply() { return new Ticket(ticketId, reserved); }
+    }
+
+    @Model
+    record Dual(@EntityId String dualId, @Parent(pathInParent = "primary") TicketId primary,
+                @Parent(pathInParent = "secondary") TicketId secondary) {}
+
+    record CreateDual(String dualId, TicketId primary, TicketId secondary) {
+        @Apply
+        Dual apply() { return new Dual(dualId, primary, secondary); }
+    }
+
+    record ReleasePrimary(String dualId) {
+        @AssertLegal
+        void readRoot(Dual dual) { assertEquals(dualId, dual.dualId()); }
+        @Apply
+        Ticket release(@Association("primary") Ticket primary, @Association("secondary") Ticket secondary) {
+            assertTrue(secondary.reserved());
+            return new Ticket(primary.ticketId(), false);
+        }
+    }
+
+    record RemoveWithParentRead(ReservationId reservationId) {
+        @Apply
+        Reservation remove(Reservation reservation, Ticket ticket) {
+            assertEquals(reservation.ticketId(), ticket.ticketId());
+            assertTrue(ticket.reserved());
+            return null;
+        }
+    }
+
+    record ExpireWithDirectParent(ReservationId reservationId, TicketId ticketId) {
+        @Apply
+        Reservation remove(Reservation reservation) { return null; }
+        @Apply
+        Ticket release(Ticket ticket) { return new Ticket(ticket.ticketId(), false); }
+    }
+
+    static class TicketId extends Id<Ticket> {
+        TicketId(String id) { super(id); }
+    }
+
+    static class ReservationId extends Id<Reservation> {
+        ReservationId(String id) { super(id); }
+    }
+}


### PR DESCRIPTION
Prepare SDK 2.0.0-RC10 with only the qualified parent-write injection repair on top of RC9. A singular Model apply can update its existing injected ancestor without duplicating the parent ID in the command. Preserve direct-ID precedence, read-only dependencies, atomic deletion, replay, and conflict handling. The focused regression cases, complete SDK reactor, Java/Kotlin downstream checks, Javadoc and targeted planning comparison are qualified locally. No protocol or persisted-data change; no stable-channel promotion.